### PR TITLE
fix: apply reviewed maintenance repairs for #3372

### DIFF
--- a/.github/workflows/test_eval_agent_gemma_consolidation.yml
+++ b/.github/workflows/test_eval_agent_gemma_consolidation.yml
@@ -147,8 +147,8 @@ on:
   # their diff at all, ended up wearing a red X from an LLM-quality gate and
   # burning hours of the scarcest runner pool. `pull_request` filters on the
   # PR's own base..head diff, so the gate fires only when the PR itself edits a
-  # path below. `branches: [main]` and the `types:` list follow
-  # test_email_agent_eval.yml; `ready_for_review` is what runs the gate on a PR
+  # path below. The `types:` list follows test_email_agent_eval.yml;
+  # `ready_for_review` is what runs the gate on a PR
   # that was opened as a draft (see the draft clause in the job `if:`).
   #
   # THE PATH LIST BELOW IS UNCHANGED ON PURPOSE. This change is mechanism only:

--- a/tests/unit/test_check_workflow_triggers.py
+++ b/tests/unit/test_check_workflow_triggers.py
@@ -72,6 +72,17 @@ class TestAccepted:
 
 
 class TestRejected:
+    @pytest.mark.parametrize("event", ["pull_request", "pull_request_target"])
+    @pytest.mark.parametrize("key", ["branches", "branches-ignore"])
+    def test_all_pr_base_filters_are_rejected(self, workflow_dir, capsys, event, key):
+        _write(
+            workflow_dir,
+            "bad.yml",
+            f"on:\n  {event}:\n    {key}: [ main ]\njobs: {{}}\n",
+        )
+        assert check_workflow_triggers.run_check() == 1
+        assert f"on.{event}.{key}" in capsys.readouterr().err
+
     def test_inline_branches_filter(self, workflow_dir):
         _write(
             workflow_dir,

--- a/util/check_workflow_triggers.py
+++ b/util/check_workflow_triggers.py
@@ -1,7 +1,7 @@
 # Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-"""Reject `on.pull_request.branches:` filters in .github/workflows/*.yml.
+"""Reject base-branch filters on PR events in .github/workflows/*.yml.
 
 Per #2767, `on.pull_request.branches` matches the PR's BASE branch, not its head.
 `branches: [ main ]` therefore means "only when merging into main" — every stacked
@@ -10,7 +10,8 @@ job is never created. Nothing shows failed or skipped; the checks page is simply
 missing it. That is how #2599 merged email-agent code with zero email tests, zero
 unit tests and zero lint behind a green checks page.
 
-Use `paths:` to scope a workflow to the code it covers. Never `branches:`.
+This also applies to `pull_request_target` and `branches-ignore`. Use `paths:`
+to scope a workflow to the code it covers, rather than base-branch filters.
 
 Runs as part of `python util/lint.py --all`. Run directly with
 `python util/check_workflow_triggers.py`.
@@ -28,10 +29,12 @@ import yaml
 # convention in util/check_dependabot.py and util/check_doc_versions.py.
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+PR_EVENTS = ("pull_request", "pull_request_target")
+FILTER_KEYS = ("branches", "branches-ignore")
 
 
-def _pull_request_trigger(workflow: Any) -> Dict[str, Any] | None:
-    """Return the `on.pull_request` mapping, or None if there isn't one.
+def _pull_request_trigger(workflow: Any, event: str) -> Dict[str, Any] | None:
+    """Return the requested PR event mapping, or None if there isn't one.
 
     PyYAML resolves the bare `on:` key to the boolean True (YAML 1.1), so both
     spellings have to be probed.
@@ -41,7 +44,7 @@ def _pull_request_trigger(workflow: Any) -> Dict[str, Any] | None:
     triggers = workflow.get("on", workflow.get(True))
     if not isinstance(triggers, dict):
         return None
-    trigger = triggers.get("pull_request")
+    trigger = triggers.get(event)
     return trigger if isinstance(trigger, dict) else None
 
 
@@ -66,14 +69,18 @@ def run_check() -> int:
             continue
 
         checked += 1
-        trigger = _pull_request_trigger(workflow)
-        if trigger is not None and "branches" in trigger:
-            errors.append(
-                f"{path.name}: `on.pull_request.branches: "
-                f"{trigger['branches']}` filters on the PR's BASE branch, so this "
-                f"workflow never runs on a stacked PR. Drop the filter; scope the "
-                f"workflow with `paths:` instead (#2767)."
-            )
+        for event in PR_EVENTS:
+            trigger = _pull_request_trigger(workflow, event)
+            if trigger is None:
+                continue
+            for key in FILTER_KEYS:
+                if key in trigger:
+                    errors.append(
+                        f"{path.name}: `on.{event}.{key}: {trigger[key]}` "
+                        f"filters on the PR's BASE branch, so this workflow can "
+                        f"skip stacked PRs. Drop the filter; scope the workflow "
+                        f"with `paths:` instead (#2767)."
+                    )
 
     if errors:
         print("[!] Workflow trigger issues found:", file=sys.stderr)


### PR DESCRIPTION
Follow-up fixes for #3372. Extended the workflow trigger guard to cover pull_request_target as well as pull_request, and both branches and branches-ignore. Added four combinations of regression coverage and corrected a stale workflow comment. Existing push/path filters are untouched by these maintenance changes.

This PR targets the original feature branch because the current account cannot push to `amd/gaia`. It carries the prepared maintenance changes for that PR.

## Test plan

- [x] Previously completed local validation: Validation: 16 tests passed; the actual checker passed across all 72 workflows. The PR already has a documented live stacked-PR A/B showing the missing CI jobs appear with its change. Existing red Gemma/email evals require infrastructure recovery/reruns.
- [ ] Fresh CI on the combined feature branch.
- [ ] Remaining live-model, hardware or platform checks described in the original PR, where applicable.
- [ ] Human review before merging the original PR.
