### PR TITLE
fix: apply reviewed maintenance repairs for #3602

### DIFF
--- a/src/gaia/agents/tools/file_io_tools.py
+++ b/src/gaia/agents/tools/file_io_tools.py
@@ -165,6 +165,10 @@ class FileIOToolsMixin:
         preferred about half the time (#3600) — but the omission was not
         deliberate and this is the largest single lever measured.
         """
+        if not {"edit_file", "edit_python_file"}.issubset(
+            getattr(self, "_tools_registry", {})
+        ):
+            return ""
         return (
             "==== CHANGING A FILE ====\n"
             "To change a file, call edit_file with the exact existing text as "

--- a/tests/unit/test_file_editing_prompt.py
+++ b/tests/unit/test_file_editing_prompt.py
@@ -13,14 +13,31 @@ These tests pin the fragment's existence and its discovery, not its wording —
 the wording should stay tunable.
 """
 
+import pytest
+
 from gaia.agents.tools.file_io_tools import FileIOToolsMixin
 
 
 class _Bare(FileIOToolsMixin):
-    """The mixin alone — no agent, no registry, no LLM."""
+    """The mixin with registered edit tools, without an agent or LLM."""
+
+    _tools_registry = {"edit_file": {}, "edit_python_file": {}}
 
 
 class TestTheFragmentExists:
+    @pytest.mark.parametrize("profile", ["chat", "doc", "file", "full", "data", "web"])
+    def test_only_profiles_with_both_edit_tools_advertise_them(self, profile):
+        from tests.unit.test_profilespec_characterization import (
+            chat_agent_build_context,
+        )
+
+        with chat_agent_build_context(profile) as agent:
+            agent._register_tools()
+            available = {"edit_file", "edit_python_file"}.issubset(
+                agent._tools_registry
+            )
+            assert bool(agent.get_file_editing_system_prompt()) == available
+
     def test_it_names_the_edit_tools(self):
         text = _Bare().get_file_editing_system_prompt()
         assert "edit_file" in text

--- a/tests/unit/test_profilespec_characterization.py
+++ b/tests/unit/test_profilespec_characterization.py
@@ -56,6 +56,13 @@ FIXTURE_DIR = (
 _PROFILES_WITHOUT_VLM = frozenset({"chat"})
 
 
+class _FixtureHome(type(Path())):
+    """Keep the fixed Linux prompt's home spelling on Windows hosts too."""
+
+    def __str__(self):
+        return super().__str__().replace("\\", "/")
+
+
 @contextlib.contextmanager
 def chat_agent_build_context(
     profile: str,
@@ -125,7 +132,7 @@ def chat_agent_build_context(
             )
             stack.enter_context(patch("platform.machine", return_value="x86_64"))
             stack.enter_context(
-                patch.object(Path, "home", return_value=Path("/fake/home"))
+                patch.object(Path, "home", return_value=_FixtureHome("/fake/home"))
             )
             with stack:
                 agent = ChatAgent.__new__(ChatAgent)


### PR DESCRIPTION
Follow-up fixes for #3602. The edit-tool prompt now appears only when both edit tools are registered. Added six real-profile tests so profiles without editing tools cannot advertise unavailable actions. Corrected the Windows fixture-home representation in the characterization harness; all 15 golden prompts pass unchanged. The harness exercises _get_system_prompt, not the mixin-composed prompt, so the PR's claim that these goldens need regeneration was incorrect. A corrected PR body is provided separately.

This PR targets the original feature branch because the current account cannot push to `amd/gaia`. It carries the prepared maintenance changes for that PR.

## Test plan

- [x] Previously completed local validation: Validation: 29 tests passed, including all golden rows and profile-specific edit-fragment tests. Black, isort, Flake8 with repository settings, and diff checks passed. No golden data was changed.
- [ ] Fresh CI on the combined feature branch.
- [ ] Remaining live-model, hardware or platform checks described in the original PR, where applicable.
- [ ] Human review before merging the original PR.
