### PR TITLE
fix: apply reviewed maintenance repairs for #3390

### DIFF
--- a/hub/skills/coding/SKILL.md
+++ b/hub/skills/coding/SKILL.md
@@ -76,12 +76,15 @@ python -m pytest tests/unit          # same thing, same rules
 python util/lint.py --all --fix      # or whatever the project's own runner is
 ```
 
-`python <script.py>` runs any program already in the checkout — the project's
-lint runner, a build script, a reproduction you just wrote. What it will not do
-is run code passed on the command line: `python -c "..."` is refused, because
-that code is in no file anyone reviewed and it can reach straight past every
-other rule here. If you need to run something new, write it to a file first —
-then it is reviewable, re-runnable, and the diff shows it.
+Loading this skill grants `pytest` and `python <script.py>` execution without
+another prompt. Tests and scripts are trusted project code: they can write
+files, access the network, and launch other programs, including commands the
+direct CLI policy refuses. These grants do not sandbox their effects. The
+separate `execute_python_file` tool still requires per-call approval.
+
+`python -c "..."` is refused because the grant requires a reviewable file in the
+checkout. Write new code to a file first so the diff shows it, and review what
+it does before executing it.
 
 The rest of the grant is narrow on purpose. `--pdb` would hang waiting for a
 debugger nobody can answer, `-p <plugin>` imports arbitrary code, `--junitxml`
@@ -118,7 +121,7 @@ the user the exact command before running. That is not a formality to click
 past — write the commit message as if it is the only thing the reviewer reads,
 because for a squashed PR it is.
 
-What you cannot do, at all: `push`, `reset --hard`, `clean`, `rebase`,
+The direct Git policy refuses `push`, `reset --hard`, `clean`, `rebase`,
 `commit --amend`, `git config`. Publishing and history-rewriting are the user's
 to run, and destroying uncommitted work has no undo anywhere. When the work is
 committed and wants pushing, **say so and stop** — *"committed on `fix/discount`;

--- a/src/gaia/skills/binaries.py
+++ b/src/gaia/skills/binaries.py
@@ -45,8 +45,9 @@ is still deferred:
    alike, so an un-updated caller fails closed.
 4. **Read-only by construction — for CLIs that talk to something *external*.**
    ``pytest`` is a different class of grant and says so in its own summary: it
-   EXECUTES the project's own test code, the same trust boundary as the ungated
-   ``execute_python_file`` tool. What its table restricts is invocation shape
+   EXECUTES the project's own test code using consent from the loaded skill.
+   The separate ``execute_python_file`` tool still prompts. This table restricts
+   invocation shape
    (no plugin injection, no interactive hang, no writes/paths outside the
    checkout) — never what the tests themselves do. It has no CONFIRM tier.
 
@@ -695,18 +696,15 @@ _INTERACTIVE_HANG = (
 # ---------------------------------------------------------------------------
 #
 # `python <script.py>` is ALLOW, and that is the widest single decision in this
-# file. It is the `pytest` reasoning taken to its conclusion: running a Python
-# file that is already in the checkout is exactly what the ungated
-# `execute_python_file` tool does, so refusing the same act through `python`
-# would be a lock on a door standing next to an open one.
+# file. The loaded skill grant pre-authorizes execution of project scripts;
+# the separate `execute_python_file` tool still requires per-call confirmation.
+# A project script can perform arbitrary actions, including actions refused by
+# the CLI tables. This grant is consent to execution, not a sandbox.
 #
-# `python -c` is NOT that act, and is refused. Code passed on the command line
-# is not in the checkout, was never reviewed, and — this is the part that
-# matters — makes every other entry in this table decorative: `python -c
-# "subprocess.run(['git','push','--force'])"` is one opaque token to the gate
-# and a force-push to the operating system. The route to running new code is to
-# write the file (which the agent's write gate shows the user) and then run it.
-# `-i` and a bare `-` operand are the same hole with different spelling.
+# `python -c` is refused because the grant requires a reviewable file in the
+# checkout. It does not make file execution safer or prevent a trusted script
+# from launching other programs. Interactive mode and stdin programs are also
+# outside the grant's invocation contract.
 
 #: Every ``-m`` target must itself be policed, so ``-m`` cannot be the way
 #: around a policy: ``python -m pytest --pdb`` is refused because
