### PR TITLE
fix: apply reviewed maintenance repairs for #3490

### DIFF
--- a/.github/workflows/email_scorecard_refresh.yml
+++ b/.github/workflows/email_scorecard_refresh.yml
@@ -241,7 +241,7 @@ jobs:
 
       - name: Install Claude Code CLI (judge transport)
         run: |
-          npm install -g @anthropic-ai/claude-code
+          npm install -g @anthropic-ai/claude-code@2.1.218
           if ($LASTEXITCODE -ne 0) { throw "claude CLI install failed" }
           claude --version
           if ($LASTEXITCODE -ne 0) { throw "claude installed but not runnable on PATH" }

--- a/.github/workflows/release_agent_email.yml
+++ b/.github/workflows/release_agent_email.yml
@@ -51,9 +51,9 @@
 #                              approved.
 #     CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_API_KEY
 #                            — Claude judge credential for the eval-gate's
-#                              voice-drafting eval; the subscription token is
-#                              preferred and the key is the fallback (the choice
-#                              lives in gaia.eval.judge_client). ONE is REQUIRED:
+#                              voice-drafting eval. judge_client uses the API key
+#                              when both are set; workflow env selection can blank
+#                              the key to select the subscription. ONE is REQUIRED:
 #                              eval_drafting_report.py exits 1 when neither is set
 #                              (no silent skip — CLAUDE.md fail-loudly), so the
 #                              eval-gate step FAILS the release and never ships an

--- a/.github/workflows/test_email_agent_eval.yml
+++ b/.github/workflows/test_email_agent_eval.yml
@@ -42,10 +42,10 @@
 # pin them), which is its own change. A judge that cannot be reached at all is
 # covered: the transport raises and the step dies.
 #
-# JUDGE CREDENTIAL. The judged evals prefer CLAUDE_CODE_OAUTH_TOKEN (a Claude
-# Code subscription token, driven through `claude -p`) and fall back to
-# ANTHROPIC_API_KEY (a console API key, driven against the Messages API); the
-# selection lives in src/gaia/eval/judge_client.py, not here. The key alone is
+# JUDGE CREDENTIAL. This workflow selects CLAUDE_CODE_OAUTH_TOKEN by blanking
+# ANTHROPIC_API_KEY when a subscription token exists. Locally judge_client uses
+# ANTHROPIC_API_KEY when both are set; clear it to choose the CLI transport.
+# The key alone is
 # what this workflow asked for until the account behind it ran out of credit and
 # every run on every branch died ~25 minutes in.
 #
@@ -368,7 +368,7 @@ jobs:
 
       - name: Install Claude Code CLI (judge transport)
         run: |
-          npm install -g @anthropic-ai/claude-code
+          npm install -g @anthropic-ai/claude-code@2.1.218
           if ($LASTEXITCODE -ne 0) { throw "claude CLI install failed" }
           claude --version
           if ($LASTEXITCODE -ne 0) { throw "claude installed but not runnable on PATH" }

--- a/.gitignore
+++ b/.gitignore
@@ -277,7 +277,7 @@ tests/unit/eval/test_mcp_tool_reliability_scenarios.py
 # Private working reports — analysis, competitive research, benchmark logs.
 # These are internal notes, not project documentation, and several were
 # published to a public fork and a public PR before this rule existed. They
-# live outside the repo now (~/Work/gaia-private/). Project docs belong in
+# live outside the repo now (../gaia-private-reports/). Project docs belong in
 # docs/ and are reviewed like any other change; anything matching these
 # patterns is assumed to be private working material.
 /BENCHMARK_ANALYSIS.md
@@ -302,7 +302,7 @@ tests/unit/eval/test_mcp_tool_reliability_scenarios.py
 # Local working scratch. Same rule as the private-reports block above: these are
 # agent-run artifacts and datasets, not project material, and `git add -A` would
 # otherwise commit a mailbox corpus. The material itself lives in
-# ~/Work/gaia-private/{plans,presentations,audits,recovered,datasets}.
+# ../gaia-private-reports/{plans,presentations,audits,recovered,datasets}.
 /email-dataset/
 /audit_reports/
 /.playwright-mcp/

