### PR TITLE
fix: apply reviewed maintenance repairs for #3613

### DIFF
--- a/docs/reference/eval.mdx
+++ b/docs/reference/eval.mdx
@@ -1427,6 +1427,14 @@ For the new scenario-based eval framework that tests the live Agent UI end-to-en
 - [Scenario Authoring](/guides/eval-scenarios) — write custom YAML scenarios
 - [CI/CD Integration](/guides/eval-ci) — regression detection in GitHub Actions
 
+### Require a complete comparison
+
+Use `gaia eval agent --compare BASELINE CURRENT --require-complete` for a local
+pre-commit gate. It exits 2 if a baseline scenario is missing or produced no
+measurement, as well as for measured regressions. Without this opt-in, incomplete
+measurements remain visible as warnings and the comparison judges measured results.
+
+
 ---
 
 <small style="color: #666;">

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -2117,6 +2117,11 @@ Examples:
         help="Compare two scorecard.json files (BASELINE CURRENT) or compare a run against saved baseline (CURRENT only)",
     )
     agent_eval_parser.add_argument(
+        "--require-complete",
+        action="store_true",
+        help="With --compare, fail when baseline scenarios are missing or unmeasured",
+    )
+    agent_eval_parser.add_argument(
         "--save-baseline",
         action="store_true",
         help="After eval, save this run's scorecard as eval/results/baseline.json for future --compare",
@@ -3897,37 +3902,49 @@ Let me know your answer!
                                 "  Run `gaia eval agent --save-baseline` first to save a baseline."
                             )
                             sys.exit(1)
+                        current_path = Path(compare_paths[0])
                         result = compare_scorecards(
-                            str(baseline_path), compare_paths[0]
+                            str(baseline_path), str(current_path)
                         )
                     elif len(compare_paths) == 2:
-                        result = compare_scorecards(compare_paths[0], compare_paths[1])
+                        baseline_path, current_path = map(Path, compare_paths)
+                        result = compare_scorecards(
+                            str(baseline_path), str(current_path)
+                        )
                     else:
                         print("[ERROR] --compare accepts 1 or 2 paths")
                         sys.exit(1)
 
-                    # If compare detected regressions or significant score drops, fail non-zero.
-                    # Scenarios with no measurement are deliberately NOT counted:
-                    # an infra failure is not a quality regression. Completeness
-                    # is the integrity gate's verdict (gaia.eval.integrity_gate),
-                    # so it is surfaced here and blocks there.
+                    # Quality and completeness are separate checks. The strict
+                    # opt-in uses exactly the CI integrity gate's missing/blocked/
+                    # skipped/error semantics, including newly added scenarios.
                     regressed = result.get("regressed", [])
                     score_regressed = result.get("score_regressed", [])
                     time_regressed = result.get("time_regressed", [])
-                    unmeasured = result.get("unmeasured", [])
-                    if unmeasured:
-                        ids = ", ".join(e["scenario_id"] for e in unmeasured)
-                        print(
-                            f"[WARN] {len(unmeasured)} scenario(s) had no measurement and were "
-                            f"excluded from this verdict: {ids}. Run "
-                            "`python -m gaia.eval.integrity_gate --help` for the completeness check."
-                        )
                     total_issues = (
                         len(regressed) + len(score_regressed) + len(time_regressed)
                     )
+                    if getattr(args, "require_complete", False):
+                        from gaia.eval.integrity_gate import check_category
+
+                        problems, status_line = check_category(
+                            baseline_path, current_path, "comparison"
+                        )
+                        print(status_line)
+                        for problem in problems:
+                            print(f"[ERROR] {problem}")
+                        total_issues += len(problems)
+                    elif result.get("unmeasured"):
+                        unmeasured = result["unmeasured"]
+                        ids = ", ".join(e["scenario_id"] for e in unmeasured)
+                        print(
+                            f"[WARN] {len(unmeasured)} scenario(s) had no measurement and were "
+                            f"excluded from the quality verdict: {ids}. Add "
+                            "--require-complete to also enforce measurement completeness."
+                        )
                     if total_issues > 0:
                         print(
-                            f"[ERROR] Detected {total_issues} issue(s) (status regressions, score regressions, or time regressions); failing."
+                            f"[ERROR] Detected {total_issues} regression or required-completeness issue(s); failing."
                         )
                         sys.exit(2)
                     # Otherwise success

--- a/src/gaia/eval/integrity_gate.py
+++ b/src/gaia/eval/integrity_gate.py
@@ -54,9 +54,9 @@ import sys
 from pathlib import Path
 
 # Summary counters meaning "a scenario produced no measurement", as distinct
