### PR TITLE
fix: apply reviewed maintenance repairs for #3375

### DIFF
--- a/src/gaia/eval/runner.py
+++ b/src/gaia/eval/runner.py
@@ -1088,7 +1088,10 @@ def run_scenario_subprocess(
                     "status": "ERRORED",
                     "overall_score": None,
                     "turns": [],
-                    "error": f"JSON parse error: {e}. stdout: {proc.stdout[:300]}",
+                    "error": (
+                        f"JSON parse error: {e}. stdout: {proc.stdout[:300]}"
+                        f"\nstderr: {proc.stderr[:300]}"
+                    ),
                     "elapsed_s": elapsed,
                     "cost_estimate": {"turns": 0, "estimated_usd": 0.0},
                 }
@@ -1101,6 +1104,7 @@ def run_scenario_subprocess(
             "status": "TIMEOUT",
             "overall_score": None,
             "turns": [],
+            "error": f"subprocess exceeded {timeout}s timeout",
             "elapsed_s": elapsed,
             "cost_estimate": {"turns": 0, "estimated_usd": 0.0},
         }

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1093,6 +1093,12 @@ class TestRunScenarioSubprocess:
         assert "on-stderr" in result["error"]
         assert "on-stdout" in result["error"]
 
+    def test_malformed_json_includes_stderr_diagnostic(self, mocker):
+        result = self._run(mocker, "{broken", stderr="Output stream interrupted")
+        assert result["status"] == "ERRORED"
+        assert "{broken" in result["error"]
+        assert "Output stream interrupted" in result["error"]
+
     def test_nonzero_exit_error_never_empty(self, mocker):
         """A silent exit must still say something — an empty string explains nothing."""
         result = self._run(mocker, "", returncode=3, stderr="")
@@ -2671,6 +2677,8 @@ class TestRunner:
         assert result["status"] == "TIMEOUT"
         assert result["overall_score"] is None
         assert result["scenario_id"] == "timeout_test"
+        assert "timeout" in result["error"]
+        assert "30s" in result["error"]
         assert "elapsed_s" in result
         assert isinstance(result["elapsed_s"], float)
 


### PR DESCRIPTION
Follow-up fixes for #3375. Persisted a specific timeout explanation in scenario results and included stderr alongside malformed JSON stdout. Added the stderr regression and strengthened the timeout assertion. The complete eval unit/integration-with-mocks suite passes: 144 tests.

This PR targets the original feature branch because the current account cannot push to `amd/gaia`. It carries the prepared maintenance changes for that PR.

## Test plan

- [x] Previously completed local validation: See affected regression tests in the diff.
- [ ] Fresh CI on the combined feature branch.
- [ ] Remaining live-model, hardware or platform checks described in the original PR, where applicable.
- [ ] Human review before merging the original PR.