--- a/docs/plans/email-eval-node-frontend.mdx
+++ b/docs/plans/email-eval-node-frontend.mdx
@@ -127,7 +127,8 @@ therefore drive a **dev-mode sidecar** via `connectSidecar()` rather than
 
 ```bash
 # Terminal 1 — Lemonade (canonical discovery port is 13305, NOT 8000)
-lemonade-server serve
+# Start Lemonade through `gaia init`; the standalone server CLI was removed.
+# The default discovery port is 13305.
 
 # Terminal 2 — email sidecar from source
 GAIA_EMAIL_AGENT_MODE=dev PYTHONPATH=$(pwd)/src \

--- a/hub/agents/email/npm/EVALUATION.md
+++ b/hub/agents/email/npm/EVALUATION.md
@@ -86,6 +86,6 @@ from the committed seed, and runs the benchmark (~17 minutes on a 4B model).
   `stx` pool) and `email_scorecard_refresh.yml` (manual dispatch only; a full-corpus
   run regenerates `SCORECARD.md`, a subset run smoke-tests the pipeline without
   committing). The drafting eval needs a Claude judge credential —
-  `CLAUDE_CODE_OAUTH_TOKEN` (preferred) or `ANTHROPIC_API_KEY`. With neither it
+  `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` (takes precedence when both are set). With neither it
   exits non-zero and fails the build; never a skip, never a pass.
 </details>

--- a/hub/agents/email/python/packaging/eval_action_item_report.py
+++ b/hub/agents/email/python/packaging/eval_action_item_report.py
@@ -20,8 +20,8 @@ make this gate block once a baseline confirms the bars.
 
 Config comes from the environment (shell-agnostic):
   EMAIL_EVAL_MODEL         Lemonade model id (required)
-  CLAUDE_CODE_OAUTH_TOKEN  Judge credential, preferred (driven via the `claude` CLI)
-  ANTHROPIC_API_KEY        Judge credential, fallback (neither set -> loud failure)
+  CLAUDE_CODE_OAUTH_TOKEN  Judge credential when no API key is set (driven via the `claude` CLI)
+  ANTHROPIC_API_KEY        Judge credential, takes precedence (neither set -> loud failure)
 
 Extracted verbatim from the former inline ``python - <<'PY'`` step so the eval
 can run on the Windows ``stx`` runner pool (PowerShell, no heredocs).

--- a/hub/agents/email/python/packaging/eval_briefing_report.py
+++ b/hub/agents/email/python/packaging/eval_briefing_report.py
@@ -20,8 +20,8 @@ briefing is good, the pipeline goes red (CLAUDE.md: No Silent Fallbacks).
 
 Config comes from the environment (shell-agnostic):
   EMAIL_EVAL_MODEL         Lemonade model id (required)
-  CLAUDE_CODE_OAUTH_TOKEN  Judge credential, preferred (driven via the `claude` CLI)
-  ANTHROPIC_API_KEY        Judge credential, fallback (neither set -> loud failure)
+  CLAUDE_CODE_OAUTH_TOKEN  Judge credential when no API key is set (driven via the `claude` CLI)
+  ANTHROPIC_API_KEY        Judge credential, takes precedence (neither set -> loud failure)
 
 Extracted verbatim from the former inline ``python - <<'PY'`` step so the eval
 can run on the Windows ``stx`` runner pool (PowerShell, no heredocs).
@@ -77,6 +77,8 @@ def main() -> int:
         )
         return 1
 
+    judge = make_claude_judge()
+
     # Generation: drives the REAL scheduled-briefing path per case (heuristic
     # classification — read-only, nothing sent/archived).
     generations = generate_briefings(model, corpus_path=CORPUS_PATH)
@@ -102,7 +104,7 @@ def main() -> int:
     results = judge_briefings(
         load_briefing_corpus(CORPUS_PATH),
         generations,
-        make_claude_judge(),
+        judge,
         model_id=model,
     )
     summary = summarize_briefings(

--- a/hub/agents/email/python/packaging/eval_drafting_report.py
+++ b/hub/agents/email/python/packaging/eval_drafting_report.py
@@ -14,7 +14,7 @@ thresholds inlined here. The manifest owns the enforce switch (data, not code).
 A judge credential is REQUIRED — the Claude judge cannot score drafts without
 one, and per CLAUDE.md's fail-loudly rule there is NO silent skip: its absence is
 a HARD FAILURE (exit 1), never a skip report and never an invented pass. Either
-``CLAUDE_CODE_OAUTH_TOKEN`` (preferred; driven through the ``claude`` CLI) or
+``CLAUDE_CODE_OAUTH_TOKEN`` (used when no API key is set; driven through the ``claude`` CLI) or
 ``ANTHROPIC_API_KEY`` will do — ``gaia.eval.judge_client`` owns the choice. The
 workflows that run this (release_agent_email.yml, test_email_agent_eval.yml,
 email_scorecard_refresh.yml) inject them from the matching secrets and never run
@@ -22,8 +22,8 @@ on fork PRs, so a credential is always present in a legitimate run.
 
 Config comes from the environment (shell-agnostic):
   EMAIL_EVAL_MODEL         Lemonade model id (required)
-  CLAUDE_CODE_OAUTH_TOKEN  Judge credential, preferred
-  ANTHROPIC_API_KEY        Judge credential, fallback (neither set -> exit 1)
+  CLAUDE_CODE_OAUTH_TOKEN  Judge credential when no API key is set
+  ANTHROPIC_API_KEY        Judge credential, takes precedence (neither set -> exit 1)
 
 Extracted verbatim from the former inline ``python - <<'PY'`` step so the eval
 can run on the Windows ``stx`` runner pool (PowerShell, no heredocs).
@@ -80,6 +80,8 @@ def main() -> int:
         )
         return 1
 
+    judge = make_claude_judge()
+
     # Generation: drives the #1607 voice-profile drafting path per case
     # (Lemonade — this job holds the serial lemonade-eval slot).
     generations = generate_drafts(model, corpus_path=CORPUS_PATH)
@@ -89,7 +91,7 @@ def main() -> int:
     results = judge_drafts(
         load_drafting_corpus(CORPUS_PATH),
         generations,
-        make_claude_judge(),
+        judge,
         model_id=model,
     )
     summary = summarize_drafting(

--- a/hub/agents/email/python/tests/test_eval_briefing_report.py
+++ b/hub/agents/email/python/tests/test_eval_briefing_report.py
@@ -223,3 +223,17 @@ def test_skipped_gate_variant_blocks_the_build(monkeypatch):
     _install_fakes(monkeypatch, summary)
 
     assert mod.main() == 1
+
+
+def test_missing_judge_transport_fails_before_generation(monkeypatch):
+    _set_model_env(monkeypatch)
+    generate = MagicMock()
+    monkeypatch.setattr(mod, "generate_briefings", generate)
+    monkeypatch.setattr(
+        mod,
+        "make_claude_judge",
+        MagicMock(side_effect=RuntimeError("claude CLI missing")),
+    )
+    with pytest.raises(RuntimeError, match="claude CLI missing"):
+        mod.main()
+    generate.assert_not_called()

--- a/hub/agents/email/python/tests/test_eval_drafting_report.py
+++ b/hub/agents/email/python/tests/test_eval_drafting_report.py
@@ -186,3 +186,17 @@ def test_skipped_gate_variant_returns_0(monkeypatch):
     _install_fakes(monkeypatch, summary)
 
     assert mod.main() == 0
+
+
+def test_missing_judge_transport_fails_before_generation(monkeypatch):
+    _set_model_env(monkeypatch)
+    generate = MagicMock()
+    monkeypatch.setattr(mod, "generate_drafts", generate)
+    monkeypatch.setattr(
+        mod,
+        "make_claude_judge",
+        MagicMock(side_effect=RuntimeError("claude CLI missing")),
+    )
+    with pytest.raises(RuntimeError, match="claude CLI missing"):
+        mod.main()
+    generate.assert_not_called()

--- a/src/gaia/eval/judge_client.py
+++ b/src/gaia/eval/judge_client.py
@@ -60,7 +60,7 @@ _JUDGE_SYSTEM_PROMPT = (
 #: Scoring must not become an agent loop. A name that no longer exists simply
 #: matches nothing, so a stale entry is harmless.
 _DISALLOWED_TOOLS = (
-    "Bash Read Write Edit Glob Grep WebFetch WebSearch Task TodoWrite NotebookEdit"
+    "Bash,Read,Write,Edit,Glob,Grep,WebFetch,WebSearch,Task,TodoWrite,NotebookEdit"
 )
 
 MISSING_CREDENTIAL_ERROR = (

--- a/tests/unit/test_eval_judge_client.py
+++ b/tests/unit/test_eval_judge_client.py
@@ -177,7 +177,8 @@ def test_get_completion_isolates_the_judge_context(monkeypatch, fake_claude_bin)
     assert "--strict-mcp-config" in cmd
     assert cmd[cmd.index("--mcp-config") + 1] == '{"mcpServers": {}}'
     assert "--no-session-persistence" in cmd
-    assert "Bash" in cmd[cmd.index("--disallowed-tools") + 1]
+    assert "Bash" in cmd[cmd.index("--disallowed-tools") + 1].split(",")
+    assert "Read" in cmd[cmd.index("--disallowed-tools") + 1].split(",")
     # Claude Code's agent prompt is replaced, not appended to.
     assert "evaluation judge" in cmd[cmd.index("--system-prompt") + 1]
     # A temp cwd is what keeps the repo's own CLAUDE.md out of the judge prompt.


### PR DESCRIPTION
Follow-up fixes for #3490. Changed: .github/workflows/{email_scorecard_refresh,test_email_agent_eval,release_agent_email}.yml; .gitignore; docs/plans/email-eval-node-frontend.mdx; hub/agents/email/npm/EVALUATION.md; hub/agents/email/python/packaging/eval_{action_item,briefing,drafting}_report.py; src/gaia/eval/judge_client.py; tests/unit/test_eval_judge_client.py; hub/agents/email/python/tests/test_eval_{drafting,briefing}_report.py. Exact changed path list is available from git diff.

This PR targets the original feature branch because the current account cannot push to `amd/gaia`. It carries the prepared maintenance changes for that PR.

## Test plan

- [x] Previously completed local validation: Validation: 43 tests passed covering judge selection, CLI invocation/error handling and all three report scripts (tests-3490.log). Exact live ClaudeCliClient transport using the existing authenticated Max subscription returned ['OK'] in about four seconds (3490-judge-probe.log). This proves actual tool flags/model/auth invocation works, not only mocked selection. All three workflow YAML files parse; Black/isort/Flake8/diff pass.
- [ ] Fresh CI on the combined feature branch.
- [ ] Remaining live-model, hardware or platform checks described in the original PR, where applicable.
- [ ] Human review before merging the original PR.