-# from `failed` (FAIL is a legitimate, comparable outcome). Mirrors
-# gaia.eval.runner._NO_MEASUREMENT_STATUSES, expressed in the scorecard summary's
-# own key names (scorecard.py::build_scorecard).
+# from `failed` (FAIL is a legitimate, comparable outcome). Unlike the runner's
+# regression comparison, completeness also treats blocked/skipped as unmeasured.
+# Keys come from scorecard.py::build_scorecard.
 NO_MEASUREMENT_COUNTERS = (
     "infra_error",
     "errored",

--- a/src/gaia/eval/runner.py
+++ b/src/gaia/eval/runner.py
@@ -591,7 +591,8 @@ _SCORE_REGRESSION_THRESHOLD = 2.0
 # "measured and failed" — FAIL is a legitimate, comparable outcome. A harness
 # death scores 0.0 (or null), which is indistinguishable from a model that
 # answered badly, so comparing the two reports infrastructure as a regression.
-# Kept in sync with the buckets in scorecard.py::build_scorecard.
+# BLOCKED_BY_ARCHITECTURE remains a comparable outcome here; the separate
+# integrity gate also counts blocked/skipped outcomes as incomplete.
 _NO_MEASUREMENT_STATUSES = frozenset(
     {"INFRA_ERROR", "SETUP_ERROR", "TIMEOUT", "BUDGET_EXCEEDED", "ERRORED"}
 )

--- a/tests/unit/eval/test_integrity_gate.py
+++ b/tests/unit/eval/test_integrity_gate.py
@@ -3,17 +3,26 @@
 """Tests for the CI eval completeness gate (``gaia.eval.integrity_gate``).
 
 The gate's whole contract is that ``--enforce`` moves the EXIT CODE and nothing
-else — the findings stay visible in both modes. Both halves are asserted here:
+else â€” the findings stay visible in both modes. Both halves are asserted here:
 report mode must exit 0 while still emitting the annotation and the job-summary
 block, and enforce mode must exit 1 on the same input.
 """
 
 import json
+import os
+import subprocess
+import sys
 
 import pytest
 
 from gaia.eval.integrity_gate import main
 from gaia.eval.scorecard import build_scorecard
+
+
+@pytest.fixture(autouse=True)
+def _isolate_job_summary(monkeypatch):
+    """Never append fabricated gate findings to the CI job summary."""
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
 
 
 def _result(scenario_id, status, score=9.0):
@@ -68,7 +77,7 @@ def test_complete_run_passes_in_both_modes(workspace):
         [_result("known_path_read", "PASS"), _result("multi_step_plan", "FAIL", 3.0)],
     )
 
-    # FAIL is a measurement, not a gap — completeness is indifferent to quality.
+    # FAIL is a measurement, not a gap â€” completeness is indifferent to quality.
     assert main(_argv(baseline_dir, results_dir)) == 0
     assert main(_argv(baseline_dir, results_dir, "--enforce")) == 0
 
@@ -157,3 +166,68 @@ def test_findings_reach_the_job_summary_in_report_mode(
 def test_no_categories_is_a_miswired_workflow(tmp_path):
     """Checking nothing is a configuration error, never a pass."""
     assert main(["--baseline-dir", str(tmp_path), "--results-dir", str(tmp_path)]) == 1
+
+
+@pytest.mark.parametrize("require_complete,expected", [(False, 0), (True, 2)])
+@pytest.mark.parametrize(
+    "status",
+    [
+        "INFRA_ERROR",
+        "ERROR",
+        "TIMEOUT",
+        "BLOCKED_BY_ARCHITECTURE",
+        "BUDGET_EXCEEDED",
+        "SKIPPED_NO_DOCUMENT",
+        "MISSING",
+    ],
+)
+def test_cli_compare_completeness_opt_in(tmp_path, require_complete, expected, status):
+    baseline = tmp_path / "baseline.json"
+    current = tmp_path / "current.json"
+    baseline.write_text(
+        json.dumps(
+            build_scorecard(
+                "baseline",
+                [_result("one", "PASS" if status == "MISSING" else status, None)],
+                {},
+            )
+        )
+    )
+    current.write_text(
+        json.dumps(
+            build_scorecard(
+                "current",
+                [] if status == "MISSING" else [_result("one", status, None)],
+                {},
+            )
+        )
+    )
+    env = dict(os.environ, USERPROFILE=str(tmp_path), HOME=str(tmp_path))
+    command = [
+        sys.executable,
+        "-m",
+        "gaia.cli",
+        "eval",
+        "agent",
+        "--compare",
+        str(baseline),
+        str(current),
+    ]
+    if require_complete:
+        command.append("--require-complete")
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=env,
+        check=False,
+    )
+    assert result.returncode == expected, result.stdout + result.stderr
+    if require_complete:
+        assert (
+            "missing from the run" in result.stdout
+            if status == "MISSING"
+            else "without a measurement" in result.stdout
+        )


### PR DESCRIPTION
Follow-up fixes for #3613. Changed: src/gaia/cli.py; src/gaia/eval/{integrity_gate.py,runner.py}; tests/unit/eval/test_integrity_gate.py; docs/reference/eval.mdx.

This PR targets the original feature branch because the current account cannot push to `amd/gaia`. It carries the prepared maintenance changes for that PR.

## Test plan

- [x] Previously completed local validation: Validation: 169 passed across test_integrity_gate.py and tests/test_eval.py, including actual CLI subprocess comparisons for each unmeasured status and missing scenarios, both default and strict modes (tests-3613.log). Ambient summary file was not created. Black/isort/Flake8 and git diff --check pass (final follow-up lint recorded separately if needed).
- [ ] Fresh CI on the combined feature branch.
- [ ] Remaining live-model, hardware or platform checks described in the original PR, where applicable.
- [ ] Human review before merging the original PR.
