### PR TITLE
fix(audio): clean scratch files and surface refinement errors

### DIFF
--- a/docs/guides/transcription.mdx
+++ b/docs/guides/transcription.mdx
@@ -84,7 +84,7 @@ appears in seconds is a summary of the opening minutes.
 
   <Step title="Start Lemonade Server">
     ```bash
-    lemonade-server serve
+    gaia init
     ```
 
     Transcription runs on the same local server as chat — `Whisper-Large-v3-Turbo`
@@ -158,6 +158,10 @@ Dan Okafor: Sure, from the platform side...
 Treat the *names* as best-effort — a confident-looking wrong name is
 possible — but not the voice split behind them: that part doesn't depend on
 what was said.
+
+If a model request for naming or consolidating speakers fails, refinement
+returns an error. Retry after restoring the model connection; anonymous labels
+are reserved for voices without naming evidence, not failed requests.
 
 If diarization can't run at all (see [First run](#first-run)), `refine_transcript`
 falls back to the old text-only method instead: turns are split on pauses in

--- a/docs/sdk/sdks/audio.mdx
+++ b/docs/sdk/sdks/audio.mdx
@@ -69,6 +69,8 @@ least confident about — not timestamps or speaker labels in the result itself.
 (see [Speaker Diarization](#speaker-diarization-who-spoke-when) below); a
 separate `refine_transcript` call then attaches real names to those voices,
 inferred from what's said, and writes the speaker-labelled transcript.
+If the naming or speaker-consolidation request fails, refinement returns an
+error so it can be retried; it does not report an incomplete result as success.
 </Note>
 
 ```python

--- a/src/gaia/agents/tools/audio_tools.py
+++ b/src/gaia/agents/tools/audio_tools.py
@@ -452,6 +452,8 @@ class AudioToolsMixin:
         output_path: Optional[str] = None,
     ) -> Dict:
         """Decode the file to WAV, transcribe it, and persist the transcript."""
+        from tempfile import TemporaryDirectory
+
         from gaia.agents.base.tools import ToolCancelled, raise_if_cancelled
         from gaia.audio.lemonade_asr import DEFAULT_ASR_MODEL, LemonadeASRClient
         from gaia.audio.media import ensure_ffmpeg, probe_duration, to_wav16k_mono
@@ -482,6 +484,7 @@ class AudioToolsMixin:
             return {"status": "error", "error": str(e)}
 
         wav_path = None
+        scratch = None
         saved_path = None
         try:
             media_seconds = probe_duration(source)
@@ -503,7 +506,12 @@ class AudioToolsMixin:
                     f"Decoding {source.name} — {pct:.0%} of {_clock(media_seconds)}"
                 )
 
-            wav_path = to_wav16k_mono(source, progress_callback=_decoding)
+            scratch = TemporaryDirectory(prefix="gaia-media-")
+            wav_path = to_wav16k_mono(
+                source,
+                dest=Path(scratch.name) / "audio.16k.wav",
+                progress_callback=_decoding,
+            )
 
             raise_if_cancelled()
             client = LemonadeASRClient(model=model or DEFAULT_ASR_MODEL)
@@ -583,6 +591,15 @@ class AudioToolsMixin:
                     logger.warning(
                         "Could not remove scratch WAV %s: %s",
                         wav_path,
+                        cleanup_error,
+                    )
+            if scratch is not None:
+                try:
+                    scratch.cleanup()
+                except OSError as cleanup_error:
+                    logger.warning(
+                        "Could not remove scratch directory %s: %s",
+                        scratch.name,
                         cleanup_error,
                     )
 
@@ -678,6 +695,11 @@ class AudioToolsMixin:
                         f"Identifying speakers — batch {index} of {len(batches)}"
                     )
                     named.extend(self._name_turns(batch, speaker_notes))
+            if acoustic_labels is None:
+                # Only the text-only path over-splits. Merging voices separated
+                # acoustically undoes real evidence.
+                self._report_progress("Consolidating speakers...")
+                named = self._consolidate_speakers(named)
         except ToolCancelled:
             logger.warning("Refinement of %s cancelled after timeout", source)
             raise
@@ -685,12 +707,6 @@ class AudioToolsMixin:
             logger.error("Refinement failed for %s: %s", source, e)
             return {"status": "error", "error": str(e)}
 
-        if acoustic_labels is None:
-            # Only the text-only path over-splits. Merging voices
-            # separated acoustically undoes real evidence — it
-            # collapsed four measured voices into two.
-            self._report_progress("Consolidating speakers...")
-            named = self._consolidate_speakers(named)
         blocks = [f"{name}: {text}" for name, text in _merge_adjacent(named)]
         speakers = list(dict.fromkeys(name for name, _ in named))
         destination.parent.mkdir(parents=True, exist_ok=True)
@@ -781,11 +797,7 @@ class AudioToolsMixin:
             "form `Label -> Name`, one per label, including labels that stay "
             "unchanged.\n\nVoices:\n" + sample
         )
-        try:
-            mapping = _parse_alias_map(self._llm_text(prompt), set(roster))
-        except Exception as e:  # noqa: BLE001 — anonymous labels still work
-            logger.info("Could not put names to voices (%s)", e)
-            return named
+        mapping = _parse_alias_map(self._llm_text(prompt), set(roster))
         # Never let naming merge two distinct voices into one person.
         collisions = {
             v for v in mapping.values() if list(mapping.values()).count(v) > 1
@@ -898,11 +910,7 @@ class AudioToolsMixin:
             "including labels that stay as they are. Use a real name as the "
             "final label when one is evident.\n\nLabels:\n" + sample
         )
-        try:
-            mapping = _parse_alias_map(self._llm_text(prompt), set(roster))
-        except Exception as e:  # noqa: BLE001 — consolidation is an improvement
-            logger.info("Speaker consolidation skipped (%s)", e)
-            return named
+        mapping = _parse_alias_map(self._llm_text(prompt), set(roster))
         if not mapping:
             return named
         return [(mapping.get(name, name), text) for name, text in named]

--- a/src/gaia/audio/lemonade_asr.py
+++ b/src/gaia/audio/lemonade_asr.py
@@ -625,9 +625,11 @@ class LemonadeASRClient:
         return self._decode(response, url, "transcription")
 
     def _unreachable(self, error: Exception) -> ConnectionError:
+        from gaia.llm.lemonade_launcher import describe_start_hint
+
         return ConnectionError(
             f"Lemonade Server is not reachable at {self.base_url} ({error}). "
-            "Start it with `lemonade-server serve`, run `gaia init` to install "
+            f"{describe_start_hint().instruction} Run `gaia init` to install "
             f"it, or set LEMONADE_BASE_URL to a running server. See {DOCS_URL}"
         )
 

--- a/tests/unit/test_audio_tools.py
+++ b/tests/unit/test_audio_tools.py
@@ -56,6 +56,19 @@ def _transcript() -> Transcript:
 
 
 class TestRegistration:
+    @pytest.mark.parametrize("method", ["_name_known_voices", "_consolidate_speakers"])
+    @pytest.mark.parametrize(
+        "failure", [ConnectionError("server down"), RuntimeError("empty reply")]
+    )
+    def test_speaker_processing_does_not_hide_infrastructure_failure(
+        self, method, failure
+    ):
+        host = Host()
+        turns = [("A", "first"), ("B", "second"), ("C", "third")]
+        with patch.object(host, "_llm_text", side_effect=failure):
+            with pytest.raises(type(failure), match=str(failure)):
+                getattr(host, method)(turns)
+
     def test_registered_in_known_tools(self):
         assert KNOWN_TOOLS["audio"] == (
             "gaia.agents.tools.audio_tools",
@@ -133,6 +146,33 @@ class TestSystemPromptAgreesWithTheToolset:
 
 
 class TestTranscribeMedia:
+    @pytest.mark.parametrize("fail_decode", [False, True])
+    def test_owned_scratch_directory_is_removed_on_failure(self, tmp_path, fail_decode):
+        source = tmp_path / "meeting.mp4"
+        source.write_bytes(b"source")
+        decoded = []
+
+        def decode(_source, *, dest, progress_callback):
+            decoded.append(dest)
+            dest.write_bytes(b"partial audio")
+            if fail_decode:
+                raise RuntimeError("decode failed")
+            return dest
+
+        with (
+            patch("gaia.audio.media.ensure_ffmpeg", return_value="ffmpeg"),
+            patch("gaia.audio.media.probe_duration", return_value=10),
+            patch("gaia.audio.media.to_wav16k_mono", side_effect=decode),
+            patch("gaia.audio.lemonade_asr.LemonadeASRClient") as client,
+        ):
+            client.return_value.transcribe.side_effect = ConnectionError("ASR down")
+            result = Host()._transcribe_media(str(source))
+
+        assert result["status"] == "error"
+        assert len(decoded) == 1
+        assert not decoded[0].parent.exists()
+        assert source.read_bytes() == b"source"
+
     def test_missing_file_is_actionable_and_does_no_work(self, tmp_path):
         """A bad path must not trigger an ffmpeg install or a model pull."""
         with patch("gaia.audio.media.ensure_ffmpeg") as ffmpeg:
@@ -354,6 +394,25 @@ class TestRefineTranscript:
             encoding="utf-8",
         )
         return raw
+
+    def test_consolidation_failure_returns_error_without_output(self, tmp_path):
+        raw = self._transcript_with_timings(
+            tmp_path, [{"start": 0.0, "end": 1.0, "text": "Hello"}]
+        )
+        destination = tmp_path / "refined.md"
+        host = Host()
+        with (
+            patch.object(host, "_name_turns", return_value=[("A", "Hello")]),
+            patch.object(
+                host,
+                "_consolidate_speakers",
+                side_effect=ConnectionError("server down"),
+            ),
+        ):
+            result = host._refine_transcript(str(raw), str(destination))
+        assert result == {"status": "error", "error": "server down"}
+        assert not destination.exists()
+        assert raw.exists()
 
     def test_missing_transcript_is_actionable(self, tmp_path):
         result = Host()._refine_transcript(str(tmp_path / "nope.txt"))

--- a/tests/unit/test_lemonade_asr.py
+++ b/tests/unit/test_lemonade_asr.py
@@ -1050,6 +1050,13 @@ class TestErrors:
     def test_unreachable_server_names_url_and_next_step(
         self, monkeypatch, client, wav_file
     ):
+        from types import SimpleNamespace
+
+        monkeypatch.setattr(
+            "gaia.llm.lemonade_launcher.describe_start_hint",
+            lambda: SimpleNamespace(instruction="Open the installed Lemonade app."),
+        )
+
         def refuse(_session, _request, **_kwargs):
             raise requests.ConnectionError("connection refused")
 
@@ -1059,7 +1066,8 @@ class TestErrors:
             client.transcribe(wav_file)
         message = str(excinfo.value)
         assert "http://localhost:13305/api/v1" in message
-        assert "lemonade-server serve" in message
+        assert "Open the installed Lemonade app." in message
+        assert "lemonade-server serve" not in message
         assert "gaia init" in message
 
     def test_timeout_suggests_a_bigger_timeout(self, monkeypatch, client, wav_file):


### PR DESCRIPTION
Failed transcription now cleans up its temporary audio without deleting the source, and speaker refinement reports model failures instead of returning incomplete work as success. This follows the already merged #3597 and also corrects the Lemonade startup guidance.

Compared with the open provider work in #3672: its audio edits change endpoint/auth resolution, while this patch changes cleanup and failure reporting.

## Test plan

- [x] `pytest tests/unit/test_audio_tools.py tests/unit/test_lemonade_asr.py -q`: 115 passed on current main; one existing live Lemonade test skipped because no server was available.
- [x] Black and isort checks on the four affected Python files; staged diff check.
- [x] Independent review of the maintenance patch before publication.
- [ ] Fresh CI, live transcription/refinement and human review.
