### PR TITLE
fix(rag): honor index_document's success flag at every truthy call site

### DIFF
--- a/src/gaia/agents/tools/file_monitor_tools.py
+++ b/src/gaia/agents/tools/file_monitor_tools.py
@@ -54,7 +54,7 @@ class FileToolsMixin:
 
                     for pdf_file in pdf_files:
                         try:
-                            if self.rag.index_document(str(pdf_file)):
+                            if self.rag.index_document(str(pdf_file)).get("success"):
                                 self.indexed_files.add(str(pdf_file))
                                 indexed_count += 1
                                 if hasattr(self, "debug") and self.debug:

--- a/src/gaia/chat/sdk.py
+++ b/src/gaia/chat/sdk.py
@@ -906,7 +906,7 @@ class AgentSDK:
         if not self.rag_enabled or not self.rag:
             raise ValueError("RAG not enabled. Call enable_rag() first.")
 
-        return self.rag.index_document(document_path)
+        return bool(self.rag.index_document(document_path).get("success"))
 
     def _estimate_tokens(self, text: str) -> int:
         """

--- a/src/gaia/rag/app.py
+++ b/src/gaia/rag/app.py
@@ -32,7 +32,7 @@ def index_command(args):
             continue
 
         print(f"📄 Indexing: {pdf_path}")
-        if rag.index_document(pdf_path):
+        if rag.index_document(pdf_path).get("success"):
             print(f"✅ Successfully indexed: {pdf_path}")
             success_count += 1
         else:
@@ -161,7 +161,7 @@ def quick_command(args):
     else:
         print(f"📄 Processing {Path(args.file).name}...")
 
-    if not rag.index_document(args.file):
+    if not rag.index_document(args.file).get("success"):
         print(f"❌ Failed to index: {args.file}")
         return
 

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -794,9 +794,8 @@ class TestChatIntegration:
         chat.enable_rag()
         result = chat.add_document("test.pdf")
 
-        # add_document returns the result from index_document (dict, not bool despite type hint)
-        assert isinstance(result, dict)
-        assert result.get("success") is True
+        # add_document now honors its bool type hint instead of forwarding the raw stats dict
+        assert result is True
         mock_chat_dependencies["rag"].index_document.assert_called_with("test.pdf")
 
     def test_add_document_without_rag(self, mock_chat_dependencies):

--- a/tests/unit/test_rag_index_status.py
+++ b/tests/unit/test_rag_index_status.py
@@ -2,9 +2,13 @@
 
 """Regression tests for RAG startup/indexing status propagation."""
 
+import argparse
 from unittest.mock import Mock, patch
 
+from gaia.agents.base.tools import _TOOL_REGISTRY
+from gaia.agents.tools.file_monitor_tools import FileToolsMixin
 from gaia.chat.sdk import AgentConfig, AgentSDK
+from gaia.rag import app as rag_app
 from gaia.talk.sdk import TalkSDK
 
 
@@ -79,3 +83,144 @@ def test_talk_enable_rag_preserves_success_status():
         for call in talk.log.info.call_args_list
     )
     talk.log.warning.assert_not_called()
+
+
+def test_chat_add_document_returns_false_on_index_failure():
+    """AgentSDK.add_document is annotated -> bool; a failed index must not
+    forward the (always truthy) stats dict as if it were success."""
+    chat = _uninitialized_chat()
+    chat.rag_enabled = True
+    chat.rag = Mock()
+    chat.rag.index_document.return_value = {
+        "success": False,
+        "error": "file not found",
+    }
+
+    result = chat.add_document("missing.pdf")
+
+    assert result is False
+
+
+def test_chat_add_document_returns_true_on_index_success():
+    """The success path must still report True, not the stats dict itself."""
+    chat = _uninitialized_chat()
+    chat.rag_enabled = True
+    chat.rag = Mock()
+    chat.rag.index_document.return_value = {"success": True, "num_chunks": 3}
+
+    result = chat.add_document("manual.pdf")
+
+    assert result is True
+
+
+def test_talk_add_document_propagates_chat_index_failure():
+    """Talk.add_document forwards whatever Chat.add_document returns; once
+    Chat reports a real bool, Talk needs no change of its own to be correct."""
+    talk = TalkSDK.__new__(TalkSDK)
+    talk.chat_sdk = Mock()
+    talk.chat_sdk.rag_enabled = True
+    talk.chat_sdk.add_document.return_value = False
+    talk.log = Mock()
+
+    assert talk.add_document("missing.pdf") is False
+
+
+def test_rag_app_index_command_counts_only_real_successes(tmp_path):
+    """`gaia rag index` must not count a failed index_document call as
+    indexed just because it returned a non-empty dict."""
+    pdf = tmp_path / "a.pdf"
+    pdf.write_bytes(b"%PDF-1.4")
+    args = argparse.Namespace(
+        files=[str(pdf)],
+        model=None,
+        verbose=False,
+        chunk_size=None,
+        max_chunks=None,
+    )
+
+    with patch("gaia.rag.app.RAGSDK") as rag_class:
+        rag_class.return_value.index_document.return_value = {
+            "success": False,
+            "error": "embedding model unavailable",
+        }
+        rag_class.return_value.get_status.return_value = {"total_chunks": 0}
+
+        with patch("builtins.print") as mock_print:
+            rag_app.index_command(args)
+
+    assert any(
+        "Indexed 0/1 documents" in call.args[0] for call in mock_print.call_args_list
+    )
+
+
+def test_rag_app_quick_command_reports_failure_and_stops(tmp_path):
+    """`gaia rag quick` must not query after a failed index_document call."""
+    pdf = tmp_path / "a.pdf"
+    pdf.write_bytes(b"%PDF-1.4")
+    args = argparse.Namespace(
+        file=str(pdf),
+        question="What is this?",
+        model=None,
+        verbose=False,
+        chunk_size=None,
+        max_chunks=None,
+    )
+
+    with patch("gaia.rag.app.RAGSDK") as rag_class:
+        rag_class.return_value.index_document.return_value = {
+            "success": False,
+            "error": "embedding model unavailable",
+        }
+
+        with patch("builtins.print") as mock_print:
+            rag_app.quick_command(args)
+
+        rag_class.return_value.query.assert_not_called()
+
+    assert any(
+        f"Failed to index: {pdf}" in call.args[0] for call in mock_print.call_args_list
+    )
+
+
+def _file_monitor_agent(rag_result):
+    """Build a minimal FileToolsMixin host with just enough state to drive
+    add_watch_directory's auto-indexing loop."""
+
+    class _Host(FileToolsMixin):
+        pass
+
+    host = _Host()
+    host.path_validator = Mock(is_path_allowed=Mock(return_value=True))
+    host.watch_directories = []
+    host.indexed_files = set()
+    host.rag = Mock(index_document=Mock(return_value=rag_result))
+    host._watch_directory = Mock()
+    host._auto_save_session = Mock()
+    host.register_file_tools()
+    return host, _TOOL_REGISTRY["add_watch_directory"]["function"]
+
+
+def test_add_watch_directory_does_not_count_failed_index_as_indexed(tmp_path):
+    """A dict-returning failed index_document call must not be counted in
+    files_indexed or added to indexed_files."""
+    (tmp_path / "a.pdf").write_bytes(b"%PDF-1.4")
+    host, add_watch_directory = _file_monitor_agent(
+        {"success": False, "error": "embedding model unavailable"}
+    )
+
+    result = add_watch_directory(str(tmp_path))
+
+    assert result["files_indexed"] == 0
+    assert host.indexed_files == set()
+
+
+def test_add_watch_directory_counts_real_success(tmp_path):
+    """The success path must still index and count the file."""
+    pdf = tmp_path / "a.pdf"
+    pdf.write_bytes(b"%PDF-1.4")
+    host, add_watch_directory = _file_monitor_agent({"success": True, "num_chunks": 2})
+
+    result = add_watch_directory(str(tmp_path))
+
+    assert result["files_indexed"] == 1
+    assert str(pdf) in host.indexed_files


### PR DESCRIPTION
`index_document` always returns a populated stats dict, so the callers that did `if rag.index_document(...)` treated every failure as success. Checked `.get("success")` instead at each site: `add_watch_directory`, `AgentSDK.add_document` (it's annotated `-> bool` but was forwarding the raw dict), `index_command`, and `quick_command`. `TalkSDK.add_document` needed no change of its own, it only forwards `AgentSDK.add_document`'s return value, which is now a real bool.

Added a test for each of the five call sites in `tests/unit/test_rag_index_status.py`, next to the existing `enable_rag` coverage for the same bug. They red without the fix, including both directions on `AgentSDK.add_document` (the raw dict isn't `True` either, even on a real success). black, isort, flake8, and pylint are clean.

Haven't run this through `gaia rag index` end to end with a real embedding model, faiss/torch aren't in my env, so the tests mock `RAGSDK` directly instead.