@@ -1239,9 +1237,9 @@ BINARY_POLICIES: dict[str, BinaryPolicy] = {
         },
     ),
     # `pytest` is NOT a read-only grant in the sense `gh` is — it EXECUTES the
-    # project's own test code. That is the same trust boundary as the
-    # ungated `execute_python_file` tool (code already in the repo runs),
-    # not a new one. What this policy restricts is the invocation shape: no
+    # project's own test code with consent from the loaded skill. The separate
+    # execute_python_file tool requires per-call confirmation. This policy
+    # restricts invocation shape: no
     # plugin injection, no interactive hang, no write outside the run, no
     # pointing pytest at config/paths outside the checkout. It does not, and
     # cannot, sandbox what the tests themselves do.
@@ -1260,7 +1258,7 @@ BINARY_POLICIES: dict[str, BinaryPolicy] = {
         binary="pytest",
         summary=(
             "pytest — runs the project's own test suite. This EXECUTES "
-            "project code (the same class as execute_python_file), not a "
+            "project code under the loaded skill grant, not a "
             "read; the grant restricts flags and paths, never what a test "
             "itself does."
         ),
@@ -1552,10 +1550,9 @@ BINARY_POLICIES: dict[str, BinaryPolicy] = {
             binary=name,
             summary=(
                 f"{name} — runs a Python program that is already in this "
-                "checkout (the same trust boundary as execute_python_file). "
-                "Code passed on the command line with -c is refused: it is "
-                "unreviewed, and it would make every other command policy "
-                "here decorative."
+                "checkout without another prompt under the loaded skill grant. "
+                "Scripts are trusted code and can launch other programs. "
+                "The grant requires a reviewable file; -c is refused."
             ),
             install_hint=(
                 f"'{name}' is not on PATH. Activate the project's virtual "
@@ -2631,8 +2628,8 @@ def _classify_script_arguments(
     ``python util/lint.py --all --fix`` — ``--all`` is lint.py's flag, and this
     table has no opinion on another program's argument grammar. Nor does it
     need one: running an in-checkout script is the trust boundary the grant
-    already crossed (the same one ``execute_python_file`` crosses ungated), and
-    the script, not its flags, is the capability.
+    already crossed. ``execute_python_file`` separately requires confirmation;
+    this skill grant pre-authorizes scripts and does not sandbox their effects.
 
     What still holds is containment: no argument may point outside the
     checkout, so a granted script cannot be aimed at ``../../.ssh``.


### PR DESCRIPTION
Follow-up fixes for #3390. Corrected the repeated false claim that execute_python_file is ungated. Kept the PR's existing ALLOW behavior for granted project scripts, but made the decision explicit in code summaries and the coding skill: loading the skill pre-authorizes project code; the separate tool still prompts. Scripts/tests can launch other programs, so direct CLI refusals are not a sandbox guarantee. Corrected the related -c rationale and absolute claim that pushing is technically impossible.

This PR targets the original feature branch because the current account cannot push to `amd/gaia`. It carries the prepared maintenance changes for that PR.

## Test plan

- [x] Previously completed local validation: Validation: binary policy, shell guardrail, skill migration, and starter-skill suites: 758 passed, 12 existing not-applicable scratchpad-skill skips. Black, isort, and diff checks passed. No policy behavior changed.
- [ ] Fresh CI on the combined feature branch.
- [ ] Remaining live-model, hardware or platform checks described in the original PR, where applicable.
- [ ] Human review before merging the original PR.
