### PR TITLE
feat(tui): choose local, Fireworks, or AMD Gateway via Lemonade

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,10 @@ LEMONADE_BASE_URL=http://localhost:8000/api/v1
 # (see https://lemonade-server.ai/docs/guide/configuration/#api-key-and-security).
 # Leave empty for local unauthenticated servers.
 # Note: if also set in your shell, the shell value wins (python-dotenv default).
+# Explicit client api_key wins over this variable. When neither is set, GAIA
+# reads $GAIA_HOME/lemonade/state.json (~/.gaia/lemonade/state.json by default)
+# and uses its generated key only for that embedded server's local HTTP port.
+# Other configured servers never inherit the embedded server's key.
 LEMONADE_API_KEY=
 GAIA_MCP_HOST=localhost
 GAIA_MCP_PORT=8765

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Discord](https://img.shields.io/badge/Discord-Join%20Community-7289DA?logo=discord&logoColor=white)](https://discord.com/channels/1392562559122407535/1402013282495102997)
 
-**GAIA** is AMD's open-source framework for building intelligent AI agents that run **100% locally** on AMD Ryzen AI hardware. Keep your data private, eliminate cloud costs, and deploy in air-gapped environments—all with hardware-accelerated performance.
+**GAIA** is AMD's open-source framework for building intelligent AI agents that run **locally by default** on AMD Ryzen AI hardware. Local inference keeps your data private, avoids cloud usage fees, and supports air-gapped deployment with hardware-accelerated performance.
+
+The terminal UI also supports optional **Fireworks AI** and **AMD LLM Gateway** chat through Lemonade. Use `/provider` to connect and choose a model; cloud chat sends conversation history to the selected provider. See [AI provider setup](docs/guides/ai-providers.mdx).
 
 <p align="center">
   <a href="https://amd-gaia.ai/docs/quickstart"><strong>Get Started →</strong></a>
@@ -34,8 +36,8 @@ See the [installation guide](https://github.com/amd/gaia/blob/main/docs/guides/i
 
 | Feature | Description |
 |---------|-------------|
-| **100% Local** | All data stays on your machine—perfect for sensitive workloads and air-gapped deployments |
-| **Zero Cloud Costs** | No API fees, no usage limits, no subscriptions—unlimited AI at no extra cost |
+| **Local Inference** | Run models on your machine for sensitive workloads and air-gapped deployments |
+| **No Cloud Inference Fees** | Local models require no API subscription; optional cloud providers have their own pricing |
 | **Privacy-First** | HIPAA-compliant, GDPR-friendly—ideal for healthcare, finance, and enterprise |
 | **Ryzen AI Optimized** | Hardware-accelerated inference using NPU + iGPU on AMD Ryzen AI processors |
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -86,6 +86,7 @@
                     "group": "Core Agents",
                     "pages": [
                       "guides/gaia",
+                      "guides/ai-providers",
                       "guides/chat",
                       "guides/talk",
                       "guides/transcription"

--- a/docs/guides/ai-providers.mdx
+++ b/docs/guides/ai-providers.mdx
@@ -1,0 +1,85 @@
+---
+title: "Choose an AI provider"
+description: "Run GAIA locally or connect Fireworks AI and AMD LLM Gateway through Lemonade."
+---
+
+GAIA's terminal UI offers **Local**, **Fireworks AI**, and **AMD LLM Gateway**.
+Lemonade runs local models and routes cloud chat requests. The header names the
+active provider and marks remote inference; document and memory embeddings stay
+on your Lemonade server.
+
+## Connect from the TUI
+
+1. Start `gaia tui`. During setup, press **p** to choose an AI provider. In chat,
+   enter **`/provider`** from the command palette.
+2. Select **Fireworks AI**. Paste your API key into the masked field and press
+   **Enter**. Keys go directly to your local Lemonade server, never through the
+   conversation or the agent.
+3. Pick a discovered model. **Gemma 4 31B IT**
+   (`fireworks.gemma-4-31b-it`) appears first when your account exposes it.
+   Type to filter the list; use **↑/↓** and **Enter** to select.
+
+The model list comes from Lemonade's provider discovery. A listed model may still
+require deployment or additional account access to serve requests. GAIA does not create a paid
+Fireworks deployment or silently substitute another model when Gemma is absent.
+Fireworks chat sends conversation history to Fireworks and may incur usage charges.
+
+For **AMD LLM Gateway**, enter your organization's OpenAI-compatible HTTPS base
+URL. The default authentication header is `Authorization`, with the prefix
+`Bearer ` (including its trailing space). For gateways using a bare API key,
+enter the required header name and leave the prefix empty. Use **Tab** to move
+between fields, then paste the key and press **Enter**.
+
+For **Local**, select a downloaded chat model. If none are installed, close the
+panel and run setup. Selecting a cloud provider before setup downloads only the
+local embedding models, not an unused local chat model.
+
+## Keys and settings
+
+- Pasted keys live in **Lemonade process memory** and disappear when Lemonade
+  restarts. GAIA does not save them in config files, transcripts, control logs,
+  traces, or command-line arguments.
+- Provider URLs and authentication-header settings are saved by Lemonade and
+  shared with its other clients. Runtime keys are also available to other clients
+  of that same Lemonade server.
+- Leave the key field blank to use a credential already configured in Lemonade.
+  `LEMONADE_FIREWORKS_API_KEY` and `LEMONADE_AMD_API_KEY`, set in the **Lemonade
+  server process**, take precedence over pasted keys. A conflict is reported
+  explicitly.
+- **Ctrl+D** in provider setup clears that provider's runtime key. Environment
+  keys remain active. **Esc** cancels input or an in-progress connection.
+- Interactive provider administration requires a **loopback Lemonade server**.
+  For a shared remote Lemonade deployment, have its administrator configure
+  providers and credentials on the server.
+
+For Lemonade's own authentication, an explicit SDK `api_key` takes precedence
+over `LEMONADE_API_KEY`. Otherwise GAIA reads its embedded-server credential from
+`$GAIA_HOME/lemonade/state.json` (`~/.gaia` by default) and uses it only for the
+matching local HTTP server and port.
+
+Cloud routing requires Lemonade **11.8.1 or later** and is experimental upstream.
+An empty model list is reported as a discovery problem, not a successful connection.
+Check credentials, account model access, the gateway URL, and Lemonade's server log.
+
+## Switching and validation
+
+Use `/provider` to reconnect or switch destinations, or `/model <id>` to select
+an already-discovered model. Successful switches preserve the current conversation
+and loaded skills. A failed switch keeps the previous model. Selection applies to
+this running session; if the agent restarts, the TUI reports any reversion to its
+launch model.
+
+For development, build `tui/bin/gaia-tui` and launch the checkout with:
+
+```bash
+scripts/dev/run-tui.sh --dev --control
+```
+
+Use the control API to inspect screens and drive the same session. Developer mode
+shows agent progress and tool details; pasted credentials remain masked and input
+contents are omitted from control diagnostics.
+
+See [Lemonade cloud offload](https://lemonade-server.ai/docs/guide/configuration/cloud/)
+for server administration and
+[Gemma 4 31B IT on Fireworks](https://fireworks.ai/models/fireworks/gemma-4-31b-it)
+for model availability and deployment requirements.

--- a/docs/guides/mcp/tui.mdx
+++ b/docs/guides/mcp/tui.mdx
@@ -111,7 +111,7 @@ lie. `tui_status` and `tui_screen` keep working, and `tui_status` reports
 
     The TUI prints the port it bound and writes `~/.gaia/tui/control.json`
     (mode `0600`) holding the pid, port, and bearer token. The token is never
-    printed. Add `--debug` to log every injected key, state transition, and
+    printed. Add `--dev` to log input counts, state transitions, and
     wait resolution to stderr.
 
     For a fixed port: `gaia tui --control-port 8770`.
@@ -242,8 +242,8 @@ Environment:
   <Accordion title="tui_wait_for keeps timing out">
     The timeout reports the screen it actually saw. Compare it with what you
     were matching on — styling is stripped in plain mode, so match on the text,
-    not on box-drawing characters. `gaia tui --control --debug` logs every
-    injected key and every wait resolution to stderr.
+    not on box-drawing characters. `gaia tui --control --dev` records input counts, state changes,
+    and waits in the TUI log. Input contents are never logged.
   </Accordion>
 </AccordionGroup>
 

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -2827,11 +2827,16 @@ ctrl+c.
 | Key | Action |
 |-----|--------|
 | `f` | Apply the focused row's fix — shown only when that row has one |
+| `p` | Choose Local, Fireworks AI, or AMD LLM Gateway (flagship setup) |
 | `r` | Re-check everything |
 | `d` | Toggle the raw answer behind the focused row |
 | `↑` / `↓` (or `k` / `j`) | Move between rows |
 | `enter` | Continue anyway — offered only when nothing is outright broken |
 | `esc`, `ctrl+c` | Quit. There is no screen behind the gate to go back to |
+
+In chat, `/provider` opens the same provider panel with masked key entry and a
+searchable model list. See [AI providers](/guides/ai-providers) for credentials,
+Gemma 4 31B, and gateway settings.
 
 #### Waiting on a consequential readiness problem
 
@@ -2876,7 +2881,7 @@ token.
 ```bash
 gaia tui --control                 # auto-assign a port
 gaia tui --control-port 8770       # explicit port (implies --control)
-gaia tui --control --debug         # log every injected key, state change, and wait
+gaia tui --control --dev           # input counts, state changes, and waits; no input contents
 ```
 
 <Note>
@@ -2889,7 +2894,7 @@ gaia tui --control --debug         # log every injected key, state change, and w
 |------|------|---------|-------------|
 | `--control` | flag | off | Start the control API on an auto-assigned loopback port. |
 | `--control-port` | integer | `0` | Bind a specific port. Implies `--control`. `0` auto-assigns. Port `4001` is reserved and rejected. |
-| `--debug` | flag | off | Log every injected key, state transition, and wait resolution/timeout to stderr. |
+| `--dev` | flag | off | Show developer details and log input counts, state transitions, and wait outcomes to the TUI log; input contents are omitted. `--debug` remains an alias. |
 
 On start the TUI writes `~/.gaia/tui/control.json` (mode `0600`) holding the
 pid, port, and token, and removes it on exit. Clients find the TUI by reading

--- a/hub/agents/gaia/npm/CHANGELOG.md
+++ b/hub/agents/gaia/npm/CHANGELOG.md
@@ -113,6 +113,16 @@ the terminal UI meant building it from source.
 - **`--allow-insecure-base-url`** — opt-in for a non-`https` `--base-url`, for a
   trusted local mirror.
 
+### Changed
+
+- **A `LEMONADE_BASE_URL` that already carries a path is now used exactly as
+  written.** Previously any URL not ending in `/api/v1` had that suffix appended,
+  so a reverse proxy configured as `https://proxy.example/lemonade` was silently
+  rewritten to `https://proxy.example/lemonade/api/v1`. It now resolves to
+  `https://proxy.example/lemonade` unchanged, and only a bare origin with no path
+  at all gains `/api/v1`. If a proxied install starts returning `404` after
+  upgrading, append the API path to the variable yourself.
+
 ### Fixed
 
 - **A second `gaia serve` no longer reports success against a server it does not

--- a/hub/agents/gaia/npm/CHANGELOG.md
+++ b/hub/agents/gaia/npm/CHANGELOG.md
@@ -14,6 +14,9 @@ the terminal UI meant building it from source.
 
 ### Added
 
+- TUI provider setup for Local, Fireworks AI, and AMD LLM Gateway, with masked
+  runtime API keys, discovered models, and remote-inference status.
+
 - **A project map at task start.** In a code repository the agent now opens
   every task knowing the directory shape, the likely entry points, which
   commands are installed, and the three platform differences that change

--- a/hub/agents/gaia/npm/README.md
+++ b/hub/agents/gaia/npm/README.md
@@ -9,7 +9,8 @@ npx @amd-gaia/gaia
 That fetches the two binaries GAIA needs — the agent sidecar and the terminal UI —
 verifies both against a checksum manifest that ships inside this package, and drops
 you into the terminal UI. No Python to install, no repo to clone, no build step.
-Everything runs locally on your machine; nothing you type or index leaves it. The
+Local inference is the default. The TUI can explicitly select Fireworks AI or AMD
+LLM Gateway through Lemonade; remote chat sends conversation history to that provider. The
 terminal UI's `--use-claude` flag, which would send a conversation to the
 Anthropic API, is refused for the agent this package installs — see
 [`SPEC.md` §5.5](./SPEC.md#55-other-transports).

--- a/hub/agents/gaia/npm/SKILL.md
+++ b/hub/agents/gaia/npm/SKILL.md
@@ -573,3 +573,13 @@ finish (or close an idle session) and retry the same `/query`.
 For the full wire contract, lock schema, exit codes, and timeout table, see
 [`SPEC.md`](./SPEC.md). For the user-facing overview, see [`README.md`](./README.md)
 and <https://amd-gaia.ai/docs/guides/gaia>.
+
+## TUI inference providers
+
+The stdio TUI supports `/provider` for Local, Fireworks AI, and AMD LLM Gateway.
+Keys are entered in a masked field and sent directly to local Lemonade's runtime
+auth API, never as agent queries. `/model` lists supported discovered cloud and
+downloaded local models; `/model fireworks.gemma-4-31b-it` selects Gemma 4 31B IT
+when available. Cloud chat sends conversation history to the selected provider;
+embeddings remain on Lemonade. The status event names the actual provider and
+marks remote inference. This is a TUI/stdio capability, not an HTTP query command.

--- a/hub/agents/gaia/npm/SPEC.md
+++ b/hub/agents/gaia/npm/SPEC.md
@@ -385,12 +385,15 @@ in flight. It also takes `--bypass-permissions` (start with gating off) and
 local Lemonade; embeddings stay on Lemonade either way). None of that is
 reachable over `/v1/gaia/query`.
 
-`--use-claude` is the one with a reach beyond the machine, and it cannot be
-turned on for what this package delivers: the terminal UI **refuses** it for a
-daemon-transport agent, with an error saying so, because the daemon relay has no
-way to switch inference backends. So the local-only claim in the README holds
-for every path this package installs — it is a property of the transport, not a
-default someone can flip.
+The stdio TUI also supports Local, Fireworks AI, and AMD LLM Gateway through
+Lemonade. `/model` lists downloaded local and discovered cloud chat models;
+`/model <id>` switches the live client while preserving conversation and skills.
+Cloud IDs (`fireworks.*`, `amd.*`) route through Lemonade without local model
+loading. Model-state status events identify the provider and remote inference.
+The TUI's `/provider` panel configures credentials directly with local Lemonade;
+keys never travel through stdio queries. These controls are not exposed over
+`/v1/gaia/query`. Lemonade may independently be configured to route a model
+remotely, so a local server URL alone does not establish local inference.
 
 ---
 

--- a/hub/agents/gaia/python/gaia_agent/stdio.py
+++ b/hub/agents/gaia/python/gaia_agent/stdio.py
@@ -600,6 +600,7 @@ def _format_model_list(agent: Any) -> str:
     try:
         models = _lemonade_models(chat.config.base_url)
     except RuntimeError as exc:
+        lines.append("**Local (Lemonade — downloaded, chat-capable models):**")
         lines.append(f"- {exc}")
     else:
         for provider, heading in (
@@ -611,7 +612,7 @@ def _format_model_list(agent: Any) -> str:
             group = [m for m in models if cloud_model_provider(m) == provider]
             if not group:
                 lines.append(
-                    "- (none downloaded — run `lemonade-server pull <model>`)"
+                    "- (none downloaded — run `gaia init`)"
                     if provider is None
                     else "- (connect this provider in the TUI provider settings)"
                 )

--- a/hub/agents/gaia/python/gaia_agent/stdio.py
+++ b/hub/agents/gaia/python/gaia_agent/stdio.py
@@ -77,6 +77,7 @@ from gaia.llm.lemonade_client import (
     DEFAULT_LEMONADE_URL,
     LemonadeClient,
     LemonadeClientError,
+    cloud_model_provider,
 )
 from gaia.logger import get_logger
 from gaia.ui.sse_translation import TERMINAL_TYPES, CanonicalTranslator
@@ -331,13 +332,14 @@ def _model_state_event(agent: Any) -> Dict[str, Any]:
     chat = agent.chat
     is_claude = bool(chat.config.use_claude)
     model_id = chat.effective_model
+    cloud_provider = cloud_model_provider(model_id) if not is_claude else None
     event = {
         "type": "status",
         "message": "",
         "model_id": model_id,
         "model_display": _model_display_name(model_id, is_claude),
-        "model_backend": "claude" if is_claude else "lemonade",
-        "model_remote": is_claude,
+        "model_backend": "claude" if is_claude else cloud_provider or "lemonade",
+        "model_remote": is_claude or bool(cloud_provider),
     }
     # Reported even on the Claude path: embeddings (RAG, memory) still run on
     # Lemonade, so "chat is remote" does not mean Lemonade being down is fine.
@@ -381,7 +383,7 @@ _NON_CHAT_LABELS = frozenset({"embeddings", "image", "reranker"})
 
 
 def _lemonade_models(base_url: Optional[str]) -> List[str]:
-    """Downloaded, chat-capable local model ids Lemonade currently serves.
+    """Downloaded local and discovered Fireworks/AMD chat models Lemonade serves.
 
     Goes through ``LemonadeClient`` (the one Lemonade HTTP client the rest of
     the codebase uses) rather than a bespoke ``requests`` call, so base_url
@@ -407,7 +409,8 @@ def _lemonade_models(base_url: Optional[str]) -> List[str]:
             m["id"]
             for m in catalog.get("data", [])
             if m.get("id")
-            and m.get("downloaded")
+            and (m.get("downloaded") or cloud_model_provider(m["id"], m))
+            and cloud_model_provider(m["id"], m) in {None, "fireworks", "amd"}
             and not (_NON_CHAT_LABELS & set(m.get("labels") or []))
         }
     )
@@ -533,12 +536,12 @@ def _apply_claude_switch(agent: Any, target: str) -> str:
 
 
 def _apply_local_switch(agent: Any, target: str) -> str:
-    """Swap the live client to local Lemonade model *target*; raise on failure."""
+    """Swap the live client to a local or cloud Lemonade model."""
     chat = agent.chat
     available = _lemonade_models(chat.config.base_url)  # raises if unreachable
     if target not in available:
         raise RuntimeError(
-            f"Unknown local model '{target}'. Downloaded, chat-capable "
+            f"Unknown Lemonade model '{target}'. Downloaded local or discovered cloud "
             "Lemonade models: "
             + (
                 ", ".join(available)
@@ -594,17 +597,28 @@ def _format_model_list(agent: Any) -> str:
         lines.append(f"- `{model_id}` — {label}{marker}")
 
     lines.append("")
-    lines.append("**Local (Lemonade — downloaded, chat-capable models):**")
     try:
-        local_models = _lemonade_models(chat.config.base_url)
+        models = _lemonade_models(chat.config.base_url)
     except RuntimeError as exc:
         lines.append(f"- {exc}")
     else:
-        if not local_models:
-            lines.append("- (none downloaded — run `lemonade-server pull <model>`)")
-        for model_id in local_models:
-            marker = " ← current" if model_id == current else ""
-            lines.append(f"- `{model_id}`{marker}")
+        for provider, heading in (
+            (None, "Local (Lemonade — downloaded, chat-capable models)"),
+            ("fireworks", "Fireworks AI (remote — via Lemonade)"),
+            ("amd", "AMD LLM Gateway (remote — via Lemonade)"),
+        ):
+            lines.append(f"**{heading}:**")
+            group = [m for m in models if cloud_model_provider(m) == provider]
+            if not group:
+                lines.append(
+                    "- (none downloaded — run `lemonade-server pull <model>`)"
+                    if provider is None
+                    else "- (connect this provider in the TUI provider settings)"
+                )
+            for model_id in group:
+                marker = " ← current" if model_id == current else ""
+                lines.append(f"- `{model_id}`{marker}")
+            lines.append("")
 
     lines.append("")
     lines.append(
@@ -639,6 +653,16 @@ def run_model_command(agent: Any, query: str, out) -> None:
         if agent._use_claude
         else "the local Lemonade backend"
     )
+    cloud_provider = cloud_model_provider(agent.chat.effective_model)
+    if cloud_provider and not agent._use_claude:
+        provider_name = {
+            "fireworks": "Fireworks AI",
+            "amd": "AMD LLM Gateway",
+        }.get(cloud_provider, cloud_provider)
+        where = (
+            f"{provider_name} via Lemonade — this conversation is sent to "
+            f"{provider_name}; embeddings stay on Lemonade"
+        )
     _write(
         {"type": "final", "answer": f"Switched to **{display}**, running on {where}."},
         out,

--- a/hub/agents/gaia/python/tests/test_stdio.py
+++ b/hub/agents/gaia/python/tests/test_stdio.py
@@ -705,7 +705,7 @@ def test_model_switch_unknown_local_id_is_refused_not_accepted(monkeypatch):
 
     events = _events(out)
     assert len(events) == 1 and events[0]["type"] == "error"
-    assert "Unknown local model" in events[0]["detail"]
+    assert "Unknown Lemonade model" in events[0]["detail"]
     assert "Gemma-4-E4B-it-GGUF" in events[0]["detail"]
     assert agent.chat.llm_client is previous_client
     assert agent.rebuild_count == 0
@@ -946,6 +946,63 @@ def test_lemonade_models_unreachable_names_url_and_fix(monkeypatch):
         assert "lemonade-server serve" in str(exc)
     finally:
         fake.error = None
+
+
+@pytest.mark.parametrize(
+    "provider,name", [("fireworks", "Fireworks AI"), ("amd", "AMD LLM Gateway")]
+)
+def test_cloud_model_switch_preserves_session_and_reports_remote(
+    monkeypatch, stub_lemonade, provider, name
+):
+    model = f"{provider}.gemma-4-31b-it"
+    stub_lemonade.catalog = {
+        "data": [{"id": model, "recipe": "cloud", "downloaded": False}]
+    }
+    client = object()
+    monkeypatch.setattr(stdio, "create_client", lambda **kwargs: client)
+    agent = _ModelSwitchAgent()
+    history = [{"role": "user", "content": "remember this"}]
+    agent.chat.history = history
+    embedder = object()
+    agent.embedder = embedder
+
+    events = _events(_model_run(agent, f"/model {model}"))
+
+    assert [event["type"] for event in events] == ["status", "final"]
+    assert events[0]["model_backend"] == provider
+    assert events[0]["model_remote"] is True
+    assert name in events[1]["answer"]
+    assert "this conversation is sent to" in events[1]["answer"]
+    assert agent.chat.history is history
+    assert agent.embedder is embedder
+    assert agent.chat.llm_client is client
+    assert agent._use_claude is False
+
+
+def test_model_list_groups_discovered_cloud_without_downloads(stub_lemonade):
+    stub_lemonade.catalog = {
+        "data": [
+            {"id": "Gemma-4-E4B-it-GGUF", "downloaded": True},
+            {"id": "fireworks.gemma-4-31b-it", "downloaded": False},
+            {"id": "amd.gemma", "downloaded": False},
+            {"id": "fireworks.embedding", "labels": ["embeddings"]},
+            {"id": "other.gemma", "recipe": "cloud", "cloud_provider": "other"},
+        ]
+    }
+    answer = _events(_model_run(_ModelSwitchAgent(), "/model"))[0]["answer"]
+    assert answer.index("Local (Lemonade") < answer.index("Gemma-4-E4B-it-GGUF")
+    assert answer.index("Fireworks AI") < answer.index("fireworks.gemma-4-31b-it")
+    assert answer.index("AMD LLM Gateway") < answer.index("amd.gemma")
+    assert "fireworks.embedding" not in answer
+    assert "other.gemma" not in answer
+
+
+def test_undiscovered_cloud_model_is_refused_without_changing_session(stub_lemonade):
+    agent = _ModelSwitchAgent()
+    previous = agent.chat.llm_client
+    events = _events(_model_run(agent, "/model fireworks.not-discovered"))
+    assert [event["type"] for event in events] == ["error"]
+    assert agent.chat.llm_client is previous
 
 
 # ---------------------------------------------------------------------------

--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -906,26 +906,33 @@ Do NOT wrap conversational replies in JSON.
         # next step boundary so the producer thread is torn down, not leaked.
         self._cancel_event: Optional[threading.Event] = None
 
-        # Read base_url from environment if not provided
+        # Resolve the same endpoint as TUI setup, including an isolated runtime.
         if base_url is None:
-            base_url = os.getenv("LEMONADE_BASE_URL", "http://localhost:13305/api/v1")
+            from gaia.llm.lemonade_client import resolve_lemonade_base_url
+
+            base_url = resolve_lemonade_base_url()
 
         # Lazy Lemonade initialization for local LLM users
         # This ensures Lemonade server is running before we try to use it
         if not (use_claude or use_chatgpt or skip_lemonade):
+            from gaia.llm.lemonade_client import LemonadeClient, cloud_model_provider
             from gaia.llm.lemonade_manager import LemonadeManager
 
             # Resolve declarative per-agent hardware requirement (if any)
             req = getattr(self.__class__, "REQUIRED_HARDWARE", None)
             required_min_device = req.min_device if req is not None else None
 
-            LemonadeManager.ensure_ready(
-                min_context_size=min_context_size,
-                quiet=silent_mode,
-                base_url=base_url,
-                required_min_device=required_min_device,
-                device=device,
-            )
+            if cloud_model_provider(model_id):
+                # The local manager preloads a chat model even on an idle server.
+                LemonadeClient(base_url=base_url, verbose=False).health_check()
+            else:
+                LemonadeManager.ensure_ready(
+                    min_context_size=min_context_size,
+                    quiet=silent_mode,
+                    base_url=base_url,
+                    required_min_device=required_min_device,
+                    device=device,
+                )
 
         # Initialize state management
         self.execution_state = self.STATE_PLANNING
@@ -4146,10 +4153,14 @@ Do NOT wrap conversational replies in JSON.
             import httpx
 
             from gaia.llm.lemonade_client import (
+                cloud_model_provider,
                 lemonade_auth_headers,
                 resolve_lemonade_api_key,
             )
             from gaia.llm.lemonade_manager import LemonadeManager
+
+            if cloud_model_provider(getattr(self, "model_id", None)):
+                return False
 
             base_url = LemonadeManager.get_base_url() or "http://localhost:13305/api/v1"
             # ``api/v0/health`` exposes ``all_models_loaded`` with ctx_size.
@@ -4159,7 +4170,9 @@ Do NOT wrap conversational replies in JSON.
             resp = httpx.get(
                 health_url,
                 timeout=3.0,
-                headers=lemonade_auth_headers(resolve_lemonade_api_key()),
+                headers=lemonade_auth_headers(
+                    resolve_lemonade_api_key(base_url=base_url)
+                ),
             )
             if resp.status_code != 200:
                 return False

--- a/src/gaia/agents/base/readiness.py
+++ b/src/gaia/agents/base/readiness.py
@@ -296,7 +296,7 @@ def probe_model_present(probe_base: str, model_id: str) -> bool:
 
     resp = requests.get(
         f"{probe_base}/models",
-        headers=lemonade_auth_headers(resolve_lemonade_api_key()),
+        headers=lemonade_auth_headers(resolve_lemonade_api_key(base_url=probe_base)),
         timeout=(PROBE_CONNECT_TIMEOUT, PROBE_READ_TIMEOUT),
     )
     resp.raise_for_status()
@@ -377,7 +377,7 @@ def pull_model(probe_base: str, model_id: str) -> None:
     resp = requests.post(
         f"{probe_base}/pull",
         json={"model_name": model_id},
-        headers=lemonade_auth_headers(resolve_lemonade_api_key()),
+        headers=lemonade_auth_headers(resolve_lemonade_api_key(base_url=probe_base)),
         timeout=PULL_TIMEOUT,
     )
     resp.raise_for_status()

--- a/src/gaia/audio/lemonade_asr.py
+++ b/src/gaia/audio/lemonade_asr.py
@@ -26,10 +26,9 @@ from typing import Any, Callable, Dict, Iterator, List, Optional
 import requests
 
 from gaia.llm.lemonade_client import (
-    LEMONADE_API_VERSION,
-    _get_lemonade_config,
     lemonade_auth_headers,
     resolve_lemonade_api_key,
+    resolve_lemonade_base_url,
 )
 from gaia.logger import get_logger
 
@@ -228,20 +227,6 @@ def _low_confidence_runs(
         yield run_start, len(words)
 
 
-def _resolve_base_url(base_url: Optional[str]) -> str:
-    """Resolve the Lemonade API root, matching ``lemonade_client``'s rules.
-
-    Falls through to ``LEMONADE_BASE_URL`` / the packaged default when the
-    caller passes nothing, and appends the ``/api/v1`` suffix users omit.
-    """
-    if not base_url:
-        return _get_lemonade_config()[2]
-    normalized = base_url.rstrip("/")
-    if not normalized.endswith(f"/api/{LEMONADE_API_VERSION}"):
-        normalized = f"{normalized}/api/{LEMONADE_API_VERSION}"
-    return normalized
-
-
 def _log_slot_wait(reason: str) -> None:
     """Surface a queued model-slot grant instead of looking hung."""
     log.info("Transcription waiting on the model slot — %s", reason)
@@ -388,9 +373,9 @@ class LemonadeASRClient:
                 "model must be a Lemonade transcription model id, e.g. "
                 f"'{DEFAULT_ASR_MODEL}'."
             )
-        self.base_url = _resolve_base_url(base_url)
+        self.base_url = resolve_lemonade_base_url(base_url)
         self.model = model
-        self.api_key = resolve_lemonade_api_key(api_key)
+        self.api_key = resolve_lemonade_api_key(api_key, base_url=self.base_url)
         self.timeout = timeout
         self._session = requests.Session()
 

--- a/src/gaia/installer/init_command.py
+++ b/src/gaia/installer/init_command.py
@@ -1951,7 +1951,7 @@ class InitCommand:
             # Ensure proper context size for this profile
             profile_config = INIT_PROFILES[self.profile]
             min_ctx = profile_config.get("min_context_size")
-            if min_ctx:
+            if min_ctx and not self.skip_chat_model:
                 from gaia.llm.lemonade_manager import LemonadeManager
 
                 self.console.print()

--- a/src/gaia/llm/lemonade_client.py
+++ b/src/gaia/llm/lemonade_client.py
@@ -18,6 +18,7 @@ import subprocess
 import sys
 import threading
 import time
+from contextlib import nullcontext
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -78,12 +79,23 @@ def _embedded_lemonade_url() -> str:
 
 
 def _read_embedded_lemonade_state() -> Optional[Dict[str, Any]]:
-    """Read ~/.gaia/lemonade/state.json, or None when there is no such server."""
+    """Read the selected GAIA home's embedded server, without crossing homes."""
+    gaia_home = os.getenv("GAIA_HOME", "").strip()
+    state_path = (
+        Path(os.path.expandvars(gaia_home)).expanduser() / "lemonade" / "state.json"
+        if gaia_home
+        else EMBEDDED_LEMONADE_STATE
+    )
     try:
-        state = json.loads(EMBEDDED_LEMONADE_STATE.read_text(encoding="utf-8"))
+        state = json.loads(state_path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return None
-    return state if isinstance(state, dict) else None
+    if not isinstance(state, dict):
+        return None
+    port = state.get("port")
+    if isinstance(port, bool) or not isinstance(port, int) or not 1 <= port <= 65535:
+        return None
+    return state
 
 
 def _get_lemonade_config() -> tuple:
@@ -91,17 +103,15 @@ def _get_lemonade_config() -> tuple:
     Get Lemonade host, port, and base_url from environment or defaults.
 
     Parses LEMONADE_BASE_URL env var if set, otherwise uses defaults.
-    Normalizes the URL to include /api/v1 suffix if omitted.
+    Adds /api/v1 to bare origins, preserving explicitly configured API paths.
 
     Returns:
         Tuple of (host, port, base_url)
     """
     from urllib.parse import urlparse
 
-    base_url = os.getenv("LEMONADE_BASE_URL") or _embedded_lemonade_url()
-    # Normalize: ensure base_url includes /api/v1 suffix (users often omit it)
-    if not base_url.rstrip("/").endswith(f"/api/{LEMONADE_API_VERSION}"):
-        base_url = f"{base_url.rstrip('/')}/api/{LEMONADE_API_VERSION}"
+    configured_url = os.getenv("LEMONADE_BASE_URL", "").strip()
+    base_url = resolve_lemonade_base_url(configured_url or _embedded_lemonade_url())
     # Parse the URL to extract host and port for backwards compatibility
     parsed = urlparse(base_url)
     host = parsed.hostname or DEFAULT_HOST
@@ -122,28 +132,31 @@ def resolve_lemonade_base_url(base_url: Optional[str] = None) -> str:
     The public counterpart to :func:`resolve_lemonade_api_key`, and the only
     thing callers should use to answer "where is Lemonade?".
 
-    Always returns a URL ending in ``/api/<version>`` — including one passed in
-    explicitly, since users routinely configure the bare origin. Callers can
-    therefore append endpoint paths directly; a caller that adds ``/api/v1``
-    itself will produce a doubled path.
+    Bare origins gain ``/api/<version>``. Explicit API paths, such as ``/v1``
+    or a reverse proxy's prefix, are preserved. Callers append endpoint paths
+    directly without adding another API prefix.
 
     Callers that instead wrote ``os.getenv("LEMONADE_BASE_URL", "http://…")``
     inline could not see GAIA's own embedded server, which binds a port chosen
     at start time. Every one of those copies had to be found and changed for
     the embedded server to be usable at all.
     """
-    if base_url is None:
+    from urllib.parse import urlparse
+
+    if base_url is None or not base_url.strip():
         return _get_lemonade_config()[2]
-    trimmed = base_url.rstrip("/")
-    suffix = f"/api/{LEMONADE_API_VERSION}"
-    return trimmed if trimmed.endswith(suffix) else f"{trimmed}{suffix}"
+    trimmed = base_url.strip().rstrip("/")
+    parsed = urlparse(trimmed)
+    if parsed.hostname and not parsed.path:
+        return parsed._replace(path=f"/api/{LEMONADE_API_VERSION}").geturl()
+    return trimmed
 
 
 #: Where GAIA's embedded Lemonade records the credential it generated.
 EMBEDDED_LEMONADE_STATE = Path.home() / ".gaia" / "lemonade" / "state.json"
 
 
-def _embedded_lemonade_api_key() -> Optional[str]:
+def _embedded_lemonade_api_key(base_url: Optional[str] = None) -> Optional[str]:
     """The key GAIA's own embedded Lemonade generated for itself, if present.
 
     ``gaia lemonade embedded`` starts a private server that mints an API key
@@ -153,11 +166,30 @@ def _embedded_lemonade_api_key() -> Optional[str]:
     running", and offered to install a second one onto the same port.
     """
     state = _read_embedded_lemonade_state()
-    key = state.get("api_key") if state else None
+    if state is None:
+        return None
+    from urllib.parse import urlparse
+
+    try:
+        parsed = urlparse(resolve_lemonade_base_url(base_url))
+        if (
+            parsed.scheme != "http"
+            or parsed.hostname not in {"localhost", "127.0.0.1", "::1"}
+            or parsed.port != state["port"]
+            or parsed.username is not None
+            or parsed.query
+            or parsed.fragment
+        ):
+            return None
+    except ValueError:
+        return None
+    key = state.get("api_key")
     return key.strip() or None if isinstance(key, str) else None
 
 
-def resolve_lemonade_api_key(api_key: Optional[str] = None) -> Optional[str]:
+def resolve_lemonade_api_key(
+    api_key: Optional[str] = None, *, base_url: Optional[str] = None
+) -> Optional[str]:
     """Resolve the Lemonade API key: argument, env var, embedded server, None.
 
     Empty or whitespace-only env values are treated as unset to avoid
@@ -166,13 +198,16 @@ def resolve_lemonade_api_key(api_key: Optional[str] = None) -> Optional[str]:
 
     An explicit argument or env var always wins — a configured credential must
     never be overridden by whatever a local state file happens to hold.
+    The embedded key is restricted to its recorded local HTTP endpoint. Callers
+    with an explicit endpoint must pass ``base_url``; omitted uses the configured
+    Lemonade URL. ``GAIA_HOME`` selects the embedded state directory.
     """
     if api_key is not None:
         return api_key
     env_value = os.getenv("LEMONADE_API_KEY")
     if env_value is not None and env_value.strip():
         return env_value.strip()
-    return _embedded_lemonade_api_key()
+    return _embedded_lemonade_api_key(base_url)
 
 
 def lemonade_auth_headers(api_key: Optional[str]) -> Dict[str, str]:
@@ -197,6 +232,27 @@ DEFAULT_MODEL_NAME = "Gemma-4-E4B-it-GGUF"
 # pull via checkpoint + recipe + the ``embedding`` label (see MODELS entry).
 DEFAULT_EMBEDDING_MODEL = "user.embeddinggemma-300m-GGUF"
 DEFAULT_EMBEDDING_CHECKPOINT = "ggml-org/embeddinggemma-300M-GGUF:Q8_0"
+
+
+def cloud_model_provider(
+    model_id: Optional[str], metadata: Optional[Dict[str, Any]] = None
+) -> Optional[str]:
+    """Identify Lemonade cloud models without mistaking dotted local ids for cloud.
+
+    Lemonade uses ``<provider>.<upstream-id>`` (cloud.md in lemonade-sdk/lemonade).
+    Known GAIA providers work before discovery; other providers require catalog
+    metadata, since ``user.*`` and local model version numbers also contain dots.
+    """
+    if not model_id:
+        return None
+    provider, separator, upstream_id = model_id.partition(".")
+    if not separator or not upstream_id:
+        return None
+    if metadata is not None and metadata.get("recipe") == "cloud":
+        return metadata.get("cloud_provider") or provider
+    if provider in {"fireworks", "amd"}:
+        return provider
+    return None
 
 
 def _model_ids_match(a: Optional[str], b: Optional[str]) -> bool:
@@ -621,6 +677,59 @@ class ModelDownloadCancelledError(LemonadeClientError):
 
 class InsufficientDiskSpaceError(LemonadeClientError):
     """Raised when there's not enough disk space for model download."""
+
+
+def _cloud_error_status(error: openai.APIError) -> Optional[int]:
+    """Read numeric status fields; never interpret or display upstream text."""
+    status = getattr(error, "status_code", None)
+    if (
+        isinstance(status, int)
+        and not isinstance(status, bool)
+        and 400 <= status <= 599
+    ):
+        return status
+    body = getattr(error, "body", None)
+    if isinstance(body, dict):
+        envelope = body.get("error", body)
+        if isinstance(envelope, dict):
+            details = envelope.get("details")
+            if isinstance(details, dict):
+                status = details.get("status_code")
+                if (
+                    isinstance(status, int)
+                    and not isinstance(status, bool)
+                    and 400 <= status <= 599
+                ):
+                    return status
+    return None
+
+
+def _cloud_request_error(status: Optional[int]) -> LemonadeClientError:
+    """Actionable cloud failures without reflecting provider response bodies."""
+    if status in {401, 403}:
+        return LemonadeAuthError(
+            f"Cloud authentication or access was denied (HTTP {status}). "
+            "Reconnect the provider in the TUI provider settings and check "
+            "your account's model access. If Lemonade itself requires "
+            "authentication, verify LEMONADE_API_KEY."
+        )
+    if status == 404:
+        return LemonadeClientError(
+            "The selected cloud model is unavailable (HTTP 404). It may need "
+            "deployment or access for your account. Choose a deployed model "
+            "or router in the TUI provider settings."
+        )
+    if status == 429:
+        return LemonadeClientError(
+            "Cloud rate limit reached (HTTP 429). Wait before retrying; "
+            "check your provider's usage limits and account in the TUI "
+            "provider settings."
+        )
+    code = f" (HTTP {status})" if status is not None else ""
+    return LemonadeClientError(
+        f"Cloud request through Lemonade failed{code}. Check the provider "
+        "connection and selected model in the TUI provider settings."
+    )
 
 
 # Phrases indicating a backend rejected a request because the prompt plus
@@ -1067,8 +1176,7 @@ class LemonadeClient:
             self.base_url = f"http://{self.host}:{self.port}/api/{LEMONADE_API_VERSION}"
         elif base_url is not None:
             # base_url parameter provided - normalize and use it
-            if not base_url.rstrip("/").endswith(f"/api/{LEMONADE_API_VERSION}"):
-                base_url = f"{base_url.rstrip('/')}/api/{LEMONADE_API_VERSION}"
+            base_url = resolve_lemonade_base_url(base_url)
             self.base_url = base_url
             # Parse for backwards compatibility with code accessing self.host/self.port
             parsed = urlparse(base_url)
@@ -1080,11 +1188,12 @@ class LemonadeClient:
             self.host = env_host
             self.port = env_port
         self.model = model
+        self._model_metadata: Dict[str, Dict[str, Any]] = {}
         self.server_process = None
         self.log = get_logger(__name__)
         self.keep_alive = keep_alive
         self._log_file = None
-        self.api_key = resolve_lemonade_api_key(api_key)
+        self.api_key = resolve_lemonade_api_key(api_key, base_url=self.base_url)
         # Instance-scoped exact-pin ctx override (#1892). Never a class-level
         # default or MODELS mutation — chat/RAG clients sharing this process
         # must keep their own floor semantics.
@@ -1723,7 +1832,9 @@ class LemonadeClient:
             LemonadeClientError: If download/load fails, or if *error* is
                 not a missing-model error (re-raised unchanged)
         """
-        if not (auto_download and self._is_model_error(error)):
+        if self.cloud_model_provider(model) or not (
+            auto_download and self._is_model_error(error)
+        ):
             # Not the missing-model condition this recovery is for --
             # retrying would just repeat the same failing request.
             raise error
@@ -1797,6 +1908,11 @@ class LemonadeClient:
           }]
         }
         """
+        if self.cloud_model_provider(model):
+            # These local llama.cpp defaults are inserted by LemonadeProvider.
+            kwargs.pop("repeat_penalty", None)
+            kwargs.pop("repeat_last_n", None)
+
         # Handle max_tokens vs max_completion_tokens
         if max_completion_tokens is None and max_tokens is None:
             max_completion_tokens = 1000  # Default value
@@ -1853,6 +1969,8 @@ class LemonadeClient:
             )
 
             if response.status_code == 401:
+                if self.cloud_model_provider(model):
+                    raise _cloud_request_error(response.status_code)
                 raise LemonadeAuthError(
                     "Lemonade returned 401 Unauthorized for /chat/completions. "
                     "Verify LEMONADE_API_KEY is correct (currently "
@@ -1860,6 +1978,8 @@ class LemonadeClient:
                 )
 
             if response.status_code != 200:
+                if self.cloud_model_provider(model):
+                    raise _cloud_request_error(response.status_code)
                 error_msg = (
                     f"Error in chat completions "
                     f"(status {response.status_code}): {response.text}"
@@ -1870,7 +1990,7 @@ class LemonadeClient:
             result = response.json()
             if "choices" in result and len(result["choices"]) > 0:
                 token_count = len(
-                    result["choices"][0].get("message", {}).get("content", "")
+                    result["choices"][0].get("message", {}).get("content") or ""
                 )
                 self.log.debug(
                     f"Chat completion successful. "
@@ -2082,6 +2202,8 @@ class LemonadeClient:
             )
 
         except openai.AuthenticationError:
+            if self.cloud_model_provider(model):
+                raise _cloud_request_error(401) from None
             # Fixed-string error: do NOT include str(e), as the OpenAI SDK's
             # exception may stringify the failing request including its
             # Authorization header.
@@ -2090,6 +2212,8 @@ class LemonadeClient:
                 "streaming chat completions. Verify LEMONADE_API_KEY is correct."
             )
         except (openai.APIError, openai.APIConnectionError, openai.RateLimitError) as e:
+            if self.cloud_model_provider(model):
+                raise _cloud_request_error(_cloud_error_status(e)) from None
             error_type = e.__class__.__name__
             error_msg = str(e)
             self.log.error(f"OpenAI {error_type}: {error_msg}")
@@ -2496,7 +2620,15 @@ class LemonadeClient:
         url = f"{self.base_url}/models"
         if show_all:
             url += "?show_all=true"
-        return self._send_request("get", url)
+        catalog = self._send_request("get", url)
+        for entry in catalog.get("data", []):
+            if entry.get("id"):
+                self._model_metadata.setdefault(entry["id"], {}).update(entry)
+        return catalog
+
+    def cloud_model_provider(self, model: str) -> Optional[str]:
+        """Return the provider for a built-in or previously discovered cloud model."""
+        return cloud_model_provider(model, self._model_metadata.get(model))
 
     def get_model_details(self, model_id: str) -> Dict[str, Any]:
         """
@@ -2562,6 +2694,12 @@ class LemonadeClient:
         Raises:
             LemonadeClientError: If the model installation fails
         """
+        if self.cloud_model_provider(model_name):
+            raise LemonadeClientError(
+                f"Cloud model '{model_name}' cannot be downloaded. "
+                "Connect its provider in the TUI provider settings, then select "
+                "a discovered model with /model."
+            )
         self.log.info(f"Installing {model_name}")
 
         request_data = {"model_name": model_name}
@@ -2715,6 +2853,12 @@ class LemonadeClient:
                 elif event["event"] == "complete":
                     print("Done!")
         """
+        if self.cloud_model_provider(model_name):
+            raise LemonadeClientError(
+                f"Cloud model '{model_name}' cannot be downloaded. "
+                "Connect its provider in the TUI provider settings, then select "
+                "a discovered model with /model."
+            )
         self.log.info(f"Installing {model_name} with streaming progress")
 
         request_data = {"model_name": model_name, "stream": True}
@@ -2877,6 +3021,15 @@ class LemonadeClient:
             if client.ensure_model_downloaded("Qwen3-0.6B-GGUF"):
                 client.load_model("Qwen3-0.6B-GGUF")
         """
+        if self.cloud_model_provider(model_name):
+            catalog = self.list_models(show_all=True)
+            if any(m.get("id") == model_name for m in catalog.get("data", [])):
+                return True
+            raise LemonadeClientError(
+                f"Cloud model '{model_name}' is not in Lemonade's catalog. "
+                "Connect its provider in the TUI provider settings and select "
+                "a discovered model with /model."
+            )
         try:
             # Check if model is already downloaded
             models_response = self.list_models()
@@ -3233,6 +3386,8 @@ class LemonadeClient:
 
         Deferred import keeps ``gaia.daemon`` off the standalone import path.
         """
+        if self.cloud_model_provider(model):
+            return nullcontext()
         from gaia.daemon.broker_client import model_lease
 
         def _on_wait(reason: str) -> None:
@@ -3267,7 +3422,7 @@ class LemonadeClient:
             the model is ready before making API requests. When a model is explicitly
             requested via CLI flags, it downloads automatically without user confirmation.
         """
-        if not auto_download:
+        if self.cloud_model_provider(model) or not auto_download:
             return  # Skip if auto_download disabled
 
         with self._model_slot_lease(model):
@@ -3482,6 +3637,12 @@ class LemonadeClient:
 
         See :meth:`_load_model_leased` for the full parameter documentation.
         """
+        if self.cloud_model_provider(model_name):
+            raise LemonadeClientError(
+                f"Cloud model '{model_name}' does not use local model loading. "
+                "Send chat requests through Lemonade; select its provider in "
+                "the TUI provider settings if it is not connected."
+            )
         with self._model_slot_lease(model_name):
             return self._load_model_leased(
                 model_name,
@@ -4139,9 +4300,16 @@ class LemonadeClient:
             models = self.list_models(show_all=True)
             for model in models.get("data", []):
                 if _model_ids_match(model.get("id"), model_id):
-                    return model.get("downloaded", False)
-        except Exception:
-            pass
+                    return bool(
+                        model.get("downloaded", False)
+                        or cloud_model_provider(model_id, model)
+                    )
+        except LemonadeClientError as exc:
+            self.log.warning(
+                "Could not check model availability (%s). "
+                "Check the Lemonade connection and authentication, then retry.",
+                type(exc).__name__,
+            )
         return False
 
     def download_agent_models(
@@ -4679,8 +4847,8 @@ def create_lemonade_client(
             client.log.error(f"Failed to start Lemonade server: {str(e)}")
             raise LemonadeClientError(f"Failed to start Lemonade server: {str(e)}")
 
-    # Auto-load model if requested
-    if auto_load:
+    # Cloud models have no local weights or context to preload.
+    if auto_load and not client.cloud_model_provider(model_name):
         try:
             # Check if auto_pull is enabled and model needs to be pulled first
             if auto_pull:

--- a/src/gaia/llm/providers/lemonade.py
+++ b/src/gaia/llm/providers/lemonade.py
@@ -308,6 +308,7 @@ class LemonadeProvider(LLMClient):
 
         self._backend = LemonadeClient(**backend_kwargs)
         self._model = model
+        self._last_model = model
         self._system_prompt = system_prompt
         # Token usage from the most recent non-streaming ``chat()`` call
         # (#1891) — the OpenAI-compatible ``/chat/completions`` response's
@@ -349,6 +350,7 @@ class LemonadeProvider(LLMClient):
 
         # Use provided model, instance model, or default CPU model
         effective_model = model or self._model or DEFAULT_MODEL_NAME
+        self._last_model = effective_model
         tool_capable = is_tool_calling_model(effective_model)
 
         # Prepend system prompt if set
@@ -505,6 +507,13 @@ class LemonadeProvider(LLMClient):
         return vlm.extract_from_image(images[0], prompt=prompt)
 
     def get_performance_stats(self) -> dict:
+        if self._backend.cloud_model_provider(self._last_model or DEFAULT_MODEL_NAME):
+            # Server-global stats can belong to a concurrent local or cloud request.
+            return {
+                key: value
+                for key, value in (self._last_usage or {}).items()
+                if key != "tokens_per_second"
+            }
         return self._backend.get_stats() or {}
 
     def get_last_usage(self) -> Optional[dict]:

--- a/src/gaia/ui/_chat_helpers.py
+++ b/src/gaia/ui/_chat_helpers.py
@@ -385,7 +385,9 @@ async def _generate_session_title(
                     # for the same conversation.
                     "temperature": 0.3,
                 },
-                headers=lemonade_auth_headers(resolve_lemonade_api_key()),
+                headers=lemonade_auth_headers(
+                    resolve_lemonade_api_key(base_url=base_url)
+                ),
             )
             if resp.status_code != 200:
                 logger.debug(
@@ -1199,7 +1201,7 @@ def _maybe_load_expected_model(model_id: str, sse_handler=None) -> None:
         from gaia.llm.lemonade_manager import DEFAULT_CONTEXT_SIZE, LemonadeManager
 
         base_url = LemonadeManager.get_base_url() or "http://localhost:13305/api/v1"
-        _auth = lemonade_auth_headers(resolve_lemonade_api_key())
+        _auth = lemonade_auth_headers(resolve_lemonade_api_key(base_url=base_url))
         resp = httpx.get(f"{base_url}/health", timeout=5.0, headers=_auth)
         if resp.status_code != 200:
             return
@@ -2603,7 +2605,9 @@ async def _stream_chat_impl(run, db: ChatDatabase, session: dict, request: ChatR
                 base_url = (
                     LemonadeManager.get_base_url() or "http://localhost:13305/api/v1"
                 )
-                _auth = lemonade_auth_headers(resolve_lemonade_api_key())
+                _auth = lemonade_auth_headers(
+                    resolve_lemonade_api_key(base_url=base_url)
+                )
                 async with httpx.AsyncClient(timeout=3.0) as stats_client:
                     stats_resp = await stats_client.get(
                         f"{base_url}/stats", headers=_auth

--- a/src/gaia/ui/routers/onboarding.py
+++ b/src/gaia/ui/routers/onboarding.py
@@ -89,7 +89,7 @@ async def _probe_lemonade_devices() -> Dict[str, Any]:
         import httpx  # pylint: disable=import-outside-toplevel
 
         base_url = _get_lemonade_base_url()
-        auth = lemonade_auth_headers(resolve_lemonade_api_key())
+        auth = lemonade_auth_headers(resolve_lemonade_api_key(base_url=base_url))
         async with httpx.AsyncClient(timeout=3.0) as client:
             resp = await client.get(f"{base_url}/system-info", headers=auth)
             if resp.status_code != 200:

--- a/src/gaia/ui/routers/system.py
+++ b/src/gaia/ui/routers/system.py
@@ -74,7 +74,7 @@ async def _lemonade_post(
         import httpx  # pylint: disable=import-outside-toplevel
 
         base_url = _get_lemonade_base_url()
-        headers = lemonade_auth_headers(resolve_lemonade_api_key())
+        headers = lemonade_auth_headers(resolve_lemonade_api_key(base_url=base_url))
         async with httpx.AsyncClient(timeout=timeout) as client:
             resp = await client.post(
                 f"{base_url}/{path}", json=payload, headers=headers
@@ -253,7 +253,7 @@ async def _stream_lemonade_pull(model_name: str, force: bool) -> None:
     # download itself can take many minutes between progress events on a slow
     # link, and we'd rather hold open than wrongly bail.
     client_timeout = httpx.Timeout(connect=10.0, read=None, write=10.0, pool=10.0)
-    headers = lemonade_auth_headers(resolve_lemonade_api_key())
+    headers = lemonade_auth_headers(resolve_lemonade_api_key(base_url=base_url))
     try:
         async with httpx.AsyncClient(timeout=client_timeout) as client:
             async with client.stream(
@@ -464,7 +464,7 @@ async def system_status(request: Request, db: ChatDatabase = Depends(get_db)):
 
         async with httpx.AsyncClient(timeout=10.0) as client:
             base_url = _get_lemonade_base_url()
-            _auth = lemonade_auth_headers(resolve_lemonade_api_key())
+            _auth = lemonade_auth_headers(resolve_lemonade_api_key(base_url=base_url))
 
             # Derive the Lemonade web UI URL (scheme://host:port without /api/v1)
             try:
@@ -804,7 +804,7 @@ async def _check_model_status(model_name: str) -> ModelStatus:
         import httpx
 
         base_url = _get_lemonade_base_url()
-        _auth = lemonade_auth_headers(resolve_lemonade_api_key())
+        _auth = lemonade_auth_headers(resolve_lemonade_api_key(base_url=base_url))
         async with httpx.AsyncClient(timeout=5.0) as client:
             # Check catalog: is model known and downloaded?
             models_resp = await client.get(

--- a/src/gaia/ui/server.py
+++ b/src/gaia/ui/server.py
@@ -315,7 +315,7 @@ def create_app(db_path: str = None, webui_dist: str = None) -> FastAPI:
             from gaia.ui._chat_helpers import model_load_lock
 
             base_url = LemonadeManager.get_base_url() or "http://localhost:13305/api/v1"
-            _auth = lemonade_auth_headers(resolve_lemonade_api_key())
+            _auth = lemonade_auth_headers(resolve_lemonade_api_key(base_url=base_url))
 
             # Check if a chat model is already loaded.
             # Let exceptions propagate so the DispatchQueue marks the job as

--- a/tests/unit/test_base_agent_lemonade_api_key.py
+++ b/tests/unit/test_base_agent_lemonade_api_key.py
@@ -116,3 +116,66 @@ def test_is_loaded_ctx_too_small_uses_active_device_profile(
     mock_httpx_get.return_value = mock_resp
 
     assert agent._is_loaded_ctx_too_small() is expected_too_small
+
+
+@pytest.mark.parametrize("model", ["fireworks.gemma-4-31b-it", "amd.gemma-4-31b-it"])
+def test_cloud_context_error_never_probes_local_model(
+    monkeypatch, _minimal_agent, model
+):
+    probe = MagicMock()
+    monkeypatch.setattr("httpx.get", probe)
+    _minimal_agent.model_id = model
+
+    assert _minimal_agent._is_loaded_ctx_too_small() is False
+    probe.assert_not_called()
+
+
+@pytest.mark.parametrize("model", ["fireworks.gemma-4-31b-it", "amd.gemma-4-31b-it"])
+def test_cloud_startup_checks_server_without_loading_local_chat(monkeypatch, model):
+    from gaia.agents.base.agent import Agent
+
+    class CloudAgent(Agent):
+        def _register_tools(self):
+            return None
+
+    health = MagicMock(return_value={"status": "ok"})
+    local_init = MagicMock()
+    monkeypatch.setattr("gaia.llm.lemonade_client.LemonadeClient.health_check", health)
+    monkeypatch.setattr(
+        "gaia.llm.lemonade_manager.LemonadeManager.ensure_ready", local_init
+    )
+
+    agent = CloudAgent(model_id=model, silent_mode=True)
+
+    assert agent.model_id == model
+    health.assert_called_once()
+    local_init.assert_not_called()
+
+
+def test_cloud_agent_without_url_uses_isolated_embedded_endpoint(monkeypatch, tmp_path):
+    import json
+
+    from gaia.agents.base.agent import Agent
+
+    class CloudAgent(Agent):
+        def _register_tools(self):
+            return None
+
+    monkeypatch.setenv("GAIA_HOME", str(tmp_path))
+    monkeypatch.delenv("LEMONADE_BASE_URL", raising=False)
+    monkeypatch.delenv("LEMONADE_API_KEY", raising=False)
+    (tmp_path / "lemonade").mkdir()
+    (tmp_path / "lemonade" / "state.json").write_text(
+        json.dumps({"port": 63209, "api_key": "isolated-key"})
+    )
+    checked = []
+
+    def health(client):
+        checked.append((client.base_url, client.api_key))
+        return {"status": "ok"}
+
+    monkeypatch.setattr("gaia.llm.lemonade_client.LemonadeClient.health_check", health)
+    agent = CloudAgent(model_id="fireworks.gemma-4-31b-it", silent_mode=True)
+
+    assert checked == [("http://localhost:63209/api/v1", "isolated-key")]
+    assert agent.chat.config.base_url == "http://localhost:63209/api/v1"

--- a/tests/unit/test_broker_wiring.py
+++ b/tests/unit/test_broker_wiring.py
@@ -189,6 +189,8 @@ class _FakeClient:
     def build(self, monkeypatch):
         client = object.__new__(self.cls)
         client.model_lease_priority = "background"
+        # load_model consults the cloud-provider lookup, which reads this cache.
+        client._model_metadata = {}
         import logging
 
         client.log = logging.getLogger("test.lemonade")
@@ -290,6 +292,8 @@ def test_load_model_forwards_every_kwarg_through_the_lease(monkeypatch):
 
     client = object.__new__(LemonadeClient)
     client.model_lease_priority = "background"
+    # load_model consults the cloud-provider lookup, which reads this cache.
+    client._model_metadata = {}
     import logging
 
     client.log = logging.getLogger("test.lemonade")
@@ -412,6 +416,8 @@ def _bare_chat_client():
     client.model_lease_priority = "background"
     client.base_url = "http://127.0.0.1:0/api/v1"
     client.api_key = None
+    # The chat paths consult the cloud-provider lookup, which reads this cache.
+    client._model_metadata = {}
     client.log = logging.getLogger("test.lemonade")
     return client
 

--- a/tests/unit/test_init_command.py
+++ b/tests/unit/test_init_command.py
@@ -870,8 +870,9 @@ class TestSkipChatModel(unittest.TestCase):
             with patch(
                 "gaia.llm.lemonade_manager.LemonadeManager.ensure_ready",
                 return_value=True,
-            ):
+            ) as ensure_ready:
                 result = cmd._verify_setup()
+            ensure_ready.assert_not_called()
             self.assertTrue(result)
             checked = {
                 c.args[0] for c in mock_client.check_model_available.call_args_list

--- a/tests/unit/test_lemonade_client_api_key.py
+++ b/tests/unit/test_lemonade_client_api_key.py
@@ -5,6 +5,7 @@
 import json
 
 import pytest
+import responses
 
 from gaia.llm import lemonade_client as lc
 
@@ -12,6 +13,8 @@ from gaia.llm import lemonade_client as lc
 @pytest.fixture
 def embedded_state(tmp_path, monkeypatch):
     """Point the resolver at a throwaway embedded-Lemonade state file."""
+    monkeypatch.delenv("GAIA_HOME", raising=False)
+    monkeypatch.delenv("LEMONADE_BASE_URL", raising=False)
 
     def _write(payload):
         path = tmp_path / "state.json"
@@ -51,7 +54,7 @@ class TestResolveLemonadeApiKey:
 
     def test_blank_env_does_not_mask_the_state_file(self, embedded_state, monkeypatch):
         """An empty env var is unset, not an instruction to send no key."""
-        embedded_state({"api_key": "from-state"})
+        embedded_state({"port": 13305, "api_key": "from-state"})
         monkeypatch.setenv("LEMONADE_API_KEY", "   ")
         assert lc.resolve_lemonade_api_key() == "from-state"
 
@@ -98,7 +101,7 @@ class TestEmbeddedBaseURL:
         _, _, base = lc._get_lemonade_config()
         assert base == lc.DEFAULT_LEMONADE_URL
 
-    @pytest.mark.parametrize("port", [0, -1, "63207", None])
+    @pytest.mark.parametrize("port", [0, -1, 65536, True, "63207", None])
     def test_an_unusable_port_is_ignored(self, embedded_state, monkeypatch, port):
         embedded_state({"port": port, "api_key": "k"})
         monkeypatch.delenv("LEMONADE_BASE_URL", raising=False)
@@ -156,3 +159,148 @@ class TestResolveLemonadeBaseURL:
         embedded_state({"port": 63207, "api_key": "k"})
         monkeypatch.delenv("LEMONADE_BASE_URL", raising=False)
         assert lc.resolve_lemonade_base_url().endswith("/api/v1")
+
+
+class TestEmbeddedCredentialScope:
+    @pytest.mark.parametrize("host", ["localhost", "127.0.0.1", "[::1]"])
+    def test_key_matches_embedded_local_endpoint(
+        self, embedded_state, monkeypatch, host
+    ):
+        embedded_state({"port": 63207, "api_key": "embedded-only"})
+        monkeypatch.delenv("LEMONADE_API_KEY", raising=False)
+        base = f"http://{host}:63207/api/v1"
+        assert lc.resolve_lemonade_api_key(base_url=base) == "embedded-only"
+        assert lc.LemonadeClient(base_url=base).api_key == "embedded-only"
+
+    @pytest.mark.parametrize(
+        "base",
+        [
+            "https://api.fireworks.ai/inference/v1",
+            "https://gateway.example.test:63207/v1",
+            "http://other-host:63207/api/v1",
+            "http://127.0.0.2:63207/api/v1",
+            "http://localhost:63208/api/v1",
+            "https://localhost:63207/api/v1",
+            "http://user@localhost:63207/api/v1",
+            "http://localhost:63207/api/v1?redirect=elsewhere",
+            "http://localhost:63207/api/v1#fragment",
+            "http://localhost:invalid/api/v1",
+        ],
+    )
+    def test_unrelated_endpoint_never_gets_embedded_key(
+        self, embedded_state, monkeypatch, base
+    ):
+        embedded_state({"port": 63207, "api_key": "embedded-only"})
+        monkeypatch.delenv("LEMONADE_API_KEY", raising=False)
+        assert lc.resolve_lemonade_api_key(base_url=base) is None
+
+    def test_explicit_and_environment_keys_still_override(
+        self, embedded_state, monkeypatch
+    ):
+        embedded_state({"port": 63207, "api_key": "embedded-only"})
+        base = "https://gateway.example.test/v1"
+        monkeypatch.setenv("LEMONADE_API_KEY", "configured-key")
+        assert lc.resolve_lemonade_api_key(base_url=base) == "configured-key"
+        assert (
+            lc.resolve_lemonade_api_key("explicit-key", base_url=base) == "explicit-key"
+        )
+
+    def test_no_argument_resolver_scopes_key_to_configured_url(
+        self, embedded_state, monkeypatch
+    ):
+        embedded_state({"port": 63207, "api_key": "embedded-only"})
+        monkeypatch.delenv("LEMONADE_API_KEY", raising=False)
+        monkeypatch.setenv("LEMONADE_BASE_URL", "https://gateway.example.test/v1")
+        assert lc.resolve_lemonade_api_key() is None
+
+    @pytest.mark.parametrize("client_type", ["chat", "transcription"])
+    def test_client_explicit_endpoint_does_not_inherit_local_key(
+        self, embedded_state, monkeypatch, client_type
+    ):
+        from gaia.audio.lemonade_asr import LemonadeASRClient
+
+        embedded_state({"port": 63207, "api_key": "embedded-only"})
+        monkeypatch.delenv("LEMONADE_API_KEY", raising=False)
+        cls = lc.LemonadeClient if client_type == "chat" else LemonadeASRClient
+        client = cls(base_url="https://gateway.example.test/v1")
+        assert client.api_key is None
+
+    def test_gaia_home_isolated_from_default_runtime(
+        self, embedded_state, monkeypatch, tmp_path
+    ):
+        embedded_state({"port": 63207, "api_key": "default-key"})
+        monkeypatch.delenv("LEMONADE_API_KEY", raising=False)
+        isolated = tmp_path / "isolated"
+        monkeypatch.setenv("GAIA_HOME", str(isolated))
+        assert lc.resolve_lemonade_base_url() == lc.DEFAULT_LEMONADE_URL
+        assert lc.resolve_lemonade_api_key() is None
+
+        (isolated / "lemonade").mkdir(parents=True)
+        state = isolated / "lemonade" / "state.json"
+        state.write_text(json.dumps({"port": 63208, "api_key": "isolated-key"}))
+        assert lc.resolve_lemonade_base_url() == "http://localhost:63208/api/v1"
+        assert lc.resolve_lemonade_api_key() == "isolated-key"
+        assert (
+            lc.resolve_lemonade_api_key(base_url="http://localhost:63207/api/v1")
+            is None
+        )
+
+        state.write_text("invalid json")
+        assert lc.resolve_lemonade_base_url() == lc.DEFAULT_LEMONADE_URL
+        assert lc.resolve_lemonade_api_key() is None
+
+    def test_readiness_explicit_endpoint_does_not_receive_embedded_key(
+        self, embedded_state, monkeypatch
+    ):
+        from unittest.mock import MagicMock
+
+        from gaia.agents.base.readiness import probe_model_present, pull_model
+
+        embedded_state({"port": 63207, "api_key": "embedded-only"})
+        monkeypatch.delenv("LEMONADE_API_KEY", raising=False)
+        response = MagicMock()
+        response.json.return_value = {"data": []}
+        get = MagicMock(return_value=response)
+        post = MagicMock(return_value=response)
+        monkeypatch.setattr("requests.get", get)
+        monkeypatch.setattr("requests.post", post)
+        base = "https://gateway.example.test/api/v1"
+
+        assert probe_model_present(base, "test-model") is False
+        pull_model(base, "test-model")
+
+        assert get.call_args.kwargs["headers"] == {}
+        assert post.call_args.kwargs["headers"] == {}
+
+
+@pytest.mark.parametrize("source", ["environment", "explicit"])
+@pytest.mark.parametrize(
+    "configured,expected",
+    [
+        ("http://proxy.test:13305", "http://proxy.test:13305/api/v1"),
+        ("http://proxy.test:13305/", "http://proxy.test:13305/api/v1"),
+        ("http://proxy.test:13305/v1", "http://proxy.test:13305/v1"),
+        ("http://proxy.test:13305/v1/", "http://proxy.test:13305/v1"),
+        ("https://proxy.test/llm/custom/v1", "https://proxy.test/llm/custom/v1"),
+        ("https://proxy.test/api/v1/", "https://proxy.test/api/v1"),
+    ],
+)
+@responses.activate
+def test_configured_api_path_reaches_exact_endpoint(
+    embedded_state, monkeypatch, source, configured, expected
+):
+    from gaia.audio.lemonade_asr import LemonadeASRClient
+
+    monkeypatch.delenv("LEMONADE_API_KEY", raising=False)
+    kwargs = {}
+    if source == "environment":
+        monkeypatch.setenv("LEMONADE_BASE_URL", configured)
+    else:
+        kwargs["base_url"] = configured
+    assert lc.resolve_lemonade_base_url(kwargs.get("base_url")) == expected
+    client = lc.LemonadeClient(**kwargs)
+    assert client.base_url == expected
+    assert LemonadeASRClient(**kwargs).base_url == expected
+    responses.get(f"{expected}/health", json={"status": "ok"})
+    assert client.health_check() == {"status": "ok"}
+    assert len(responses.calls) == 1

--- a/tests/unit/test_lemonade_cloud_models.py
+++ b/tests/unit/test_lemonade_cloud_models.py
@@ -1,0 +1,436 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Cloud inference must never acquire or reconfigure the local model slot."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+import responses
+from openai import OpenAI
+
+from gaia.llm.lemonade_client import (
+    LemonadeClient,
+    LemonadeClientError,
+    cloud_model_provider,
+    create_lemonade_client,
+)
+from gaia.llm.providers.lemonade import LemonadeProvider
+
+
+@pytest.mark.parametrize(
+    "model,provider",
+    [
+        ("fireworks.gemma-4-31b-it", "fireworks"),
+        ("fireworks.accounts/fireworks/models/gemma-4-31b-it", "fireworks"),
+        ("amd.gpt-4.1", "amd"),
+        ("user.embeddinggemma-300m-GGUF", None),
+        ("Qwen3.5-35B-GGUF", None),
+        ("qwen3.5-35B-GGUF", None),
+        ("cloud.example.model", None),
+        ("fireworks.", None),
+        (None, None),
+    ],
+)
+def test_cloud_model_namespace(model, provider):
+    assert cloud_model_provider(model) == provider
+
+
+def test_cloud_catalog_metadata_identifies_custom_provider():
+    assert (
+        cloud_model_provider(
+            "company.llama-4", {"recipe": "cloud", "cloud_provider": "company"}
+        )
+        == "company"
+    )
+    assert cloud_model_provider("company.llama-4", {"recipe": "llamacpp"}) is None
+
+
+@pytest.fixture
+def client(monkeypatch):
+    def reject_local_operation(*args, **kwargs):
+        pytest.fail("Cloud inference attempted a local model operation")
+
+    client = LemonadeClient(verbose=False, ctx_size_override=1024)
+    monkeypatch.setattr(client, "get_status", reject_local_operation)
+    monkeypatch.setattr(client, "_ensure_pinned_load", reject_local_operation)
+    monkeypatch.setattr(client, "_load_model_leased", reject_local_operation)
+    monkeypatch.setattr("gaia.daemon.broker_client.model_lease", reject_local_operation)
+    return client
+
+
+@pytest.mark.parametrize("provider", ["fireworks", "amd"])
+@responses.activate
+def test_cloud_chat_only_calls_inference_and_preserves_tools(client, provider):
+    model = f"{provider}.gemma-4-31b-it"
+    reply = {"choices": [{"message": {"content": "hello"}}]}
+    responses.post(f"{client.base_url}/chat/completions", json=reply)
+    tools = [{"type": "function", "function": {"name": "get_weather"}}]
+
+    assert (
+        client.chat_completions(
+            model,
+            [{"role": "user", "content": "hello"}],
+            tools=tools,
+            repeat_penalty=1.1,
+            repeat_last_n=256,
+            frequency_penalty=0.3,
+        )
+        == reply
+    )
+
+    assert len(responses.calls) == 1
+    body = json.loads(responses.calls[0].request.body)
+    assert body["model"] == model
+    assert body["tools"] == tools
+    assert body["frequency_penalty"] == 0.3
+    assert "repeat_penalty" not in body and "repeat_last_n" not in body
+    assert "ctx_size" not in body
+
+
+def test_cloud_stream_skips_slot_and_preserves_stream_and_tools(client, monkeypatch):
+    sdk = MagicMock()
+    sdk.chat.completions.create.return_value = [
+        SimpleNamespace(
+            id="chunk-1",
+            created=0,
+            model="amd.gemma-4-31b-it",
+            choices=[
+                SimpleNamespace(
+                    index=0,
+                    finish_reason=None,
+                    delta=SimpleNamespace(
+                        role="assistant", content="hello", tool_calls=None
+                    ),
+                )
+            ],
+        )
+    ]
+    monkeypatch.setattr("gaia.llm.lemonade_client.OpenAI", lambda **kwargs: sdk)
+    tools = [{"type": "function", "function": {"name": "get_weather"}}]
+
+    chunks = list(
+        client.chat_completions(
+            "amd.gemma-4-31b-it",
+            [],
+            stream=True,
+            tools=tools,
+            repeat_penalty=1.1,
+            repeat_last_n=256,
+        )
+    )
+
+    assert chunks[0]["choices"][0]["delta"]["content"] == "hello"
+    sent = sdk.chat.completions.create.call_args.kwargs
+    assert sent["stream"] is True and sent["tools"] == tools
+    assert "extra_body" not in sent
+
+
+@responses.activate
+def test_missing_cloud_model_fails_without_download_or_retry(client):
+    responses.post(
+        f"{client.base_url}/chat/completions",
+        status=404,
+        json={"error": {"message": "model not found"}},
+    )
+    with pytest.raises(LemonadeClientError):
+        client.chat_completions("fireworks.missing", [])
+    assert len(responses.calls) == 1
+
+
+@pytest.mark.parametrize("operation", ["load_model", "pull_model", "pull_model_stream"])
+def test_explicit_local_operations_on_cloud_fail_before_network(client, operation):
+    with pytest.raises(LemonadeClientError, match="Cloud model"):
+        result = getattr(client, operation)("fireworks.gemma-4-31b-it")
+        if operation == "pull_model_stream":
+            list(result)
+
+
+@responses.activate
+def test_cloud_availability_does_not_require_downloaded(client):
+    responses.get(
+        f"{client.base_url}/models?show_all=true",
+        json={"data": [{"id": "fireworks.gemma-4-31b-it", "downloaded": False}]},
+    )
+    assert client.check_model_available("fireworks.gemma-4-31b-it")
+    assert client.ensure_model_downloaded("fireworks.gemma-4-31b-it")
+
+
+@responses.activate
+def test_discovered_custom_cloud_avoids_local_load(client):
+    responses.get(
+        f"{client.base_url}/models?show_all=true",
+        json={
+            "data": [
+                {"id": "company.gemma", "recipe": "cloud", "cloud_provider": "company"}
+            ]
+        },
+    )
+    responses.post(
+        f"{client.base_url}/chat/completions",
+        json={"choices": [{"message": {"content": "hello"}}]},
+    )
+    client.list_models(show_all=True)
+    client.chat_completions("company.gemma", [])
+    assert len(responses.calls) == 2
+
+
+@pytest.mark.parametrize(
+    "status,remedy",
+    [
+        (401, "Reconnect"),
+        (403, "model access"),
+        (404, "deployed model"),
+        (429, "Wait before retrying"),
+        (500, "Check the provider"),
+    ],
+)
+@responses.activate
+def test_cloud_error_never_echoes_upstream_body(client, status, remedy, caplog):
+    reflected_key = "test-upstream-key-do-not-display"
+    responses.post(
+        f"{client.base_url}/chat/completions",
+        status=status,
+        json={"error": {"message": reflected_key}},
+    )
+    with pytest.raises(LemonadeClientError) as error:
+        client.chat_completions("fireworks.gemma-4-31b-it", [])
+    assert str(status) in str(error.value)
+    assert "provider settings" in str(error.value)
+    assert remedy in str(error.value)
+    assert reflected_key not in str(error.value)
+    assert reflected_key not in caplog.text
+
+
+def test_cloud_factory_auto_load_does_not_download_or_load(monkeypatch):
+    load = MagicMock()
+    pull = MagicMock()
+    monkeypatch.setattr(LemonadeClient, "load_model", load)
+    monkeypatch.setattr(LemonadeClient, "pull_model", pull)
+
+    client = create_lemonade_client(
+        model="fireworks.gemma-4-31b-it", auto_load=True, auto_pull=True
+    )
+
+    assert client.model == "fireworks.gemma-4-31b-it"
+    load.assert_not_called()
+    pull.assert_not_called()
+
+
+@pytest.mark.parametrize("provider", ["fireworks", "amd"])
+@pytest.mark.parametrize("stream", [False, True])
+@responses.activate
+def test_cloud_provider_preserves_native_tool_only_response(
+    client, monkeypatch, provider, stream
+):
+    model = f"{provider}.gemma-4-31b-it"
+    tool_call = {
+        "id": "call-weather",
+        "type": "function",
+        "function": {"name": "get_weather", "arguments": '{"city":"Paris"}'},
+    }
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            },
+        }
+    ]
+    sent = []
+    if stream:
+        fragments = [
+            {
+                "index": 0,
+                "id": tool_call["id"],
+                "type": "function",
+                "function": {"name": "get_weather", "arguments": '{"city":'},
+            },
+            {"index": 0, "function": {"arguments": '"Paris"}'}},
+        ]
+        chunks = [
+            {
+                "id": "chat-weather",
+                "object": "chat.completion.chunk",
+                "created": 0,
+                "model": model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"content": None, "tool_calls": [fragment]},
+                        "finish_reason": None,
+                    }
+                ],
+            }
+            for fragment in fragments
+        ]
+        chunks.append(
+            {
+                "id": "chat-weather",
+                "object": "chat.completion.chunk",
+                "created": 0,
+                "model": model,
+                "choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}],
+            }
+        )
+        wire = "".join(f"data: {json.dumps(chunk)}\n\n" for chunk in chunks)
+        wire += "data: [DONE]\n\n"
+
+        def handle(request):
+            assert str(request.url) == f"{client.base_url}/chat/completions"
+            sent.append(json.loads(request.content))
+            return httpx.Response(
+                200, content=wire, headers={"content-type": "text/event-stream"}
+            )
+
+        http_client = httpx.Client(transport=httpx.MockTransport(handle))
+        sdk = OpenAI(
+            base_url=client.base_url,
+            api_key="test-placeholder",
+            http_client=http_client,
+        )
+        monkeypatch.setattr("gaia.llm.lemonade_client.OpenAI", lambda **kwargs: sdk)
+    else:
+        responses.post(
+            f"{client.base_url}/chat/completions",
+            json={
+                "usage": {
+                    "prompt_tokens": 12,
+                    "completion_tokens": 7,
+                    "total_tokens": 19,
+                },
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": [tool_call],
+                        },
+                        "finish_reason": "tool_calls",
+                    }
+                ],
+            },
+        )
+
+    adapter = LemonadeProvider(model="Gemma-4-E4B-it-GGUF")
+    adapter._backend = client
+    global_stats = MagicMock(
+        return_value={"output_tokens": 999, "tokens_per_second": 999}
+    )
+    monkeypatch.setattr(client, "get_stats", global_stats)
+    try:
+        result = adapter.chat(
+            [{"role": "user", "content": "What's the weather in Paris?"}],
+            model=model,
+            tools=tools,
+            stream=stream,
+        )
+        if stream:
+            events = list(result)
+            assert len(events) == 1
+            envelope = json.loads(events[0])
+        else:
+            envelope = json.loads(result)
+            assert len(responses.calls) == 1
+            sent.append(json.loads(responses.calls[0].request.body))
+    finally:
+        if stream:
+            sdk.close()
+
+    assert envelope == {
+        "__tool_calls__": [tool_call],
+        "finish_reason": "tool_calls",
+        "content": None,
+    }
+    assert len(sent) == 1
+    assert sent[0]["model"] == model
+    assert sent[0]["tools"] == tools
+    assert sent[0]["stream"] is stream
+    assert "repeat_penalty" not in sent[0] and "repeat_last_n" not in sent[0]
+    assert adapter.get_performance_stats() == (
+        {}
+        if stream
+        else {"prompt_tokens": 12, "completion_tokens": 7, "total_tokens": 19}
+    )
+    global_stats.assert_not_called()
+
+
+def test_local_provider_keeps_lemonade_performance_stats(monkeypatch):
+    adapter = LemonadeProvider(model="Gemma-4-E4B-it-GGUF")
+    stats = {"input_tokens": 12, "output_tokens": 7, "tokens_per_second": 25.0}
+    get_stats = MagicMock(return_value=stats)
+    monkeypatch.setattr(adapter._backend, "get_stats", get_stats)
+
+    assert adapter.get_performance_stats() == stats
+    get_stats.assert_called_once()
+
+
+def test_model_availability_failure_emits_diagnostic(client, monkeypatch, caplog):
+    monkeypatch.setattr(
+        client,
+        "list_models",
+        MagicMock(side_effect=LemonadeClientError("private upstream body")),
+    )
+    assert client.check_model_available("fireworks.gemma-4-31b-it") is False
+    assert "Could not check model availability" in caplog.text
+    assert "Check the Lemonade connection and authentication" in caplog.text
+    assert "private upstream body" not in caplog.text
+
+
+def test_model_availability_does_not_hide_programming_errors(client, monkeypatch):
+    monkeypatch.setattr(
+        client, "list_models", MagicMock(side_effect=RuntimeError("bug"))
+    )
+    with pytest.raises(RuntimeError, match="bug"):
+        client.check_model_available("fireworks.gemma-4-31b-it")
+
+
+@pytest.mark.parametrize(
+    "status,remedy",
+    [
+        (401, "Reconnect"),
+        (403, "model access"),
+        (404, "deployed model"),
+        (429, "Wait before retrying"),
+        (500, "Check the provider"),
+    ],
+)
+def test_cloud_sse_backend_error_uses_status_without_reflecting_body(
+    client, monkeypatch, caplog, status, remedy
+):
+    reflected_key = "private-upstream-response-and-key"
+    error_frame = {
+        "error": {
+            "type": "backend_error",
+            "message": reflected_key,
+            "details": {"status_code": status, "response": {"error": reflected_key}},
+        }
+    }
+
+    def handle(request):
+        return httpx.Response(
+            200,
+            content=f"data: {json.dumps(error_frame)}\n\ndata: [DONE]\n\n",
+            headers={"content-type": "text/event-stream"},
+        )
+
+    with httpx.Client(transport=httpx.MockTransport(handle)) as transport:
+        with OpenAI(
+            base_url=client.base_url, api_key="test-placeholder", http_client=transport
+        ) as sdk:
+            monkeypatch.setattr("gaia.llm.lemonade_client.OpenAI", lambda **kwargs: sdk)
+            with pytest.raises(LemonadeClientError) as error:
+                list(client.chat_completions("fireworks.not-deployed", [], stream=True))
+
+    assert str(status) in str(error.value)
+    assert remedy in str(error.value)
+    assert reflected_key not in str(error.value)
+    assert reflected_key not in caplog.text

--- a/tui/README.md
+++ b/tui/README.md
@@ -150,6 +150,20 @@ In the pre-run checks, a condition that cannot be determined renders `[?]`
 rather than a checkmark and never counts as ready — unknown is never treated as
 fine.
 
+## Choosing an AI provider
+
+Press **p** during setup, or enter **`/provider`** in chat, to choose **Local**,
+**Fireworks AI**, or **AMD LLM Gateway** through Lemonade 11.8.1+. Paste a key into
+the masked field; it stays in Lemonade memory until the server restarts. Provider
+settings are shared with other clients of that server. Fireworks suggests
+`fireworks.gemma-4-31b-it` when your account exposes it. AMD Gateway accepts your
+organization's HTTPS endpoint and authentication header.
+
+Type to search discovered models, then press Enter to select. The header shows
+the active provider; remote chat sends conversation history to that provider.
+Embeddings remain on Lemonade. Cloud setup skips downloading a local chat model.
+See [AI providers](../docs/guides/ai-providers.mdx) for key handling and recovery.
+
 ## Testing the harness against Claude
 
 `--use-claude` runs an agent on Anthropic's Claude API instead of the local
@@ -186,7 +200,7 @@ and `chat --subprocess` tells you to put the flag in the command line you own.
 
 **Switching models mid-session:** the gaia agent also takes `/model` in the
 chat composer — `/model` alone lists every switchable id (the curated Claude
-5 family, plus whatever Lemonade currently has downloaded), and `/model <id>`
+5 family, downloaded local models, and discovered Fireworks/AMD models), and `/model <id>`
 swaps the live client without losing conversation history or loaded skills.
 Typing the space in `/model ` turns the slash palette into a model picker, so
 the Claude ids are pickable rather than remembered; local ids stay behind bare

--- a/tui/internal/client/factory.go
+++ b/tui/internal/client/factory.go
@@ -118,6 +118,12 @@ func ForAgent(agent catalog.Agent, opts ForAgentOptions) (AgentClient, error) {
 			}
 			args = append(append([]string{}, args...), extra...)
 		}
+		if opts.Model != "" {
+			if agent.ID != catalog.FlagshipID {
+				return nil, fmt.Errorf("model override is unsupported for subprocess agent %q", agent.ID)
+			}
+			args = append(append([]string{}, args...), "--model", opts.Model)
+		}
 		if agent.CanonicalEvents {
 			return NewCanonicalSubprocessClient(bin, args, opts.Dev).WithTrace(opts.Trace), nil
 		}

--- a/tui/internal/client/factory_test.go
+++ b/tui/internal/client/factory_test.go
@@ -8,6 +8,48 @@ import (
 	"github.com/amd/gaia/tui/internal/catalog"
 )
 
+func TestFlagshipModelOverrideReachesSubprocessWithoutMutatingCatalog(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, model := range []string{"fireworks.gemma-4-31b-it", "amd.gpt-4.1", "Gemma-4-E4B-it-GGUF"} {
+		t.Run(model, func(t *testing.T) {
+			args := make([]string, 1, 8)
+			args[0] = "--json-events"
+			agent := catalog.Agent{ID: catalog.FlagshipID, BinaryPath: self, BinaryArgs: args, DevArgs: []string{"--dev"}, CanonicalEvents: true}
+			c, err := ForAgent(agent, ForAgentOptions{Model: model, Dev: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer c.Close()
+			sub := c.(*SubprocessClient)
+			if got := strings.Join(sub.args, " "); got != "--json-events --dev --model "+model {
+				t.Fatalf("model did not reach the canonical subprocess: %q", got)
+			}
+			plain, err := ForAgent(agent, ForAgentOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer plain.Close()
+			if got := strings.Join(plain.(*SubprocessClient).args, " "); got != "--json-events" {
+				t.Fatalf("model override leaked into later launch: %q", got)
+			}
+		})
+	}
+}
+
+func TestModelOverrideRejectsUnsupportedSubprocessAgent(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = ForAgent(catalog.Agent{ID: "custom", BinaryPath: self}, ForAgentOptions{Model: "fireworks.gemma-4-31b-it"})
+	if err == nil || !strings.Contains(err.Error(), "model override is unsupported") {
+		t.Fatalf("unsupported override was silently dropped: %v", err)
+	}
+}
+
 func TestForAgentBuildsTheDeclaredTransport(t *testing.T) {
 	daemonAgent := catalog.Agent{ID: "email", Transport: catalog.TransportDaemon}
 	c, err := ForAgent(daemonAgent, ForAgentOptions{})

--- a/tui/internal/client/subprocess.go
+++ b/tui/internal/client/subprocess.go
@@ -7,13 +7,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"os/exec"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/amd/gaia/tui/internal/event"
+	"github.com/amd/gaia/tui/internal/lemonade"
 )
 
 var (
@@ -25,19 +26,20 @@ var (
 // finish before giving up on a clean reap.
 const closeGrace = 2 * time.Second
 
-// detectLemonadeURL probes common Lemonade Server ports and returns the first reachable URL.
-func detectLemonadeURL() string {
-	ports := []string{"13305", "8000"}
-	client := &http.Client{Timeout: 2 * time.Second}
+var subprocessLemonadePorts = []string{"13305", "8000"}
 
-	for _, port := range ports {
+// detectLemonadeURL resolves configured and embedded endpoints before probing
+// legacy ports. An unrelated local server cannot override the private runtime.
+func detectLemonadeURL() string {
+	if strings.TrimSpace(os.Getenv("LEMONADE_BASE_URL")) != "" || lemonade.ReadEmbedded() != nil {
+		return lemonade.ResolveBaseURL("")
+	}
+	for _, port := range subprocessLemonadePorts {
 		url := "http://localhost:" + port + "/api/v1"
-		resp, err := client.Get(url + "/models")
-		if err == nil {
-			resp.Body.Close()
-			if resp.StatusCode == 200 {
-				return url
-			}
+		client := lemonade.New(url)
+		client.HTTP.Timeout = 2 * time.Second
+		if _, err := client.Models(context.Background(), "local"); err == nil {
+			return url
 		}
 	}
 	return ""
@@ -156,13 +158,12 @@ func (s *SubprocessClient) startLocked() (turnState, error) {
 	stderr := &bytes.Buffer{}
 	cmd.Stderr = stderr
 
-	// Auto-detect Lemonade URL if not set in environment
-	if os.Getenv("LEMONADE_BASE_URL") == "" {
-		if url := detectLemonadeURL(); url != "" {
-			cmd.Env = append(os.Environ(), "LEMONADE_BASE_URL="+url)
-			if s.debug {
-				fmt.Fprintf(os.Stderr, "[DEBUG] Auto-detected Lemonade at %s\n", url)
-			}
+	// Resolve once for the child so provider setup and Python use the same
+	// endpoint, even when a second server answers on a legacy port.
+	if url := detectLemonadeURL(); url != "" {
+		cmd.Env = append(os.Environ(), "LEMONADE_BASE_URL="+url)
+		if s.debug {
+			fmt.Fprintf(os.Stderr, "[DEBUG] Lemonade endpoint: %s\n", url)
 		}
 	}
 
@@ -480,6 +481,8 @@ func (s *SubprocessClient) SetBypassPermissions(enabled bool) error {
 // so the UI can show the warning from the very first frame rather than only
 // after a toggle.
 func (s *SubprocessClient) BypassAtLaunch() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	for _, a := range s.args {
 		if a == "--bypass-permissions" {
 			return true
@@ -492,6 +495,8 @@ func (s *SubprocessClient) BypassAtLaunch() bool {
 // the UI's "claude" chip is driven by what actually reached the child's argv
 // rather than by a second bool that could disagree with it.
 func (s *SubprocessClient) ClaudeAtLaunch() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	for _, a := range s.args {
 		if a == UseClaudeFlag {
 			return true
@@ -510,6 +515,8 @@ func (s *SubprocessClient) ClaudeAtLaunch() bool {
 // is authoritative, but it is not read until the first turn (see
 // gaia_agent.stdio.main), which on a session that opens and waits is never.
 func (s *SubprocessClient) ClaudeModelAtLaunch() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	for i, a := range s.args {
 		if a == ClaudeModelFlag && i+1 < len(s.args) {
 			return s.args[i+1]
@@ -598,4 +605,46 @@ func truncateLine(s string) string {
 		return s
 	}
 	return s[:limit] + "…"
+}
+
+// ModelAtLaunch reports the Lemonade model in the child's launch arguments.
+func (s *SubprocessClient) ModelAtLaunch() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, a := range s.args {
+		if a == "--model" && i+1 < len(s.args) {
+			return s.args[i+1]
+		}
+	}
+	return ""
+}
+
+// SetModelBeforeStart changes a canonical agent's pending launch after an
+// explicit catalog selection. Once a child is running, /model must perform the
+// switch inside that conversation instead. Credentials never enter argv.
+func (s *SubprocessClient) SetModelBeforeStart(model string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.canonical || s.started || strings.TrimSpace(model) == "" {
+		return false
+	}
+	args := make([]string, 0, len(s.args)+2)
+	for i := 0; i < len(s.args); i++ {
+		arg := s.args[i]
+		switch {
+		case arg == UseClaudeFlag, strings.HasPrefix(arg, UseClaudeFlag+"="):
+			continue
+		case arg == "--model", arg == ClaudeModelFlag:
+			if i+1 < len(s.args) && !strings.HasPrefix(s.args[i+1], "--") {
+				i++
+			}
+			continue
+		case strings.HasPrefix(arg, "--model="), strings.HasPrefix(arg, ClaudeModelFlag+"="):
+			continue
+		default:
+			args = append(args, arg)
+		}
+	}
+	s.args = append(args, "--model", model)
+	return true
 }

--- a/tui/internal/client/subprocess_provider_test.go
+++ b/tui/internal/client/subprocess_provider_test.go
@@ -1,0 +1,178 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestSetModelBeforeStartReplacesOnlyInferenceFlags(t *testing.T) {
+	for _, args := range [][]string{
+		{"--json-events", "--dev", "--use-claude", "--claude-model", "claude-sonnet-5", "--bypass-permissions", "--model", "old-model"},
+		{"--json-events", "--dev", "--use-claude=true", "--claude-model=claude-sonnet-5", "--bypass-permissions", "--model=old-model"},
+	} {
+		original := append([]string(nil), args...)
+		c := NewCanonicalSubprocessClient("unused", args, true)
+		if !c.SetModelBeforeStart("fireworks.gemma-4-31b-it") {
+			t.Fatal("catalog selection was refused before startup")
+		}
+		want := []string{"--json-events", "--dev", "--bypass-permissions", "--model", "fireworks.gemma-4-31b-it"}
+		if !reflect.DeepEqual(c.args, want) || !reflect.DeepEqual(args, original) {
+			t.Fatalf("inference flags or caller's arguments were changed incorrectly: %v", c.args)
+		}
+		if c.ClaudeAtLaunch() || c.ClaudeModelAtLaunch() != "" || !c.BypassAtLaunch() || c.ModelAtLaunch() != "fireworks.gemma-4-31b-it" {
+			t.Fatal("launch getters disagree with the selected provider")
+		}
+		if !c.SetModelBeforeStart("amd.gpt-4.1") || c.ModelAtLaunch() != "amd.gpt-4.1" {
+			t.Fatal("second selection retained a stale launch model")
+		}
+	}
+}
+
+func TestSetModelBeforeStartRefusesRunningLegacyAndEmptySelections(t *testing.T) {
+	for _, tc := range []struct {
+		name, model        string
+		canonical, started bool
+	}{
+		{"running conversation", "amd.gpt-4.1", true, true},
+		{"legacy agent", "amd.gpt-4.1", false, false},
+		{"empty selection", "  ", true, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := NewSubprocessClient("unused", []string{"--model", "existing"}, false)
+			c.canonical, c.started = tc.canonical, tc.started
+			if c.SetModelBeforeStart(tc.model) || c.ModelAtLaunch() != "existing" {
+				t.Fatal("unsupported switch changed the launch arguments")
+			}
+		})
+	}
+}
+
+func TestLaunchModelSettersAndGettersAreSafeTogether(t *testing.T) {
+	c := NewCanonicalSubprocessClient("unused", []string{"--use-claude", "--claude-model", "claude-sonnet-5", "--bypass-permissions"}, false)
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				c.SetModelBeforeStart("fireworks.gemma-4-31b-it")
+				c.ModelAtLaunch()
+				c.ClaudeAtLaunch()
+				c.ClaudeModelAtLaunch()
+				c.BypassAtLaunch()
+			}
+		}()
+	}
+	wg.Wait()
+	if c.ModelAtLaunch() != "fireworks.gemma-4-31b-it" || c.ClaudeAtLaunch() {
+		t.Fatal("concurrent access left stale model flags")
+	}
+}
+
+func isolateSubprocessConnection(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("GAIA_HOME", dir)
+	t.Setenv("LEMONADE_BASE_URL", "")
+	t.Setenv("LEMONADE_API_KEY", "")
+	return dir
+}
+
+func replaceSubprocessPorts(t *testing.T, serverURL string) {
+	t.Helper()
+	u, err := url.Parse(serverURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := subprocessLemonadePorts
+	subprocessLemonadePorts = []string{u.Port()}
+	t.Cleanup(func() { subprocessLemonadePorts = old })
+}
+
+func TestPendingCloudSelectionLaunchesAgainstEmbeddedEndpoint(t *testing.T) {
+	dir := isolateSubprocessConnection(t)
+	private := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("recorded private endpoint needs no rediscovery during spawn")
+	}))
+	defer private.Close()
+	other := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("unrelated fixed-port server must not override embedded routing")
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer other.Close()
+	replaceSubprocessPorts(t, other.URL)
+	u, _ := url.Parse(private.URL)
+	port, _ := strconv.Atoi(u.Port())
+	dir = filepath.Join(dir, "lemonade")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	body, _ := json.Marshal(map[string]any{"port": port, "api_key": "embedded-private-key"})
+	if err := os.WriteFile(filepath.Join(dir, "state.json"), body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	c := NewCanonicalSubprocessClient(buildMockAgent(t), []string{"--json-events", "--use-claude"}, false)
+	if !c.SetModelBeforeStart("fireworks.gemma-4-31b-it") {
+		t.Fatal("could not select cloud before launch")
+	}
+	c.mu.Lock()
+	st, err := c.startLocked()
+	c.mu.Unlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = st.stdin.Close()
+		st.proc.kill()
+		st.proc.reap()
+		c.discard(st.proc)
+		close(st.turnDone)
+	})
+	if !reflect.DeepEqual(st.proc.cmd.Args[1:], []string{"--json-events", "--model", "fireworks.gemma-4-31b-it"}) {
+		t.Fatalf("actual child launch had incorrect model arguments: %v", st.proc.cmd.Args[1:])
+	}
+	var selectedURL string
+	for _, env := range st.proc.cmd.Env {
+		if strings.HasPrefix(env, "LEMONADE_BASE_URL=") {
+			selectedURL = strings.TrimPrefix(env, "LEMONADE_BASE_URL=")
+		}
+	}
+	if selectedURL != "http://localhost:"+u.Port()+"/api/v1" {
+		t.Fatalf("child did not receive the selected embedded endpoint: %q", selectedURL)
+	}
+	if c.SetModelBeforeStart("amd.gpt-4.1") {
+		t.Fatal("already-started child accepted a startup-only change")
+	}
+}
+
+func TestSubprocessLegacyDiscoveryAuthenticatesAndRefusesRedirects(t *testing.T) {
+	isolateSubprocessConnection(t)
+	t.Setenv("LEMONADE_API_KEY", "explicit-router-key")
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("discovery followed a redirect")
+	}))
+	defer target.Close()
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer explicit-router-key" {
+			t.Error("legacy probe omitted explicitly configured authentication")
+		}
+		http.Redirect(w, r, target.URL, http.StatusTemporaryRedirect)
+	}))
+	defer source.Close()
+	replaceSubprocessPorts(t, source.URL)
+	if detectLemonadeURL() != "" {
+		t.Fatal("redirected discovery reported a usable server")
+	}
+}

--- a/tui/internal/control/server.go
+++ b/tui/internal/control/server.go
@@ -52,8 +52,8 @@ type Sender interface {
 type Options struct {
 	// Port to bind. 0 auto-assigns. 4001 is rejected — it is reserved.
 	Port int
-	// Debug mirrors the TUI's --debug flag: every injected key, every state
-	// transition, and every wait resolution is logged to stderr.
+	// Debug records input counts (never contents), state transitions, and waits
+	// to the TUI diagnostic file.
 	Debug bool
 	// Version is reported by /status and written to the discovery file.
 	Version string
@@ -548,7 +548,7 @@ func (s *Server) handleKeys(w http.ResponseWriter, r *http.Request) {
 	if !s.injectable(w) {
 		return
 	}
-	s.debugf("inject: keys %v (delay %dms)", req.Keys, req.DelayMS)
+	s.debugf("inject: keys (%d inputs; content omitted; delay %dms)", len(req.Keys), req.DelayMS)
 	seq, settled := s.send(msgs, time.Duration(req.DelayMS)*time.Millisecond)
 	writeJSON(w, http.StatusOK, map[string]any{
 		"sent":    len(msgs),
@@ -589,7 +589,7 @@ func (s *Server) handleText(w http.ResponseWriter, r *http.Request) {
 	if !s.injectable(w) {
 		return
 	}
-	s.debugf("inject: text %q (%d runes)", req.Text, len(keys))
+	s.debugf("inject: text (%d runes; content omitted)", len(keys))
 	seq, settled := s.send(msgs, time.Duration(req.DelayMS)*time.Millisecond)
 	writeJSON(w, http.StatusOK, map[string]any{
 		"sent_runes": len(keys),

--- a/tui/internal/control/server_test.go
+++ b/tui/internal/control/server_test.go
@@ -1003,3 +1003,31 @@ func TestWaitAcceptsTheBlockerMatcher(t *testing.T) {
 		t.Errorf("status = %d, want 408 (%v)", status, body)
 	}
 }
+
+func TestInputDiagnosticsOmitBothTextAndKeyContents(t *testing.T) {
+	srv, state := newTestServer(t)
+	var lines []string
+	debug := func(format string, args ...any) { lines = append(lines, fmt.Sprintf(format, args...)) }
+	srv.debugf = debug
+	// /text emits a single character per key; test the recorder separately
+	// because a fake test model is allowed to render the injected text.
+	status, _ := request(t, srv, http.MethodPost, "/text", map[string]any{"text": "secret-test"}, srv.Token())
+	if status != http.StatusOK {
+		t.Fatal(status)
+	}
+	status, _ = request(t, srv, http.MethodPost, "/keys", map[string]any{"keys": []string{"s", "e", "c", "r", "e", "t"}}, srv.Token())
+	if status != http.StatusOK {
+		t.Fatal(status)
+	}
+	state.debugf = debug
+	recorder := NewRecorder(newTestModel(), state)
+	recorder.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("secret-test")})
+	for _, line := range lines {
+		if strings.Contains(line, "secret-test") || strings.Contains(line, "[s e c r e t]") {
+			t.Fatal("input content present in diagnostics")
+		}
+	}
+	if !strings.Contains(strings.Join(lines, "\n"), "content omitted") {
+		t.Fatal("diagnostics missing")
+	}
+}

--- a/tui/internal/control/state.go
+++ b/tui/internal/control/state.go
@@ -304,7 +304,7 @@ func (r Recorder) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		r.state.SetSize(m.Width, m.Height)
 	case tea.KeyMsg:
-		r.state.debugf("inject: key %q reached the model", m.String())
+		r.state.debugf("inject: key reached the model (content omitted)")
 	}
 
 	next, cmd := r.inner.Update(msg)

--- a/tui/internal/lemonade/cloud.go
+++ b/tui/internal/lemonade/cloud.go
@@ -1,0 +1,185 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+// Package lemonade configures cloud routing without passing credentials to agents.
+package lemonade
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const FireworksURL = "https://api.fireworks.ai/inference/v1"
+const FireworksModel = "fireworks.gemma-4-31b-it"
+
+type Provider struct {
+	Name       string `json:"name"`
+	BaseURL    string `json:"base_url"`
+	Header     string `json:"auth_header_name"`
+	Prefix     string `json:"auth_header_prefix"`
+	EnvKey     bool   `json:"env_var_set"`
+	RuntimeKey bool   `json:"runtime_key_set"`
+}
+type Model struct {
+	ID            string   `json:"id"`
+	ContextLength int      `json:"context_length"`
+	Recipe        string   `json:"recipe"`
+	Provider      string   `json:"cloud_provider"`
+	Downloaded    bool     `json:"downloaded"`
+	Labels        []string `json:"labels"`
+}
+
+func (m Model) Cloud() bool { return m.Recipe == "cloud" || m.Provider != "" || IsCloudID(m.ID) }
+func IsCloudID(id string) bool {
+	return strings.HasPrefix(id, "fireworks.") || strings.HasPrefix(id, "amd.")
+}
+func Label(provider string) string {
+	switch provider {
+	case "local":
+		return "Local"
+	case "fireworks":
+		return "Fireworks AI"
+	case "amd":
+		return "AMD LLM Gateway"
+	}
+	return provider
+}
+
+type Client struct {
+	BaseURL string
+	HTTP    *http.Client
+}
+
+func New(base string) *Client {
+	return &Client{ResolveBaseURL(base), &http.Client{Timeout: 45 * time.Second, CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}}
+}
+func validateURL(raw string, loopback bool) error {
+	u, err := url.Parse(raw)
+	if err != nil || u.Hostname() == "" || u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+		return fmt.Errorf("Enter a base URL without credentials, query parameters, or fragments")
+	}
+	ip := net.ParseIP(u.Hostname())
+	local := u.Hostname() == "localhost" || (ip != nil && ip.IsLoopback())
+	if (u.Scheme != "https" && !(loopback && u.Scheme == "http" && local)) || (loopback && !local) {
+		return fmt.Errorf("Use HTTPS for gateways; provider setup requires a loopback Lemonade server")
+	}
+	return nil
+}
+func (c *Client) request(ctx context.Context, method, path string, data any, result any) error {
+	// Configuration changes are local administrative operations. Never send a
+	// pasted key to an arbitrary remote Lemonade address or follow a redirect.
+	if err := validateURL(c.BaseURL, true); err != nil {
+		return err
+	}
+	var body io.Reader
+	if data != nil {
+		b, err := json.Marshal(data)
+		if err != nil {
+			return fmt.Errorf("Could not encode provider settings")
+		}
+		body = bytes.NewReader(b)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.BaseURL+path, body)
+	if err != nil {
+		return fmt.Errorf("Invalid Lemonade address")
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if key := APIKeyFor(c.BaseURL); key != "" {
+		req.Header.Set("Authorization", "Bearer "+key)
+	}
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return fmt.Errorf("Lemonade did not respond. Start it, check its address, and retry")
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		switch resp.StatusCode {
+		case 401, 403:
+			return fmt.Errorf("Authentication was rejected. Check the Lemonade or provider credential and retry")
+		case 404:
+			return fmt.Errorf("Cloud setup is unavailable. Update Lemonade to 11.8.1 or later and retry")
+		case 409:
+			return fmt.Errorf("Lemonade has an environment key for this provider. It takes precedence; the pasted key was not saved. Leave the key blank to use it")
+		default:
+			return fmt.Errorf("Lemonade rejected the operation (HTTP %d). Check provider settings and retry", resp.StatusCode)
+		}
+	}
+	if result != nil && json.NewDecoder(io.LimitReader(resp.Body, 4<<20)).Decode(result) != nil {
+		return fmt.Errorf("Lemonade returned an invalid response")
+	}
+	return nil
+}
+func (c *Client) Providers(ctx context.Context) ([]Provider, error) {
+	var reply struct {
+		Cloud struct {
+			Providers []Provider `json:"providers"`
+		} `json:"cloud"`
+	}
+	err := c.request(ctx, "GET", "/system-info", nil, &reply)
+	return reply.Cloud.Providers, err
+}
+func (c *Client) Models(ctx context.Context, provider string) ([]Model, error) {
+	var reply struct {
+		Data []Model `json:"data"`
+	}
+	if err := c.request(ctx, "GET", "/models?show_all=true", nil, &reply); err != nil {
+		return nil, err
+	}
+	var out []Model
+	for _, m := range reply.Data {
+		chat := true
+		for _, label := range m.Labels {
+			switch label {
+			case "embeddings", "image", "reranker", "audio", "tts", "stt":
+				chat = false
+			}
+		}
+		if !chat || m.ID == "" {
+			continue
+		}
+		if provider == "local" {
+			if !m.Cloud() && m.Downloaded {
+				out = append(out, m)
+			}
+		} else if m.Cloud() && strings.HasPrefix(m.ID, provider+".") {
+			out = append(out, m)
+		}
+	}
+	return out, nil
+}
+func (c *Client) Configure(ctx context.Context, p Provider, key string) error {
+	if p.Name != "fireworks" && p.Name != "amd" {
+		return fmt.Errorf("Unknown provider")
+	}
+	if p.Name == "fireworks" && p.BaseURL != FireworksURL {
+		return fmt.Errorf("Fireworks must use its official API endpoint")
+	}
+	if err := validateURL(p.BaseURL, false); err != nil {
+		return err
+	}
+	if strings.TrimSpace(p.Header) == "" || strings.ContainsAny(p.Header+p.Prefix, "\r\n") {
+		return fmt.Errorf("Enter a valid authentication header and prefix")
+	}
+	data := map[string]any{"backend": "cloud", "provider": p.Name, "base_url": p.BaseURL, "auth_header_name": p.Header, "auth_header_prefix": p.Prefix, "wire_format": "openai"}
+	if err := c.request(ctx, "POST", "/install", data, nil); err != nil {
+		return err
+	}
+	if key != "" {
+		return c.request(ctx, "POST", "/cloud/auth", map[string]string{"provider": p.Name, "api_key": key}, nil)
+	}
+	return nil
+}
+func (c *Client) Clear(ctx context.Context, provider string) error {
+	if provider != "fireworks" && provider != "amd" {
+		return fmt.Errorf("Unknown provider")
+	}
+	return c.request(ctx, "DELETE", "/cloud/auth/"+provider, nil, nil)
+}

--- a/tui/internal/lemonade/cloud_test.go
+++ b/tui/internal/lemonade/cloud_test.go
@@ -1,0 +1,139 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+package lemonade
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestConfigureKeepsKeyOutOfInstallAndDiscoversModels(t *testing.T) {
+	var calls []string
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/v1")
+		calls = append(calls, path)
+		if r.Header.Get("Authorization") != "Bearer local-key" {
+			t.Error("missing Lemonade authorization")
+		}
+		var body map[string]any
+		if r.Method == "POST" {
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatal(err)
+			}
+		}
+		switch path {
+		case "/install":
+			if body["api_key"] != nil || body["backend"] != "cloud" || body["base_url"] != FireworksURL {
+				t.Errorf("incorrect install body: %v", body)
+			}
+			fmt.Fprint(w, `{}`)
+		case "/cloud/auth":
+			if body["api_key"] != "secret-test" || body["provider"] != "fireworks" {
+				t.Error("incorrect credential handoff")
+			}
+			fmt.Fprint(w, `{}`)
+		case "/models":
+			fmt.Fprint(w, `{"data":[{"id":"fireworks.gemma-4-31b-it","recipe":"cloud","downloaded":false},{"id":"local","downloaded":true},{"id":"fireworks.embed","recipe":"cloud","labels":["embeddings"]}]}`)
+		}
+	}))
+	defer s.Close()
+	t.Setenv("LEMONADE_API_KEY", "local-key")
+	c := New(s.URL + "/v1")
+	if err := c.Configure(context.Background(), Provider{Name: "fireworks", BaseURL: FireworksURL, Header: "Authorization", Prefix: "Bearer "}, "secret-test"); err != nil {
+		t.Fatal(err)
+	}
+	models, err := c.Models(context.Background(), "fireworks")
+	if err != nil || len(models) != 1 || models[0].ID != FireworksModel {
+		t.Fatalf("models=%v err=%v", models, err)
+	}
+	if strings.Join(calls, ",") != "/install,/cloud/auth,/models" {
+		t.Fatal(calls)
+	}
+}
+func TestErrorsNeverReflectProviderBodyOrFollowRedirects(t *testing.T) {
+	for _, status := range []int{301, 400, 401, 403, 404, 409, 500} {
+		t.Run(fmt.Sprint(status), func(t *testing.T) {
+			s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Location", "https://example.com/key")
+				w.WriteHeader(status)
+				fmt.Fprint(w, "secret-reflected-value")
+			}))
+			defer s.Close()
+			err := New(s.URL).Clear(context.Background(), "fireworks")
+			if err == nil || strings.Contains(err.Error(), "secret-reflected-value") {
+				t.Fatalf("unsafe error %v", err)
+			}
+		})
+	}
+}
+func TestProviderURLValidation(t *testing.T) {
+	for _, u := range []string{"http://gateway.example/v1", "http://localhost/v1", "https://user:secret@example.com/v1", "https://example.com/v1?key=secret", "file:///tmp/key"} {
+		if validateURL(u, false) == nil {
+			t.Errorf("accepted %s", u)
+		}
+	}
+	if validateURL("https://gateway.example/v1", false) != nil {
+		t.Fatal("HTTPS gateway rejected")
+	}
+	if validateURL("https://gateway.example/v1", true) == nil {
+		t.Fatal("remote administration accepted")
+	}
+}
+func TestLocalCatalogExcludesCloudAndNonChat(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"data":[{"id":"Gemma-4","downloaded":true},{"id":"fireworks.gemma","downloaded":true},{"id":"qwen","downloaded":false},{"id":"embed","downloaded":true,"labels":["embeddings"]}]}`)
+	}))
+	defer s.Close()
+	models, err := New(s.URL).Models(context.Background(), "local")
+	if err != nil || len(models) != 1 || models[0].ID != "Gemma-4" {
+		t.Fatalf("%v %v", models, err)
+	}
+}
+
+func TestAMDGatewayCustomHeaderAndRuntimeKey(t *testing.T) {
+	var installed, authenticated, cleared bool
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if r.Method == http.MethodPost {
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Error(err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+		}
+		switch r.URL.Path {
+		case "/api/v1/install":
+			installed = body["provider"] == "amd" && body["base_url"] == "https://gateway.example/v1" && body["auth_header_name"] == "api-key" && body["auth_header_prefix"] == "" && body["wire_format"] == "openai" && body["api_key"] == nil
+		case "/api/v1/cloud/auth":
+			authenticated = body["provider"] == "amd" && body["api_key"] == "test-key"
+		case "/api/v1/models":
+			fmt.Fprint(w, `{"data":[{"id":"amd.gemma","recipe":"cloud","cloud_provider":"amd"},{"id":"fireworks.gemma","recipe":"cloud","cloud_provider":"fireworks"}]}`)
+			return
+		case "/api/v1/cloud/auth/amd":
+			cleared = r.Method == http.MethodDelete
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		fmt.Fprint(w, `{}`)
+	}))
+	defer s.Close()
+	c := New(s.URL)
+	if err := c.Configure(context.Background(), Provider{Name: "amd", BaseURL: "https://gateway.example/v1", Header: "api-key"}, "test-key"); err != nil {
+		t.Fatal(err)
+	}
+	models, err := c.Models(context.Background(), "amd")
+	if err != nil || len(models) != 1 || models[0].ID != "amd.gemma" {
+		t.Fatalf("AMD discovery failed: %v", err)
+	}
+	if err := c.Clear(context.Background(), "amd"); err != nil {
+		t.Fatal(err)
+	}
+	if !installed || !authenticated || !cleared {
+		t.Fatal("gateway configuration or key lifecycle failed")
+	}
+}

--- a/tui/internal/lemonade/connection.go
+++ b/tui/internal/lemonade/connection.go
@@ -1,0 +1,98 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package lemonade
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const DefaultBaseURL = "http://localhost:13305/api/v1"
+
+// EmbeddedState records the private Lemonade endpoint, whose port and key are
+// chosen when GAIA starts it. Never include this structure in logs or errors.
+type EmbeddedState struct {
+	Port   int    `json:"port"`
+	APIKey string `json:"api_key"`
+}
+
+// ReadEmbedded uses the same state directory as Python's EmbeddedLemonade.
+// An explicit GAIA_HOME isolates the entire runtime: absent or malformed state
+// there must not cause a connection to the user's unrelated default instance.
+func ReadEmbedded() *EmbeddedState {
+	dir := strings.TrimSpace(os.Getenv("GAIA_HOME"))
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil
+		}
+		dir = filepath.Join(home, ".gaia")
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, "lemonade", "state.json"))
+	if err != nil {
+		return nil
+	}
+	var state EmbeddedState
+	if json.Unmarshal(raw, &state) != nil || state.Port < 1 || state.Port > 65535 {
+		return nil
+	}
+	state.APIKey = strings.TrimSpace(state.APIKey)
+	return &state
+}
+
+// ResolveBaseURL keeps an explicitly selected endpoint, then checks the
+// environment, the private runtime, and finally Lemonade's standard port.
+func ResolveBaseURL(base string) string {
+	if base = strings.TrimSpace(base); base != "" {
+		return normalizeBaseURL(base)
+	}
+	if base = strings.TrimSpace(os.Getenv("LEMONADE_BASE_URL")); base != "" {
+		return normalizeBaseURL(base)
+	}
+	if state := ReadEmbedded(); state != nil {
+		return fmt.Sprintf("http://localhost:%d/api/v1", state.Port)
+	}
+	return DefaultBaseURL
+}
+
+// A bare Lemonade origin means its standard API. Preserve an explicitly
+// configured API path, including reverse proxies serving a different prefix.
+func normalizeBaseURL(base string) string {
+	base = strings.TrimRight(base, "/")
+	u, err := url.Parse(base)
+	if err == nil && u.Hostname() != "" && u.Path == "" {
+		u.Path = "/api/v1"
+		return u.String()
+	}
+	return base
+}
+
+// APIKeyFor scopes automatically discovered credentials to the private
+// endpoint that issued them. A user-supplied environment key is an explicit
+// override and remains available for other configured Lemonade servers.
+func APIKeyFor(base string) string {
+	if key := strings.TrimSpace(os.Getenv("LEMONADE_API_KEY")); key != "" {
+		return key
+	}
+	state := ReadEmbedded()
+	if state == nil || state.APIKey == "" {
+		return ""
+	}
+	u, err := url.Parse(ResolveBaseURL(base))
+	if err != nil || u.Scheme != "http" || u.User != nil || u.RawQuery != "" || u.Fragment != "" || u.Port() != strconv.Itoa(state.Port) {
+		return ""
+	}
+	// lemond binds localhost. Treat its IPv4/IPv6 spellings as the same
+	// endpoint, without extending that trust to arbitrary 127/8 addresses.
+	switch strings.ToLower(u.Hostname()) {
+	case "localhost", "127.0.0.1", "::1":
+		return state.APIKey
+	}
+	return ""
+}

--- a/tui/internal/lemonade/connection_test.go
+++ b/tui/internal/lemonade/connection_test.go
@@ -1,0 +1,150 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package lemonade
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+func isolatedConnection(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("GAIA_HOME", "")
+	t.Setenv("LEMONADE_BASE_URL", "")
+	t.Setenv("LEMONADE_API_KEY", "")
+	return filepath.Join(home, ".gaia")
+}
+
+func writeEmbeddedState(t *testing.T, dir string, port int, key string) {
+	t.Helper()
+	dir = filepath.Join(dir, "lemonade")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	body, err := json.Marshal(EmbeddedState{Port: port, APIKey: key})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "state.json"), body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEmbeddedConnectionHonorsIsolatedRuntimeAndExplicitOverrides(t *testing.T) {
+	defaultDir := isolatedConnection(t)
+	writeEmbeddedState(t, defaultDir, 63207, "default-instance-key")
+	if ResolveBaseURL("") != "http://localhost:63207/api/v1" || APIKeyFor("") != "default-instance-key" {
+		t.Fatal("default embedded connection was not resolved")
+	}
+	dir := t.TempDir()
+	t.Setenv("GAIA_HOME", dir)
+	if ReadEmbedded() != nil || ResolveBaseURL("") != DefaultBaseURL || APIKeyFor("") != "" {
+		t.Fatal("empty isolated runtime reused the user's unrelated instance")
+	}
+	writeEmbeddedState(t, dir, 63208, "isolated-instance-key")
+	if ResolveBaseURL("") != "http://localhost:63208/api/v1" || APIKeyFor("") != "isolated-instance-key" {
+		t.Fatal("GAIA_HOME was not used for the connection")
+	}
+	t.Setenv("LEMONADE_BASE_URL", "https://router.example/api/v1/")
+	if ResolveBaseURL("") != "https://router.example/api/v1" || APIKeyFor("") != "" {
+		t.Fatal("explicit server did not win, or inherited the embedded key")
+	}
+	t.Setenv("LEMONADE_API_KEY", " explicit-key ")
+	if APIKeyFor("") != "explicit-key" {
+		t.Fatal("explicit credential did not win")
+	}
+	if ResolveBaseURL("http://localhost:62300/api/v1/") != "http://localhost:62300/api/v1" {
+		t.Fatal("the agent's selected server was replaced by environment discovery")
+	}
+}
+
+func TestEmbeddedCredentialOnlyBelongsToRecordedEndpoint(t *testing.T) {
+	dir := isolatedConnection(t)
+	writeEmbeddedState(t, dir, 63207, "private-router-key")
+	for _, base := range []string{
+		"http://localhost:63207/api/v1", "http://127.0.0.1:63207/api/v1", "http://[::1]:63207/api/v1",
+	} {
+		if APIKeyFor(base) != "private-router-key" {
+			t.Errorf("matching endpoint %q did not receive its key", base)
+		}
+	}
+	for _, base := range []string{
+		"http://localhost:13305/api/v1", "http://127.0.0.2:63207/api/v1",
+		"https://localhost:63207/api/v1", "https://router.example:63207/api/v1",
+		"http://localhost.attacker.example:63207/api/v1", "http://user@localhost:63207/api/v1",
+		"http://localhost:63207/api/v1?key=anything", "http://localhost:63207/api/v1#other",
+		"://invalid",
+	} {
+		if APIKeyFor(base) != "" {
+			t.Errorf("unrelated endpoint %q received the embedded key", base)
+		}
+	}
+}
+
+func TestLemonadeOriginsNormalizeWithoutChangingExplicitAPIPaths(t *testing.T) {
+	isolatedConnection(t)
+	for _, tc := range []struct{ input, want string }{
+		{"http://localhost:13305", DefaultBaseURL},
+		{"http://localhost:13305/", DefaultBaseURL},
+		{"https://router.example", "https://router.example/api/v1"},
+		{"http://localhost:13305/api/v1/", DefaultBaseURL},
+		{"http://localhost:13305/v1/", "http://localhost:13305/v1"},
+		{"https://router.example/lemonade/api/v1", "https://router.example/lemonade/api/v1"},
+	} {
+		t.Run(tc.input, func(t *testing.T) {
+			t.Setenv("LEMONADE_BASE_URL", tc.input)
+			if ResolveBaseURL("") != tc.want || New("").BaseURL != tc.want || New(tc.input).BaseURL != tc.want {
+				t.Fatalf("client and shared resolver disagree for %q", tc.input)
+			}
+		})
+	}
+}
+
+func TestInvalidEmbeddedStateDoesNotInventConnection(t *testing.T) {
+	dir := isolatedConnection(t)
+	for _, port := range []int{0, -1, 65536} {
+		writeEmbeddedState(t, dir, port, "private-router-key")
+		if ReadEmbedded() != nil || ResolveBaseURL("") != DefaultBaseURL || APIKeyFor("") != "" {
+			t.Fatalf("invalid port %d supplied a connection", port)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "lemonade", "state.json"), []byte("{invalid"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if ReadEmbedded() != nil {
+		t.Fatal("malformed embedded state was accepted")
+	}
+}
+
+func TestCloudProviderClientUsesEmbeddedConnectionWithoutExportedCredentials(t *testing.T) {
+	isolatedConnection(t)
+	dir := t.TempDir()
+	t.Setenv("GAIA_HOME", dir)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/system-info" || r.Header.Get("Authorization") != "Bearer isolated-router-key" {
+			t.Error("provider client did not use embedded URL and credential")
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_, _ = w.Write([]byte(`{"cloud":{"providers":[{"name":"fireworks","runtime_key_set":true}]}}`))
+	}))
+	defer server.Close()
+	u, _ := url.Parse(server.URL)
+	port, _ := strconv.Atoi(u.Port())
+	writeEmbeddedState(t, dir, port, "isolated-router-key")
+	providers, err := New("").Providers(context.Background())
+	if err != nil || len(providers) != 1 || providers[0].Name != "fireworks" {
+		t.Fatalf("embedded provider discovery failed: %v", err)
+	}
+}

--- a/tui/internal/ui/chat/canonical.go
+++ b/tui/internal/ui/chat/canonical.go
@@ -69,7 +69,7 @@ func (m ChatModel) handleCanonicalEvent(evt interface{}) (ChatModel, tea.Cmd, bo
 			}
 			// Keep the legacy flag in sync — renderClaudeChip is still the
 			// pre-first-event fallback (see renderModelChip).
-			m.claudeMode = e.ModelRemote
+			m.claudeMode = e.ModelBackend == "claude"
 			break
 		}
 

--- a/tui/internal/ui/chat/claude.go
+++ b/tui/internal/ui/chat/claude.go
@@ -4,9 +4,12 @@
 package chat
 
 import (
+	"strings"
+
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/amd/gaia/tui/internal/client"
+	"github.com/amd/gaia/tui/internal/lemonade"
 	"github.com/amd/gaia/tui/internal/ui/theme"
 )
 
@@ -25,6 +28,16 @@ var claudeChipStyle = lipgloss.NewStyle().
 // the transport so the chip is driven by what was actually passed to the
 // child, never by a second copy that could disagree with it.
 func (m ChatModel) applyLaunchClaude() ChatModel {
+	if c, ok := m.client.(interface{ ModelAtLaunch() string }); ok && c.ModelAtLaunch() != "" {
+		m.modelID = c.ModelAtLaunch()
+		m.modelDisplay = m.modelID
+		m.modelBackend = "lemonade"
+		if lemonade.IsCloudID(m.modelID) {
+			m.modelBackend = strings.SplitN(m.modelID, ".", 2)[0]
+			m.modelRemote = true
+		}
+	}
+
 	type launchClaude interface{ ClaudeAtLaunch() bool }
 	c, ok := m.client.(launchClaude)
 	if !ok || !c.ClaudeAtLaunch() {
@@ -100,6 +113,9 @@ var modelChipStyle = lipgloss.NewStyle().Foreground(theme.Text)
 func (m ChatModel) renderModelChip() string {
 	if m.modelDisplay == "" {
 		return m.renderClaudeChip()
+	}
+	if m.modelRemote && m.modelBackend != "claude" {
+		return claudeChipStyle.Render(" │ " + lemonade.Label(m.modelBackend) + " · " + strings.TrimPrefix(m.modelDisplay, m.modelBackend+".") + " (remote)")
 	}
 	if m.modelRemote {
 		return claudeChipStyle.Render(" │ " + claudeChipLabel(m.modelID))

--- a/tui/internal/ui/chat/introspect.go
+++ b/tui/internal/ui/chat/introspect.go
@@ -11,9 +11,13 @@ func (m ChatModel) AgentID() string { return m.agentID }
 // ControlSnapshot lets the control API describe a standalone chat session (the
 // `gaia chat --subprocess` entry point, where ChatModel is the root model).
 func (m ChatModel) ControlSnapshot() control.Snapshot {
-	return control.Snapshot{
+	snap := control.Snapshot{
 		View:      "chat",
 		Agent:     m.agentID,
 		Streaming: m.streaming,
 	}
+	if m.providerPanel != nil {
+		snap.Overlay = "provider"
+	}
+	return snap
 }

--- a/tui/internal/ui/chat/model.go
+++ b/tui/internal/ui/chat/model.go
@@ -21,6 +21,7 @@ import (
 	"github.com/amd/gaia/tui/internal/gaiainit"
 	"github.com/amd/gaia/tui/internal/ui/components"
 
+	"github.com/amd/gaia/tui/internal/ui/providers"
 	"github.com/amd/gaia/tui/internal/ui/theme"
 )
 
@@ -126,9 +127,10 @@ var (
 )
 
 type ChatModel struct {
-	messages  []Message
-	activity  []ActivityItem
-	streaming bool
+	providerPanel *providers.Model
+	messages      []Message
+	activity      []ActivityItem
+	streaming     bool
 	// cancelPending is true from the moment Esc/Ctrl+C requests a cancel until
 	// doneMsg confirms the run's channel actually closed. It exists only to
 	// let the doneMsg handler distinguish "this settlement was a cancel" (so
@@ -438,7 +440,7 @@ func (m ChatModel) Init() tea.Cmd {
 		// hold the initial query, if any, until the check -- and the setup
 		// run it may trigger -- resolves (setupCheckResultMsg / setupEvent
 		// handlers call releaseAfterSetupGate to send it then).
-		cmds = append(cmds, checkSetupCmd(m.claudeMode))
+		cmds = append(cmds, checkSetupCmd(m.skipLocalChatSetup()))
 	} else if m.initialQuery != "" {
 		cmds = append(cmds, func() tea.Msg {
 			return sendQueryMsg{query: m.initialQuery}
@@ -575,7 +577,7 @@ func (m ChatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	if len(next.queued) == 0 || next.streaming ||
-		next.setupChecking || next.setupRunning {
+		next.setupChecking || next.setupRunning || next.providerPanel != nil {
 		return next, cmd
 	}
 	// A question or confirmation still on screen owns the conversation; the
@@ -594,6 +596,32 @@ func (m ChatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m ChatModel) update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if m.providerPanel != nil {
+		switch v := msg.(type) {
+		case providers.ClosedMsg:
+			m.providerPanel = nil
+			return m, nil
+		case providers.SelectedMsg:
+			m.providerPanel = nil
+			if c, ok := m.client.(interface{ SetModelBeforeStart(string) bool }); ok && c.SetModelBeforeStart(v.ID) {
+				m.claudeMode = false
+				m.modelRemote = false
+				m = m.applyLaunchClaude()
+			}
+			return m.submit("/model " + v.ID)
+		default:
+			if size, ok := msg.(tea.WindowSizeMsg); ok {
+				m.width = size.Width
+				m.height = size.Height
+				m.resize()
+			}
+			updated, cmd := m.providerPanel.Update(msg)
+			panel := updated.(providers.Model)
+			m.providerPanel = &panel
+			return m, cmd
+		}
+	}
+
 	var cmds []tea.Cmd
 
 	switch msg := msg.(type) {
@@ -1287,6 +1315,16 @@ func (m ChatModel) submit(query string) (tea.Model, tea.Cmd) {
 	}
 
 	switch query {
+	case "/provider":
+		if !m.supportsModelCommand() {
+			m.messages = append(m.messages, Message{Role: RoleError, Content: "Provider setup is available for the GAIA flagship agent."})
+			m.updateViewport()
+			return m, nil
+		}
+		panel := providers.New(m.lemonadeBaseURL, m.width, m.height)
+		m.providerPanel = &panel
+		m.palette.open = false
+		return m, panel.Init()
 	case "/help":
 		return m, func() tea.Msg { return ToggleHelpMsg{} }
 
@@ -2597,6 +2635,9 @@ func (m ChatModel) contentHeaderRows() int {
 }
 
 func (m ChatModel) View() string {
+	if m.providerPanel != nil {
+		return m.providerPanel.View()
+	}
 	if m.width == 0 {
 		return m.renderWelcome()
 	}

--- a/tui/internal/ui/chat/palette.go
+++ b/tui/internal/ui/chat/palette.go
@@ -36,6 +36,7 @@ var paletteCommands = []paletteCommand{
 	{"/bypass", "Run every tool without asking first — shows a warning before it turns on"},
 	{"/setup", "Run first-time setup (gaia flagship agent only)"},
 	{"/model", "Switch the model this session runs on (gaia flagship agent only)"},
+	{"/provider", "Choose Local, Fireworks AI, or AMD LLM Gateway; configure a key"},
 }
 
 // modelPalettePrefix is what turns the palette into the model picker: the

--- a/tui/internal/ui/chat/providers_test.go
+++ b/tui/internal/ui/chat/providers_test.go
@@ -1,0 +1,77 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+package chat
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/amd/gaia/tui/internal/client"
+	"github.com/amd/gaia/tui/internal/event"
+	"github.com/amd/gaia/tui/internal/ui/providers"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestProviderPanelNeverSendsCredentialAsChat(t *testing.T) {
+	c := &queryCapturingClient{}
+	m := NewChatModelForFlagship(c, "gaia", "GAIA", true, true)
+	m.width = 80
+	m.height = 24
+	updated, _ := m.submit("/provider")
+	m = updated.(ChatModel)
+	for _, key := range []tea.KeyMsg{{Type: tea.KeyDown}, {Type: tea.KeyEnter}, {Type: tea.KeyRunes, Runes: []rune("sensitive-test-value"), Paste: true}} {
+		updated, _ = m.Update(key)
+		m = updated.(ChatModel)
+	}
+	if len(c.sent) != 0 || strings.Contains(m.View(), "sensitive-test-value") {
+		t.Fatal("credential escaped provider input")
+	}
+	if m.ControlSnapshot().Overlay != "provider" {
+		t.Fatal("control API cannot identify provider panel")
+	}
+	updated, _ = m.Update(providers.ClosedMsg{})
+	m = updated.(ChatModel)
+	if m.providerPanel != nil {
+		t.Fatal("panel did not close")
+	}
+}
+func TestCloudHeaderDoesNotCallFireworksClaude(t *testing.T) {
+	m, _ := newTestModel(t)
+	m = feed(t, m, event.CanonicalStatusEvent{Type: "status", ModelID: "fireworks.gemma-4-31b-it", ModelDisplay: "Gemma 4 31B IT", ModelBackend: "fireworks", ModelRemote: true})
+	if m.claudeMode || strings.Contains(m.renderHeader(), "claude") || !strings.Contains(m.renderHeader(), "Fireworks AI") {
+		t.Fatal("cloud provider mislabeled")
+	}
+	if !m.skipLocalChatSetup() {
+		t.Fatal("cloud setup would download local chat")
+	}
+	m = feed(t, m, event.CanonicalStatusEvent{Type: "status", ModelID: "Gemma-4-E4B-it-GGUF", ModelDisplay: "Gemma", ModelBackend: "lemonade"})
+	if m.skipLocalChatSetup() {
+		t.Fatal("local setup must restore local chat requirement")
+	}
+}
+
+type cloudLaunchClient struct{ nullClient }
+
+func (*cloudLaunchClient) ModelAtLaunch() string { return "fireworks.gemma-4-31b-it" }
+func TestCloudLaunchHasProviderBeforeFirstAgentEvent(t *testing.T) {
+	m := NewChatModelForFlagship(&cloudLaunchClient{}, "gaia", "GAIA", true, true)
+	if !m.skipLocalChatSetup() || !m.modelRemote || m.modelBackend != "fireworks" {
+		t.Fatal("cloud launch lost before first turn")
+	}
+	if !strings.Contains(m.renderHeader(), "Fireworks AI") {
+		t.Fatal("initial header missing provider")
+	}
+}
+
+func TestProviderSelectionSetsUnstartedChildModel(t *testing.T) {
+	c := client.NewCanonicalSubprocessClient("unused", []string{"--use-claude", "--dev"}, true)
+	m := NewChatModelForFlagship(c, "gaia", "GAIA", true, true)
+	m.width, m.height = 80, 24
+	updated, _ := m.submit("/provider")
+	m = updated.(ChatModel)
+	updated, _ = m.Update(providers.SelectedMsg{ID: "fireworks.gemma-4-31b-it"})
+	m = updated.(ChatModel)
+	if c.ModelAtLaunch() != "fireworks.gemma-4-31b-it" || c.ClaudeAtLaunch() || m.claudeMode || !m.modelRemote || !m.skipLocalChatSetup() {
+		t.Fatal("first provider selection would start the wrong backend")
+	}
+}

--- a/tui/internal/ui/chat/setup.go
+++ b/tui/internal/ui/chat/setup.go
@@ -11,6 +11,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/amd/gaia/tui/internal/gaiainit"
+	"github.com/amd/gaia/tui/internal/lemonade"
 )
 
 // First-boot setup for a chat opened WITHOUT the readiness gate in front of it.
@@ -144,7 +145,7 @@ func (m ChatModel) handleSetupCheckResult(msg setupCheckResultMsg) (tea.Model, t
 			Content: fmt.Sprintf(
 				"Could not check whether %s is set up: %v\nType /setup to try running it directly, "+
 					"or run `%s` in a terminal.",
-				m.agentName, msg.err, gaiainit.RunCommand(m.claudeMode)),
+				m.agentName, msg.err, gaiainit.RunCommand(m.skipLocalChatSetup())),
 		})
 		m.updateViewport()
 		return m, m.releaseAfterSetupGate()
@@ -161,14 +162,18 @@ func (m ChatModel) handleSetupCheckResult(msg setupCheckResultMsg) (tea.Model, t
 // profile. firstBoot only changes the announcement's wording -- the
 // first-boot trigger and /setup share every other line of code, so a user
 // who reconfigures later gets exactly what a fresh machine gets.
+func (m ChatModel) skipLocalChatSetup() bool {
+	return m.claudeMode || m.modelRemote || lemonade.IsCloudID(m.modelID)
+}
+
 func (m ChatModel) startSetupRun(firstBoot bool) (tea.Model, tea.Cmd) {
-	ch, cancel, err := gaiainit.Start(m.claudeMode)
+	ch, cancel, err := gaiainit.Start(m.skipLocalChatSetup())
 	if err != nil {
 		m.messages = append(m.messages, Message{
 			Role: RoleError,
 			Content: fmt.Sprintf(
 				"Could not start setup: %v\nRun `%s` in a terminal instead.",
-				err, gaiainit.RunCommand(m.claudeMode)),
+				err, gaiainit.RunCommand(m.skipLocalChatSetup())),
 		})
 		m.updateViewport()
 		return m, m.releaseAfterSetupGate()
@@ -177,6 +182,9 @@ func (m ChatModel) startSetupRun(firstBoot bool) (tea.Model, tea.Cmd) {
 	intro := "Setting up " + m.agentName + " -- running `gaia init --profile " + gaiainit.Profile + "`"
 	if m.claudeMode {
 		intro += " (skipping the local chat model: this session runs on Claude)"
+	}
+	if m.modelRemote && !m.claudeMode {
+		intro += " (skipping the local chat model: chat runs via " + m.modelBackend + ")"
 	}
 	intro += ". This can take a few minutes on a slow connection. Press Esc to cancel."
 	if firstBoot {
@@ -222,7 +230,7 @@ func (m ChatModel) handleSetupEvent(evt gaiainit.Event) (tea.Model, tea.Cmd) {
 			Role: RoleError,
 			Content: fmt.Sprintf(
 				"Setup failed: %v\nRun `%s` in a terminal to see the full log, then /setup to retry.",
-				evt.Err, gaiainit.RunCommand(m.claudeMode)),
+				evt.Err, gaiainit.RunCommand(m.skipLocalChatSetup())),
 		})
 	default:
 		m.messages = append(m.messages, Message{Role: RoleStatus, Content: "[✓] Setup complete."})

--- a/tui/internal/ui/components/helpoverlay.go
+++ b/tui/internal/ui/components/helpoverlay.go
@@ -198,7 +198,7 @@ const chatHelpText = `  GAIA Chat
   Ctrl+C      Quit
 
   Commands    /help /clear /bypass
-              /setup /memory /model
+              /setup /memory /model /provider
   /           On an empty line, browse commands —
               hover/click or ↑/↓ to pick, Enter or
               click to run, Esc or click out to close

--- a/tui/internal/ui/components/helpoverlay_test.go
+++ b/tui/internal/ui/components/helpoverlay_test.go
@@ -178,11 +178,12 @@ func TestChatHelpNamesEveryChatBinding(t *testing.T) {
 
 	// commandText does the same for submit's local commands.
 	commandText := map[string]string{
-		"/help":   "/help",
-		"/clear":  "/clear",
-		"/memory": "/memory",
-		"/setup":  "/setup",
-		"/bypass": "/bypass",
+		"/provider": "/provider",
+		"/help":     "/help",
+		"/clear":    "/clear",
+		"/memory":   "/memory",
+		"/setup":    "/setup",
+		"/bypass":   "/bypass",
 	}
 	for _, cmd := range chatModelCommands(t) {
 		key := cmd

--- a/tui/internal/ui/preflight/lemonade_key_test.go
+++ b/tui/internal/ui/preflight/lemonade_key_test.go
@@ -1,9 +1,16 @@
 package preflight
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
+	"sync/atomic"
 	"testing"
 )
 
@@ -12,6 +19,8 @@ import (
 // as "Lemonade not running" — while the server was healthy and serving — and
 // then offered a second install that would fight for the same port.
 func TestLemonadeAPIKey(t *testing.T) {
+	t.Setenv("GAIA_HOME", "")
+	t.Setenv("LEMONADE_BASE_URL", "")
 	writeState := func(t *testing.T, key string) {
 		t.Helper()
 		home := t.TempDir()
@@ -71,6 +80,7 @@ func TestLemonadeAPIKey(t *testing.T) {
 // list could never reach it -- this screen called GAIA's own model server
 // "not running" and offered to install a second one.
 func TestReadEmbeddedLemonade(t *testing.T) {
+	t.Setenv("GAIA_HOME", "")
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
@@ -96,10 +106,131 @@ func TestReadEmbeddedLemonade(t *testing.T) {
 }
 
 func TestReadEmbeddedLemonadeAbsent(t *testing.T) {
+	t.Setenv("GAIA_HOME", "")
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	if state := readEmbeddedLemonade(); state != nil {
 		t.Fatalf("got %+v, want nil when no embedded server was ever started", state)
+	}
+}
+
+func writeProbeEmbeddedState(t *testing.T, serverURL string) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("GAIA_HOME", dir)
+	t.Setenv("LEMONADE_BASE_URL", "")
+	t.Setenv("LEMONADE_API_KEY", "")
+	u, err := url.Parse(serverURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir = filepath.Join(dir, "lemonade")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	body, err := json.Marshal(map[string]any{"port": port, "api_key": "embedded-probe-key"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "state.json"), body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPreflightDoesNotReplaceFailingEmbeddedEndpointWithAnotherServer(t *testing.T) {
+	private := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Header.Get("Authorization") != "Bearer embedded-probe-key" {
+			t.Error("private probe did not receive its credential")
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer private.Close()
+	var fallbackCalls atomic.Int32
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		fallbackCalls.Add(1)
+		if req.Header.Get("Authorization") != "" {
+			t.Error("fallback port received another server's credential")
+		}
+		fmt.Fprint(w, `{"data":[]}`)
+	}))
+	defer fallback.Close()
+	writeProbeEmbeddedState(t, private.URL)
+	u, _ := url.Parse(fallback.URL)
+	oldPorts := lemonadePorts
+	lemonadePorts = []string{u.Port()}
+	t.Cleanup(func() { lemonadePorts = oldPorts })
+	base, reachable, _ := probeLemonadeHTTP(context.Background())
+	privateURL, _ := url.Parse(private.URL)
+	if reachable || base != "http://localhost:"+privateURL.Port()+"/api/v1" || fallbackCalls.Load() != 0 {
+		t.Fatalf("unrelated server masked a failing embedded connection: reachable=%v base=%s fallbackCalls=%d", reachable, base, fallbackCalls.Load())
+	}
+	// Once explicitly chosen, the other endpoint is usable, but it must not
+	// inherit the private instance's automatically discovered credential.
+	t.Setenv("LEMONADE_BASE_URL", fallback.URL+"/api/v1")
+	_, reachable, _ = probeLemonadeHTTP(context.Background())
+	if !reachable || fallbackCalls.Load() != 1 {
+		t.Fatal("explicit endpoint did not override embedded discovery")
+	}
+}
+
+func TestStaleEmbeddedEndpointDoesNotPassAgainstHealthyDefaultPort(t *testing.T) {
+	stale := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {}))
+	writeProbeEmbeddedState(t, stale.URL)
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		t.Error("stale embedded state must not trigger a different server probe")
+		fmt.Fprint(w, `{"data":[]}`)
+	}))
+	defer fallback.Close()
+	stale.Close()
+	u, _ := url.Parse(fallback.URL)
+	oldPorts := lemonadePorts
+	lemonadePorts = []string{u.Port()}
+	t.Cleanup(func() { lemonadePorts = oldPorts })
+	if _, reachable, _ := probeLemonadeHTTP(context.Background()); reachable {
+		t.Fatal("stale embedded endpoint was incorrectly reported ready")
+	}
+}
+
+func TestPreflightDoesNotFollowEmbeddedServerRedirect(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		t.Error("redirect target must never receive a probe or credential")
+	}))
+	defer target.Close()
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Header.Get("Authorization") != "Bearer embedded-probe-key" {
+			t.Error("source probe did not receive its credential")
+		}
+		http.Redirect(w, req, target.URL, http.StatusTemporaryRedirect)
+	}))
+	defer source.Close()
+	writeProbeEmbeddedState(t, source.URL)
+	t.Setenv("LEMONADE_BASE_URL", source.URL+"/api/v1")
+	_, reachable, _ := probeLemonadeHTTP(context.Background())
+	if reachable {
+		t.Fatal("redirected server was reported ready")
+	}
+}
+
+func TestPreflightNormalizesExplicitBareLemonadeOrigin(t *testing.T) {
+	t.Setenv("GAIA_HOME", t.TempDir())
+	t.Setenv("LEMONADE_API_KEY", "")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/api/v1/models" {
+			t.Errorf("probe used %q instead of Lemonade's API path", req.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		fmt.Fprint(w, `{"data":[]}`)
+	}))
+	defer server.Close()
+	t.Setenv("LEMONADE_BASE_URL", server.URL)
+	base, ready, _ := probeLemonadeHTTP(context.Background())
+	if !ready || base != server.URL+"/api/v1" {
+		t.Fatal("bare Lemonade origin was not normalized consistently")
 	}
 }

--- a/tui/internal/ui/preflight/local.go
+++ b/tui/internal/ui/preflight/local.go
@@ -3,7 +3,6 @@ package preflight
 import (
 	"bufio"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -15,6 +14,7 @@ import (
 
 	"github.com/amd/gaia/tui/internal/catalog"
 	"github.com/amd/gaia/tui/internal/gaiainit"
+	"github.com/amd/gaia/tui/internal/lemonade"
 	"github.com/amd/gaia/tui/internal/ui/status"
 )
 
@@ -74,6 +74,7 @@ type LocalOptions struct {
 	// asked with --skip-chat-model and a down Lemonade must not refuse the
 	// launch — see checkLemonade.
 	ClaudeMode bool
+	Model      string
 }
 
 // NewLocalRunner builds the runner for an agent the TUI spawns itself.
@@ -90,9 +91,13 @@ func (l localRunner) Rows(cfg Config) []Row {
 	if l.opts.ClaudeMode {
 		rows = append(rows, Row{Key: KeyClaudeCredential, Label: "Claude credential"})
 	}
+	modelLabel := modelRowLabel
+	if l.skipChatModel() {
+		modelLabel = "Embeddings"
+	}
 	rows = append(rows,
 		Row{Key: KeyLemonade, Label: lemonadeRowLabel},
-		Row{Key: KeyModel, Label: modelRowLabel},
+		Row{Key: KeyModel, Label: modelLabel},
 	)
 	for i := range rows {
 		rows[i].State = StatePending
@@ -332,8 +337,7 @@ func (l localRunner) checkLemonade(ctx context.Context, _ Config) Row {
 	row.State = StateFailed
 	row.Disposition = status.DispositionHalt
 	row.Line = "not running"
-	row.Detail = "GAIA needs a local model server. It runs on your machine; no message " +
-		"text ever leaves it."
+	row.Detail = "GAIA needs Lemonade to run local models or route chat to your chosen provider."
 	row.Remedy = lemonadeStartRemedy()
 	// Installing and starting Lemonade is `gaia init`'s job, so this row gets
 	// the same one-key setup the model row does. It cannot run twice: Check
@@ -366,10 +370,7 @@ func (l localRunner) checkLemonade(ctx context.Context, _ Config) Row {
 // smallest call that proves it is actually serving rather than merely bound.
 // embeddedLemonade is what `gaia lemonade embedded` records about the private
 // server it runs: a port chosen at start time, and a generated API key.
-type embeddedLemonade struct {
-	Port   int    `json:"port"`
-	APIKey string `json:"api_key"`
-}
+type embeddedLemonade = lemonade.EmbeddedState
 
 // readEmbeddedLemonade loads that state file, or returns nil.
 //
@@ -380,20 +381,7 @@ type embeddedLemonade struct {
 // this screen report "Lemonade not running" for GAIA's own model server, then
 // offer to install a second one.
 func readEmbeddedLemonade() *embeddedLemonade {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return nil
-	}
-	raw, err := os.ReadFile(filepath.Join(home, ".gaia", "lemonade", "state.json"))
-	if err != nil {
-		return nil
-	}
-	var state embeddedLemonade
-	if err := json.Unmarshal(raw, &state); err != nil {
-		return nil
-	}
-	state.APIKey = strings.TrimSpace(state.APIKey)
-	return &state
+	return lemonade.ReadEmbedded()
 }
 
 // lemonadeAPIKey resolves the credential a local Lemonade may demand.
@@ -401,13 +389,7 @@ func readEmbeddedLemonade() *embeddedLemonade {
 // LEMONADE_API_KEY wins when set, so an explicitly configured credential is
 // never overridden by whatever a local state file happens to hold.
 func lemonadeAPIKey() string {
-	if key := strings.TrimSpace(os.Getenv("LEMONADE_API_KEY")); key != "" {
-		return key
-	}
-	if state := readEmbeddedLemonade(); state != nil {
-		return state.APIKey
-	}
-	return ""
+	return lemonade.APIKeyFor(lemonade.ResolveBaseURL(""))
 }
 
 // It returns the base URL it settled on, whether it answered, and a trace for
@@ -428,18 +410,21 @@ func probeLemonadeHTTP(ctx context.Context) (base string, reachable bool, trace 
 	if override := strings.TrimSpace(os.Getenv(lemonadeBaseURLEnv)); override != "" {
 		// The agent will use exactly this, so it is the only thing worth
 		// probing — a local server on 13305 proves nothing about it.
-		bases = []string{strings.TrimRight(override, "/")}
+		bases = []string{lemonade.ResolveBaseURL(override)}
+	} else if readEmbeddedLemonade() != nil {
+		// The agent resolves this recorded endpoint too. A different server
+		// answering on a standard port cannot make that connection ready.
+		bases = []string{lemonade.ResolveBaseURL("")}
 	} else {
-		// GAIA's own embedded server first: its port is chosen at start time,
-		// so it is never one of the fixed ones below.
-		if state := readEmbeddedLemonade(); state != nil && state.Port > 0 {
-			bases = append(bases, fmt.Sprintf("http://localhost:%d/api/v1", state.Port))
-		}
 		for _, port := range lemonadePorts {
 			bases = append(bases, "http://localhost:"+port+"/api/v1")
 		}
 	}
 
+	// Authentication belongs to the endpoint being probed, not any redirect
+	// target (even a different port on the same hostname).
+	probeClient := *http.DefaultClient
+	probeClient.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
 	var traces []string
 	for _, b := range bases {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, b+"/models", nil)
@@ -447,10 +432,10 @@ func probeLemonadeHTTP(ctx context.Context) (base string, reachable bool, trace 
 			traces = append(traces, fmt.Sprintf("GET %s/models -> %v", b, err))
 			continue
 		}
-		if key := lemonadeAPIKey(); key != "" {
+		if key := lemonade.APIKeyFor(b); key != "" {
 			req.Header.Set("Authorization", "Bearer "+key)
 		}
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := probeClient.Do(req)
 		if err != nil {
 			traces = append(traces, fmt.Sprintf("GET %s/models -> %v", b, err))
 			continue
@@ -471,10 +456,14 @@ func probeLemonadeHTTP(ctx context.Context) (base string, reachable bool, trace 
 
 // --- 3. the models -----------------------------------------------------------
 
+func (l localRunner) skipChatModel() bool {
+	return l.opts.ClaudeMode || lemonade.IsCloudID(l.opts.Model)
+}
+
 func (l localRunner) checkModels(ctx context.Context, _ Config) Row {
 	row := Row{Key: KeyModel}
 
-	ready, err := gaiainit.Check(ctx, l.opts.ClaudeMode)
+	ready, err := gaiainit.Check(ctx, l.skipChatModel())
 	switch {
 	case errors.Is(err, gaiainit.ErrUnanswered):
 		// The question was never answered — an installed gaia older than
@@ -487,7 +476,7 @@ func (l localRunner) checkModels(ctx context.Context, _ Config) Row {
 		row.Detail = err.Error()
 		row.Remedy = Remedy{
 			Action:  "Run setup yourself if anything below behaves oddly.",
-			Command: gaiainit.RunCommand(l.opts.ClaudeMode),
+			Command: gaiainit.RunCommand(l.skipChatModel()),
 			Where:   "https://amd-gaia.ai/docs/guides/install",
 		}
 		row.Raw = err.Error()
@@ -506,6 +495,9 @@ func (l localRunner) checkModels(ctx context.Context, _ Config) Row {
 	case ready:
 		row.State = StateOK
 		row.Line = "downloaded"
+		if lemonade.IsCloudID(l.opts.Model) {
+			row.Line = "embedder downloaded — chat uses " + l.opts.Model
+		}
 		if l.opts.ClaudeMode {
 			row.Line = "embedder downloaded — chat runs on Claude"
 		}
@@ -517,10 +509,14 @@ func (l localRunner) checkModels(ctx context.Context, _ Config) Row {
 	row.Line = "not downloaded yet"
 	row.Detail = "Several GB on a first run. Once downloaded they are reused by every " +
 		"GAIA session."
+	if l.skipChatModel() {
+		row.Line = "embedding models not downloaded"
+		row.Detail = "Chat uses your selected remote provider. Setup downloads local embedding models for document search and memory."
+	}
 	row.Fix = FixRunSetup
 	row.Remedy = Remedy{
 		Action:  "Setup downloads what is missing and starts the local server.",
-		Command: gaiainit.RunCommand(l.opts.ClaudeMode),
+		Command: gaiainit.RunCommand(l.skipChatModel()),
 		Where:   "https://amd-gaia.ai/docs/guides/install",
 	}
 	return row
@@ -533,12 +529,12 @@ func (l localRunner) Fix(ctx context.Context, _ Config, kind FixKind, onLine fun
 		return FixResult{Err: errNoFix}
 	}
 
-	ch, cancel, err := gaiainit.Start(l.opts.ClaudeMode)
+	ch, cancel, err := gaiainit.Start(l.skipChatModel())
 	if err != nil {
 		return FixResult{Err: err, Diagnosis: Diagnosis{
 			Cause:   err.Error(),
 			Remedy:  "Run setup in a terminal instead, then press r to re-check.",
-			Command: gaiainit.RunCommand(l.opts.ClaudeMode),
+			Command: gaiainit.RunCommand(l.skipChatModel()),
 			Where:   "https://amd-gaia.ai/docs/guides/install",
 		}}
 	}
@@ -552,7 +548,7 @@ func (l localRunner) Fix(ctx context.Context, _ Config, kind FixKind, onLine fun
 			return FixResult{Err: ctx.Err(), Final: last, Diagnosis: Diagnosis{
 				Cause:   "Setup was cancelled, or ran past the time limit.",
 				Remedy:  "Run it in a terminal instead, then press r to re-check.",
-				Command: gaiainit.RunCommand(l.opts.ClaudeMode),
+				Command: gaiainit.RunCommand(l.skipChatModel()),
 				Where:   "https://amd-gaia.ai/docs/guides/install",
 			}}
 		case evt, ok := <-ch:
@@ -560,7 +556,7 @@ func (l localRunner) Fix(ctx context.Context, _ Config, kind FixKind, onLine fun
 				return FixResult{Err: errFixFailed, Final: last, Diagnosis: Diagnosis{
 					Cause:   "Setup ended without saying whether it worked.",
 					Remedy:  "Press r to re-check whether the models landed, then retry.",
-					Command: gaiainit.RunCommand(l.opts.ClaudeMode),
+					Command: gaiainit.RunCommand(l.skipChatModel()),
 					Where:   "https://amd-gaia.ai/docs/guides/install",
 				}}
 			}
@@ -575,7 +571,7 @@ func (l localRunner) Fix(ctx context.Context, _ Config, kind FixKind, onLine fun
 				return FixResult{Err: evt.Err, Final: last, Diagnosis: Diagnosis{
 					Cause:   "Setup failed: " + evt.Err.Error(),
 					Remedy:  "Run it in a terminal to see the full log, then press r.",
-					Command: gaiainit.RunCommand(l.opts.ClaudeMode),
+					Command: gaiainit.RunCommand(l.skipChatModel()),
 					Where:   "https://amd-gaia.ai/docs/guides/install",
 				}}
 			}

--- a/tui/internal/ui/preflight/local_test.go
+++ b/tui/internal/ui/preflight/local_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -14,6 +16,50 @@ import (
 	"github.com/amd/gaia/tui/internal/gaiainit"
 	"github.com/amd/gaia/tui/internal/ui/status"
 )
+
+func TestCloudPreflightStillRequiresEmbeddingReadiness(t *testing.T) {
+	for _, model := range []string{"fireworks.gemma-4-31b-it", "amd.gpt-4.1"} {
+		t.Run(model, func(t *testing.T) {
+			r := localRunner{opts: LocalOptions{Model: model}}
+			if !r.skipChatModel() {
+				t.Fatal("cloud setup would download the local chat model")
+			}
+			stubGaiaInit(t, func() (string, error) { return exitStub(t, 1), nil })
+			row := r.checkModels(context.Background(), localCfg())
+			if row.State != StateFailed || row.Fix != FixRunSetup || !strings.Contains(row.Remedy.Command, "--skip-chat-model") {
+				t.Fatalf("missing embedder did not block with cloud-compatible setup: %+v", row)
+			}
+			stubGaiaInit(t, func() (string, error) { return exitStub(t, 0), nil })
+			row = r.checkModels(context.Background(), localCfg())
+			if row.State != StateOK || !strings.Contains(row.Line, "embedder downloaded") || !strings.Contains(row.Line, model) {
+				t.Fatalf("ready cloud state is incorrect: %+v", row)
+			}
+		})
+	}
+	if (localRunner{opts: LocalOptions{Model: "user.embeddinggemma-300m-GGUF"}}).skipChatModel() {
+		t.Fatal("a dotted local id was mistaken for cloud inference")
+	}
+}
+
+func TestCloudPreflightNeedsAuthenticatedLemonadeRouter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Header.Get("Authorization") != "Bearer isolated-router-key" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		fmt.Fprint(w, `{"data":[]}`)
+	}))
+	t.Setenv(lemonadeBaseURLEnv, server.URL)
+	t.Setenv("LEMONADE_API_KEY", "isolated-router-key")
+	r := localRunner{opts: LocalOptions{Model: "fireworks.gemma-4-31b-it"}}
+	if row := r.checkLemonade(context.Background(), localCfg()); row.State != StateOK {
+		t.Fatalf("authenticated router was rejected: %+v", row)
+	}
+	server.Close()
+	if row := r.checkLemonade(context.Background(), localCfg()); row.State != StateFailed {
+		t.Fatalf("cloud chat was allowed without its Lemonade router: %+v", row)
+	}
+}
 
 // isolateHome points the install-root lookup at a temp dir, so a developer box
 // with a real ~/.gaia/agents cannot make a "nothing is installed" test pass or

--- a/tui/internal/ui/preflight/view.go
+++ b/tui/internal/ui/preflight/view.go
@@ -166,6 +166,9 @@ func (m Model) footer(w int) string {
 	if fix := m.focusedFix(); fix != FixNone && !m.Busy() {
 		keys = append(keys, [2]string{"f", fix.Label()})
 	}
+	if m.cfg.AgentID == "gaia" && !m.Busy() {
+		keys = append(keys, [2]string{"p", "AI provider"})
+	}
 	keys = append(keys, [2]string{"r", "re-check"})
 	keys = append(keys, [2]string{"d", "details"})
 	// `enter` is offered whenever pressing it would actually do something:

--- a/tui/internal/ui/providers/model.go
+++ b/tui/internal/ui/providers/model.go
@@ -287,7 +287,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.activity = "Connecting"
 				c := m.client
 				return m, tea.Batch(m.spin.Tick, func() tea.Msg {
-					defer func() { key = "" }()
 					if err := c.Configure(m.ctx, p, key); err != nil {
 						return modelsMsg{source: c, err: err}
 					}

--- a/tui/internal/ui/providers/model.go
+++ b/tui/internal/ui/providers/model.go
@@ -1,0 +1,467 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+// Package providers owns the provider setup screen shared by startup and chat.
+package providers
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/amd/gaia/tui/internal/lemonade"
+	"github.com/amd/gaia/tui/internal/ui/theme"
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+)
+
+type SelectedMsg struct{ ID string }
+type ClosedMsg struct{}
+type loadedMsg struct {
+	source    *lemonade.Client
+	providers []lemonade.Provider
+	err       error
+}
+type modelsMsg struct {
+	source *lemonade.Client
+	models []lemonade.Model
+	err    error
+}
+type clearedMsg struct {
+	source *lemonade.Client
+	err    error
+}
+
+type Model struct {
+	spin          spinner.Model
+	ctx           context.Context
+	cancel        context.CancelFunc
+	search        string
+	client        *lemonade.Client
+	providers     []lemonade.Provider
+	selected      int
+	stage         string
+	fields        []textinput.Model
+	focus         int
+	models        []lemonade.Model
+	busy          bool
+	activity      string
+	note          string
+	width, height int
+}
+
+var names = []string{"local", "fireworks", "amd"}
+
+func New(base string, width, height int) Model {
+	ctx, cancel := context.WithCancel(context.Background())
+	spin := spinner.New()
+	spin.Spinner = spinner.Dot
+	spin.Style = lipgloss.NewStyle().Foreground(theme.AccentBright)
+	return Model{spin: spin, client: lemonade.New(base), ctx: ctx, cancel: cancel, stage: "providers", width: width, height: height}
+}
+func (m Model) Init() tea.Cmd {
+	c := m.client
+	return func() tea.Msg { p, e := c.Providers(m.ctx); return loadedMsg{source: c, providers: p, err: e} }
+}
+func (m Model) chosen() string { return names[m.selected] }
+func (m Model) fetchModels() tea.Cmd {
+	c, p := m.client, m.chosen()
+	return func() tea.Msg { models, e := c.Models(m.ctx, p); return modelsMsg{source: c, models: models, err: e} }
+}
+func (m Model) setup() Model {
+	p := lemonade.Provider{Name: m.chosen(), Header: "Authorization", Prefix: "Bearer "}
+	if p.Name == "fireworks" {
+		p.BaseURL = lemonade.FireworksURL
+	}
+	for _, existing := range m.providers {
+		if existing.Name == p.Name {
+			p = existing
+		}
+	}
+	// The Fireworks destination is fixed even if another client edited it.
+	if p.Name == "fireworks" {
+		p.BaseURL = lemonade.FireworksURL
+		p.Header = "Authorization"
+		p.Prefix = "Bearer "
+	}
+	values := []string{p.BaseURL, p.Header, p.Prefix, ""}
+	m.fields = make([]textinput.Model, 4)
+	for i, value := range values {
+		f := textinput.New()
+		f.SetValue(value)
+		f.CharLimit = 2048
+		f.Prompt = ""
+		m.fields[i] = f
+	}
+	m.fields[3].EchoMode = textinput.EchoPassword
+	m.fields[3].EchoCharacter = '•'
+	m.fields[3].Placeholder = "Paste API key (blank uses existing key)"
+	m.focus = 3
+	if p.Name == "amd" && p.BaseURL == "" {
+		m.focus = 0
+	}
+	m.fields[m.focus].Focus()
+	m.stage = "setup"
+	m.note = ""
+	return m
+}
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if m.ctx.Err() != nil {
+		return m, nil
+	}
+	switch v := msg.(type) {
+	case spinner.TickMsg:
+		if m.busy {
+			var cmd tea.Cmd
+			m.spin, cmd = m.spin.Update(msg)
+			return m, cmd
+		}
+		return m, nil
+	case tea.WindowSizeMsg:
+		m.width = v.Width
+		m.height = v.Height
+		return m, nil
+	case loadedMsg:
+		if v.source != nil && v.source != m.client {
+			return m, nil
+		}
+		m.providers = v.providers
+		if v.err != nil {
+			m.note = v.err.Error()
+		}
+		return m, nil
+	case modelsMsg:
+		if v.source != nil && v.source != m.client {
+			return m, nil
+		}
+		m.busy = false
+		if v.err != nil {
+			m.note = v.err.Error()
+			return m, nil
+		}
+		if len(v.models) == 0 {
+			m.models = nil
+			if m.stage == "models" {
+				if m.chosen() == "local" {
+					m.stage = "providers"
+				} else {
+					m = m.setup()
+				}
+			}
+			m.note = "No chat models discovered. Check the key, model access, and gateway URL; then retry."
+			if m.chosen() == "local" {
+				m.note = "No local chat models downloaded. Close this panel and run setup to download one."
+			}
+			return m, nil
+		}
+		m.models = v.models
+		sort.Slice(m.models, func(i, j int) bool {
+			if m.models[i].ID == lemonade.FireworksModel {
+				return true
+			}
+			if m.models[j].ID == lemonade.FireworksModel {
+				return false
+			}
+			return m.models[i].ID < m.models[j].ID
+		})
+		m.stage = "models"
+		m.search = ""
+		m.focus = 0
+		m.note = ""
+		return m, m.Init()
+	case clearedMsg:
+		if v.source != nil && v.source != m.client {
+			return m, nil
+		}
+		m.busy = false
+		if v.err != nil {
+			m.note = v.err.Error()
+		} else {
+			m.note = "Runtime key cleared. An environment key, if set, remains active."
+		}
+		return m, m.Init()
+	case tea.KeyMsg:
+		if v.String() == "ctrl+c" {
+			m.fields = nil
+			m.stage = "closing"
+			m.cancel()
+			return m, tea.Quit
+		}
+		if m.busy {
+			if v.String() == "esc" {
+				m.cancel()
+				m.stage = "closing"
+				m.fields = nil
+				return m, func() tea.Msg { return ClosedMsg{} }
+			}
+			return m, nil
+		}
+		if v.String() == "esc" {
+			if m.stage == "providers" {
+				m.cancel()
+				return m, func() tea.Msg { return ClosedMsg{} }
+			}
+			m.fields = nil
+			m.stage = "providers"
+			m.note = ""
+			return m, nil
+		}
+		switch m.stage {
+		case "providers":
+			switch v.String() {
+			case "up":
+				m.selected = (m.selected + 2) % 3
+			case "down", "tab":
+				m.selected = (m.selected + 1) % 3
+			case "enter":
+				if m.chosen() == "local" {
+					m.busy = true
+					m.activity = "Loading models"
+					return m, tea.Batch(m.spin.Tick, m.fetchModels())
+				}
+				m = m.setup()
+				return m, textinput.Blink
+			case "r":
+				return m, m.Init()
+			}
+		case "models":
+			models := m.filteredModels()
+			switch v.String() {
+			case "up":
+				m.focus = max(0, m.focus-1)
+			case "down", "tab":
+				m.focus = max(0, min(len(models)-1, m.focus+1))
+			case "enter":
+				if m.focus < 0 || m.focus >= len(models) {
+					return m, nil
+				}
+				id := models[m.focus].ID
+				m.cancel()
+				return m, func() tea.Msg { return SelectedMsg{ID: id} }
+			case "ctrl+r":
+				m.busy = true
+				m.note = ""
+				m.activity = "Refreshing models"
+				return m, tea.Batch(m.spin.Tick, m.fetchModels())
+			case "backspace":
+				r := []rune(m.search)
+				if len(r) > 0 {
+					m.search = string(r[:len(r)-1])
+					m.focus = 0
+				}
+			default:
+				if v.Type == tea.KeyRunes {
+					m.search += string(v.Runes)
+					m.focus = 0
+				}
+			}
+		case "setup":
+			switch v.String() {
+			case "tab", "shift+tab":
+				m.fields[m.focus].Blur()
+				if m.chosen() == "fireworks" {
+					m.focus = 3
+				} else if v.String() == "tab" {
+					m.focus = (m.focus + 1) % 4
+				} else {
+					m.focus = (m.focus + 3) % 4
+				}
+				return m, m.fields[m.focus].Focus()
+			case "ctrl+d":
+				m.fields[3].SetValue("")
+				m.busy = true
+				m.note = ""
+				m.activity = "Clearing key"
+				c, p := m.client, m.chosen()
+				return m, tea.Batch(m.spin.Tick, func() tea.Msg { return clearedMsg{source: c, err: c.Clear(m.ctx, p)} })
+			case "enter":
+				p := lemonade.Provider{Name: m.chosen(), BaseURL: strings.TrimSpace(m.fields[0].Value()), Header: strings.TrimSpace(m.fields[1].Value()), Prefix: m.fields[2].Value()}
+				key := strings.TrimSpace(m.fields[3].Value())
+				m.fields[3].SetValue("")
+				m.busy = true
+				m.note = ""
+				m.activity = "Connecting"
+				c := m.client
+				return m, tea.Batch(m.spin.Tick, func() tea.Msg {
+					defer func() { key = "" }()
+					if err := c.Configure(m.ctx, p, key); err != nil {
+						return modelsMsg{source: c, err: err}
+					}
+					models, err := c.Models(m.ctx, p.Name)
+					return modelsMsg{source: c, models: models, err: err}
+				})
+			}
+			var cmd tea.Cmd
+			m.fields[m.focus], cmd = m.fields[m.focus].Update(msg)
+			return m, cmd
+		}
+	}
+	if m.stage == "setup" {
+		var cmd tea.Cmd
+		m.fields[m.focus], cmd = m.fields[m.focus].Update(msg)
+		return m, cmd
+	}
+	return m, nil
+}
+func (m Model) filteredModels() []lemonade.Model {
+	var out []lemonade.Model
+	for _, model := range m.models {
+		if strings.Contains(strings.ToLower(model.ID), strings.ToLower(m.search)) {
+			out = append(out, model)
+		}
+	}
+	return out
+}
+
+func (m Model) View() string {
+	w := max(1, m.width-4)
+	title := lipgloss.NewStyle().Bold(true).Foreground(theme.AccentBright)
+	lines := []string{title.Render("AI provider"), ""}
+	switch m.stage {
+	case "providers":
+		lines = append(lines, "Choose where GAIA runs chat inference.", "")
+		for i, name := range names {
+			desc := "On this machine · downloaded models"
+			if name != "local" {
+				desc = "Via Lemonade · key needed"
+				for _, p := range m.providers {
+					if p.Name == name && (p.EnvKey || p.RuntimeKey) {
+						desc = "Via Lemonade · key configured"
+					}
+				}
+			}
+			marker := "  "
+			if i == m.selected {
+				marker = "› "
+			}
+			label := marker + lemonade.Label(name)
+			if i == m.selected {
+				label = title.Render(label)
+			}
+			lines = append(lines, label, lipgloss.NewStyle().Foreground(theme.Dim).Render("    "+desc), "")
+		}
+	case "setup":
+		lines = append(lines, title.Render(lemonade.Label(m.chosen())))
+		if m.height < 22 {
+			lines = append(lines, "Remote chat · key kept until restart.")
+			if m.chosen() == "fireworks" {
+				lines = append(lines, "Usage may incur charges.")
+			}
+		} else if m.chosen() == "fireworks" {
+			lines = append(lines, "Chat history is sent to Fireworks AI. Usage may incur charges.", "Suggested model: Gemma 4 31B IT", "Endpoint: "+lemonade.FireworksURL)
+		} else {
+			lines = append(lines, "Chat history is sent to your configured AMD gateway.")
+		}
+		if m.height >= 22 {
+			lines = append(lines, "Keys stay in Lemonade memory until it restarts.", "Provider settings are shared by clients of this Lemonade server.")
+		}
+		lines = append(lines, "")
+		labels := []string{"Gateway URL", "Auth header", "Prefix (include trailing space for Bearer)", "API key"}
+		for i := range m.fields {
+			if m.chosen() == "fireworks" && i < 3 {
+				continue
+			}
+			f := m.fields[i]
+			f.Width = max(10, w-4)
+			marker := "  "
+			if m.focus == i {
+				marker = "› "
+			}
+			lines = append(lines, marker+labels[i], "  "+f.View())
+		}
+	case "models":
+		models := m.filteredModels()
+		lines = append(lines, title.Render(lemonade.Label(m.chosen())+" models"), "Enter selects a model. Existing conversation is preserved.", "Search: "+m.search, "")
+		count := max(1, m.height-14)
+		start := max(0, m.focus-count+1)
+		for i := start; i < min(len(models), start+count); i++ {
+			marker := "  "
+			if i == m.focus {
+				marker = "› "
+			}
+			label := strings.TrimPrefix(models[i].ID, m.chosen()+".")
+			if models[i].ID == lemonade.FireworksModel {
+				label += " · suggested"
+			}
+			if i == m.focus {
+				lines = append(lines, title.Render(marker+label))
+			} else {
+				lines = append(lines, marker+label)
+			}
+		}
+		if len(models) == 0 {
+			lines = append(lines, "No matching models. Backspace to change the search.")
+		} else {
+			lines = append(lines, fmt.Sprintf("%d of %d", m.focus+1, len(models)))
+			selected := models[m.focus]
+			details := []string{}
+			if selected.ContextLength > 0 {
+				details = append(details, fmt.Sprintf("Context: %s tokens", formatTokens(selected.ContextLength)))
+			}
+			for _, label := range selected.Labels {
+				switch label {
+				case "tool-calling":
+					details = append(details, "tool calling")
+				case "vision":
+					details = append(details, "images")
+				case "reasoning":
+					details = append(details, "reasoning")
+				}
+			}
+			if len(details) > 0 {
+				lines = append(lines, strings.Join(details, " · "))
+			}
+		}
+	}
+	if m.note != "" {
+		lines = append(lines, "", m.note)
+	}
+	hint := "↑/↓ choose · enter continue · r refresh · esc close"
+	if m.stage == "models" {
+		hint = "type to search · ↑/↓ choose · enter select · ctrl+r refresh · esc back"
+	}
+	if m.stage == "setup" {
+		hint = "tab field · enter connect · ctrl+d forget key · esc back"
+	}
+	if w < 65 {
+		switch m.stage {
+		case "models":
+			hint = "type to search · ↑/↓ · enter · esc back"
+		case "setup":
+			hint = "tab field · enter connect · esc back"
+		default:
+			hint = "↑/↓ choose · enter · esc close"
+		}
+		if w < 40 {
+			hint = "↑/↓ · enter · esc"
+			if m.stage == "setup" {
+				hint = "tab · enter · esc"
+			}
+		}
+	}
+	if m.busy {
+		hint = m.spin.View() + " " + m.activity + "… · esc cancel"
+	}
+	// Keep the focused field and navigation visible on small terminals.
+	var wrapped []string
+	for _, line := range lines {
+		wrapped = append(wrapped, strings.Split(ansi.Wrap(line, w, ""), "\n")...)
+	}
+	budget := max(1, m.height-4)
+	if len(wrapped) > budget {
+		wrapped = append(wrapped[:1], wrapped[len(wrapped)-budget+1:]...)
+	}
+	return lipgloss.NewStyle().Padding(1, 2).Render(strings.Join(append(wrapped, "", ansi.Truncate(hint, w, "…")), "\n"))
+}
+
+func formatTokens(n int) string {
+	s := fmt.Sprint(n)
+	for i := len(s) - 3; i > 0; i -= 3 {
+		s = s[:i] + "," + s[i:]
+	}
+	return s
+}

--- a/tui/internal/ui/providers/model_test.go
+++ b/tui/internal/ui/providers/model_test.go
@@ -1,0 +1,185 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+package providers
+
+import (
+	"errors"
+	"github.com/amd/gaia/tui/internal/lemonade"
+	"github.com/charmbracelet/bubbles/cursor"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+	"strings"
+	"testing"
+)
+
+func key(m Model, k tea.KeyType) Model { next, _ := m.Update(tea.KeyMsg{Type: k}); return next.(Model) }
+func TestMaskedPasteNeverReachesViewAndClearsOnCancel(t *testing.T) {
+	m := New("", 100, 30)
+	m.selected = 1
+	m = m.setup()
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("fw-sensitive-test-key"), Paste: true})
+	m = next.(Model)
+	if m.fields[3].Value() != "fw-sensitive-test-key" {
+		t.Fatal("paste did not reach credential field")
+	}
+	if strings.Contains(m.View(), "fw-sensitive-test-key") || !strings.Contains(m.View(), "•") {
+		t.Fatal("password exposed or missing mask")
+	}
+	m = key(m, tea.KeyEsc)
+	if m.fields != nil || m.stage != "providers" {
+		t.Fatal("cancel retained key")
+	}
+}
+func TestProviderScreenOffersAllDestinations(t *testing.T) {
+	m := New("", 100, 30)
+	for _, label := range []string{"Local", "Fireworks AI", "AMD LLM Gateway"} {
+		if !strings.Contains(m.View(), label) {
+			t.Fatal(label)
+		}
+	}
+}
+func TestSuggestedGemmaIsFirstAndSelectionIsExplicit(t *testing.T) {
+	m := New("", 100, 30)
+	m.selected = 1
+	m = m.setup()
+	next, cmd := m.Update(modelsMsg{models: []lemonade.Model{{ID: "fireworks.z"}, {ID: lemonade.FireworksModel}}})
+	m = next.(Model)
+	if m.ctx.Err() != nil || m.models[0].ID != lemonade.FireworksModel || m.stage != "models" {
+		t.Fatal("model silently selected or suggestion missing")
+	}
+	_, cmd = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd().(SelectedMsg).ID != lemonade.FireworksModel {
+		t.Fatal("wrong selection")
+	}
+}
+func TestEmptyCatalogStaysInSetup(t *testing.T) {
+	m := New("", 100, 30)
+	m.selected = 1
+	m = m.setup()
+	m.busy = true
+	next, _ := m.Update(modelsMsg{})
+	m = next.(Model)
+	if m.busy || m.stage != "setup" || !strings.Contains(m.View(), "No chat models discovered") {
+		t.Fatal("empty discovery was treated as connected")
+	}
+}
+func TestCredentialFieldRemainsVisibleInSmallTerminal(t *testing.T) {
+	for _, size := range [][2]int{{80, 24}, {48, 18}, {32, 12}} {
+		m := New("", size[0], size[1])
+		m.selected = 1
+		m = m.setup()
+		view := m.View()
+		if !strings.Contains(view, "API key") {
+			t.Fatal("key field clipped", size)
+		}
+		for _, line := range strings.Split(view, "\n") {
+			if ansi.StringWidth(line) > size[0] {
+				t.Fatalf("overflow at %v: %q", size, line)
+			}
+		}
+	}
+}
+
+func TestRefreshFailureOrEmptyCatalogCannotCrashSelection(t *testing.T) {
+	for _, failure := range []bool{false, true} {
+		m := New("", 80, 24)
+		m.selected = 1
+		m = m.setup()
+		m.stage = "models"
+		m.models = []lemonade.Model{{ID: lemonade.FireworksModel}}
+		result := modelsMsg{}
+		if failure {
+			result.err = errors.New("connection failed")
+		}
+		next, _ := m.Update(result)
+		m = next.(Model)
+		if failure && len(m.models) != 1 {
+			t.Fatal("failed refresh erased existing models")
+		}
+		if !failure && m.stage != "setup" {
+			t.Fatal("empty refresh should return to setup")
+		}
+		m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	}
+}
+
+func TestModelSearchAndMetadata(t *testing.T) {
+	m := New("", 80, 24)
+	m.selected = 1
+	next, _ := m.Update(modelsMsg{models: []lemonade.Model{{ID: lemonade.FireworksModel, ContextLength: 262144, Labels: []string{"tool-calling", "vision"}}, {ID: "fireworks.qwen"}}})
+	m = next.(Model)
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("gemma")})
+	m = next.(Model)
+	if len(m.filteredModels()) != 1 || !strings.Contains(m.View(), "262,144 tokens") || !strings.Contains(m.View(), "tool calling") {
+		t.Fatal("search or metadata missing", m.View())
+	}
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("no-match")})
+	m = next.(Model)
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Fatal("empty search selected a model")
+	}
+}
+func TestConnectingCanBeCancelledWithoutWaiting(t *testing.T) {
+	m := New("", 80, 24)
+	m.selected = 1
+	m = m.setup()
+	m.busy = true
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = next.(Model)
+	if m.ctx.Err() == nil || m.fields != nil {
+		t.Fatal("cancel did not cancel request and clear input")
+	}
+	if _, ok := cmd().(ClosedMsg); !ok {
+		t.Fatal("cancel did not close")
+	}
+}
+func TestOldPanelResultsCannotAffectNewPanel(t *testing.T) {
+	old := New("", 80, 24)
+	m := New("", 80, 24)
+	next, _ := m.Update(modelsMsg{source: old.client, models: []lemonade.Model{{ID: lemonade.FireworksModel}}})
+	m = next.(Model)
+	if m.stage != "providers" {
+		t.Fatal("late result reopened an old model selection")
+	}
+}
+
+func TestCancelIgnoresQueuedInputAndBlinkEvents(t *testing.T) {
+	for _, k := range []tea.KeyType{tea.KeyEsc, tea.KeyCtrlC} {
+		m := New("", 80, 24)
+		m.selected = 1
+		m = m.setup()
+		m.busy = true
+		next, _ := m.Update(tea.KeyMsg{Type: k})
+		m = next.(Model)
+		for _, msg := range []tea.Msg{cursor.BlinkMsg{}, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("queued")}, tea.WindowSizeMsg{Width: 40, Height: 12}} {
+			next, _ = m.Update(msg)
+			m = next.(Model)
+			m.View()
+		}
+	}
+}
+
+func TestNarrowProviderNoticeWrapsAtWords(t *testing.T) {
+	m := New("", 48, 18)
+	m.selected = 1
+	m = m.setup()
+	view := ansi.Strip(m.View())
+	if strings.Contains(view, "restar\n") || strings.Contains(view, "of t\n") {
+		t.Fatal("notice splits words", view)
+	}
+	if len(strings.Split(view, "\n")) > 18 {
+		t.Fatal("panel exceeds terminal height", view)
+	}
+}
+
+func TestCompactGatewayKeepsProviderAndFieldsVisible(t *testing.T) {
+	m := New("", 48, 18)
+	m.selected = 2
+	m = m.setup()
+	for _, label := range []string{"AMD LLM Gateway", "Gateway URL", "Auth header", "API key", "esc back"} {
+		if !strings.Contains(m.View(), label) {
+			t.Fatalf("compact gateway lost %s: %s", label, m.View())
+		}
+	}
+}

--- a/tui/internal/ui/providers/model_test.go
+++ b/tui/internal/ui/providers/model_test.go
@@ -42,12 +42,12 @@ func TestSuggestedGemmaIsFirstAndSelectionIsExplicit(t *testing.T) {
 	m := New("", 100, 30)
 	m.selected = 1
 	m = m.setup()
-	next, cmd := m.Update(modelsMsg{models: []lemonade.Model{{ID: "fireworks.z"}, {ID: lemonade.FireworksModel}}})
+	next, _ := m.Update(modelsMsg{models: []lemonade.Model{{ID: "fireworks.z"}, {ID: lemonade.FireworksModel}}})
 	m = next.(Model)
 	if m.ctx.Err() != nil || m.models[0].ID != lemonade.FireworksModel || m.stage != "models" {
 		t.Fatal("model silently selected or suggestion missing")
 	}
-	_, cmd = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	if cmd().(SelectedMsg).ID != lemonade.FireworksModel {
 		t.Fatal("wrong selection")
 	}

--- a/tui/internal/ui/root/introspect.go
+++ b/tui/internal/ui/root/introspect.go
@@ -35,6 +35,7 @@ func (m FlagshipModel) ControlSnapshot() control.Snapshot {
 		if m.chat != nil {
 			snap.Agent = m.chat.AgentID()
 			snap.Streaming = m.chat.IsStreaming()
+			snap.Overlay = m.chat.ControlSnapshot().Overlay
 		}
 	}
 
@@ -48,6 +49,9 @@ func (m FlagshipModel) ControlSnapshot() control.Snapshot {
 	// /status never blinds to "unknown" while held.
 	if m.Halted() {
 		snap.Overlay = "halt"
+	}
+	if m.providerPanel != nil {
+		snap.Overlay = "provider"
 	}
 	return snap
 }

--- a/tui/internal/ui/root/model.go
+++ b/tui/internal/ui/root/model.go
@@ -13,6 +13,7 @@ import (
 	"github.com/amd/gaia/tui/internal/ui/chat"
 	"github.com/amd/gaia/tui/internal/ui/components"
 	"github.com/amd/gaia/tui/internal/ui/preflight"
+	"github.com/amd/gaia/tui/internal/ui/providers"
 	"github.com/amd/gaia/tui/internal/ui/status"
 )
 
@@ -34,9 +35,10 @@ const (
 // agent. GAIA ships one, so there is nothing to browse and nothing to pick —
 // the launch goes straight at it.
 type FlagshipModel struct {
-	activeView view
-	agent      catalog.Agent
-	chat       *chat.ChatModel
+	providerPanel *providers.Model
+	activeView    view
+	agent         catalog.Agent
+	chat          *chat.ChatModel
 	// chatClient is held behind a pointer shared by every copy Bubble Tea
 	// makes, so whoever tears the program down can close the child this model
 	// opened. Stored by value it would live on a copy that dies with the
@@ -220,6 +222,35 @@ func beginCmd() tea.Cmd { return func() tea.Msg { return beginMsg{} } }
 type beginMsg struct{}
 
 func (m FlagshipModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if m.providerPanel != nil {
+		switch v := msg.(type) {
+		case providers.ClosedMsg:
+			m.providerPanel = nil
+			return m, m.preflight.Init()
+		case providers.SelectedMsg:
+			m.providerPanel = nil
+			m.model = v.ID
+			m.useClaude = false
+			m.claudeModel = ""
+			return m.beginPreflight(m.agent)
+		default:
+			if size, ok := msg.(tea.WindowSizeMsg); ok {
+				m.width = size.Width
+				m.height = size.Height
+			}
+			updated, cmd := m.providerPanel.Update(msg)
+			panel := updated.(providers.Model)
+			m.providerPanel = &panel
+			return m, cmd
+		}
+	}
+	if key, ok := msg.(tea.KeyMsg); ok && key.String() == "p" && m.activeView == viewPreflight && m.preflight != nil && !m.preflight.Busy() && m.agent.ID == catalog.FlagshipID {
+		m.preflight.Cancel()
+		panel := providers.New("", m.width, m.height)
+		m.providerPanel = &panel
+		return m, panel.Init()
+	}
+
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
@@ -321,6 +352,9 @@ func (m FlagshipModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m FlagshipModel) View() string {
+	if m.providerPanel != nil {
+		return m.providerPanel.View()
+	}
 	var base string
 	switch m.activeView {
 	case viewSplash:

--- a/tui/internal/ui/root/preflight.go
+++ b/tui/internal/ui/root/preflight.go
@@ -53,9 +53,12 @@ func (m FlagshipModel) beginPreflight(agent catalog.Agent) (tea.Model, tea.Cmd) 
 // will actually spawn, and whether this session runs on Claude.
 func (m FlagshipModel) localOptions(agent catalog.Agent) preflight.LocalOptions {
 	if m.pfLocal != nil {
-		return *m.pfLocal
+		opts := *m.pfLocal
+		opts.Model = m.model
+		opts.ClaudeMode = m.useClaude
+		return opts
 	}
-	return preflight.LocalOptions{Binary: agent.BinaryPath, ClaudeMode: m.useClaude}
+	return preflight.LocalOptions{Binary: agent.BinaryPath, ClaudeMode: m.useClaude, Model: m.model}
 }
 
 // preflightTransport builds the gate's transport on first use and keeps it for

--- a/tui/internal/ui/root/providers_test.go
+++ b/tui/internal/ui/root/providers_test.go
@@ -1,0 +1,74 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package root
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/amd/gaia/tui/internal/catalog"
+	"github.com/amd/gaia/tui/internal/ui/preflight"
+	"github.com/amd/gaia/tui/internal/ui/providers"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Finish the first read-only probe against an absent binary. This avoids a
+// real server or Python subprocess while exercising the root/gate boundary.
+func providerBlockedRoot(t *testing.T) FlagshipModel {
+	t.Helper()
+	agent := catalog.Agent{ID: catalog.FlagshipID, Name: "GAIA", BinaryPath: filepath.Join(t.TempDir(), "missing-agent")}
+	m := NewFlagshipModel(agent, true)
+	next, cmd := m.beginPreflight(agent)
+	m = next.(FlagshipModel)
+	batch := cmd().(tea.BatchMsg)
+	next, _ = m.Update(batch[0]())
+	m = next.(FlagshipModel)
+	if m.preflight.Busy() || !m.preflight.Report().Blocked() {
+		t.Fatal("fixture did not reach a blocked, idle preflight")
+	}
+	return m
+}
+
+func TestProviderSelectionRebuildsStartupGateWithSelectedModel(t *testing.T) {
+	for _, model := range []string{"fireworks.gemma-4-31b-it", "amd.gpt-4.1", "Gemma-4-E4B-it-GGUF"} {
+		t.Run(model, func(t *testing.T) {
+			m := providerBlockedRoot(t).WithClaude(true, "claude-sonnet-5")
+			old := m.preflight
+			next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("p")})
+			m = next.(FlagshipModel)
+			if m.ControlSnapshot().Overlay != "provider" {
+				t.Fatal("startup did not open provider setup")
+			}
+			next, _ = m.Update(providers.SelectedMsg{ID: model})
+			m = next.(FlagshipModel)
+			defer m.preflight.Cancel()
+			opts := m.localOptions(m.agent)
+			if m.model != model || opts.Model != model || opts.ClaudeMode || m.useClaude || m.claudeModel != "" {
+				t.Fatalf("selection did not replace launch and readiness settings: %+v", opts)
+			}
+			if m.providerPanel != nil || m.preflight == old || !m.preflight.Busy() || m.chat != nil {
+				t.Fatal("provider selection bypassed the new readiness check")
+			}
+		})
+	}
+}
+
+func TestClosingProviderSetupRechecksWithoutChangingStartupModel(t *testing.T) {
+	m := providerBlockedRoot(t).WithModel("fireworks.gemma-4-31b-it")
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("p")})
+	m = next.(FlagshipModel)
+	next, cmd := m.Update(providers.ClosedMsg{})
+	m = next.(FlagshipModel)
+	defer m.preflight.Cancel()
+	if m.providerPanel != nil || m.model != "fireworks.gemma-4-31b-it" || m.activeView != viewPreflight || cmd == nil {
+		t.Fatal("cancel changed model or left the canceled provider screen active")
+	}
+	batch := cmd().(tea.BatchMsg)
+	next, _ = m.Update(batch[0]())
+	m = next.(FlagshipModel)
+	row, ok := m.preflight.Report().Find(preflight.KeyBinary)
+	if !ok || row.State != preflight.StateFailed || m.chat != nil {
+		t.Fatal("cancel bypassed readiness or failed to restart the probe")
+	}
+}


### PR DESCRIPTION
GAIA’s TUI can now choose Local, Fireworks AI, or AMD LLM Gateway through Lemonade, with masked runtime-key entry and model discovery. Cloud chat avoids local chat downloads and model loading; Gemma 4 31B IT is suggested when the provider exposes it. Searchable models, clearer progress, compact layouts, and cancellable setup make provider changes easier to follow.

Based on current main, including #3597’s TUI and transcription changes.

## Test plan

- [x] Full `cd tui && go test ./...`, `go vet ./...`, and targeted race checks.
- [x] Focused Python tests, changed-file lint, and internal documentation links.
- [x] Real Lemonade 11.8.1 + TUI `--dev --control`: Fireworks streaming, native `read_file`, cancellation, and switching to local Gemma while preserving the conversation.
- [x] Masked paste, narrow layouts, provider failures, and AMD custom-header/key lifecycle contract tests.
- [ ] Live AMD gateway validation with an organization endpoint.
- [ ] Broader agent evaluation against the committed baseline before merge.

Gemma 4 31B was absent from the test account’s discovered catalog; live Fireworks checks used its GLM fast router. No deployment was provisioned.
