### PR TITLE
fix: apply reviewed maintenance repairs for #3336

### DIFF
--- a/hub/agents/gaia/python/packaging/smoke_test.py
+++ b/hub/agents/gaia/python/packaging/smoke_test.py
@@ -335,6 +335,7 @@ def check_startup_ping(event: dict) -> None:
             f"to name: {event}"
         )
     backend = event.get("model_backend")
+    # Keep aligned with gaia_agent.stdio's startup-ping backend contract.
     if backend not in ("lemonade", "claude"):
         raise StdioContractBreak(
             f"the startup ping's model_backend is {backend!r}, expected "

--- a/tests/unit/installer/test_install_scripts_terminal_hub.py
+++ b/tests/unit/installer/test_install_scripts_terminal_hub.py
@@ -665,7 +665,7 @@ def test_the_agent_artifact_is_the_stdio_build(sh_text, ps1_text, script):
         for line in text.splitlines()
         if not line.lstrip().startswith("#") and line.strip()
     )
-    for wrong in ('"gaia-agent-${platform}"', '"gaia-agent-$lockPlatform.exe"'):
+    for wrong in ("gaia-agent-${platform}", "gaia-agent-$lockPlatform.exe"):
         assert wrong not in code, f"install.{script} asks for the REST sidecar"
 
 


### PR DESCRIPTION
Follow-up fixes for #3336. Review nits addressed locally: smoke-test backend allowlist now points maintainers at the stdio startup-ping contract; wrong-transport installer guards no longer depend on double-quote style.

This PR targets the original feature branch because the current account cannot push to `amd/gaia`. It carries the prepared maintenance changes for that PR.

## Test plan

- [x] Previously completed local validation: Validation: `tests/unit/test_fetch_sidecar.py tests/unit/installer/test_install_scripts_terminal_hub.py hub/agents/gaia/python/tests/test_gen_binaries_lock.py` — 76 passed, 16 existing skips (POSIX-only bootstrap tests / unavailable optional artifact environment). Source changes limited to a comment and quote-independent guards.
- [ ] Fresh CI on the combined feature branch.
- [ ] Remaining live-model, hardware or platform checks described in the original PR, where applicable.
- [ ] Human review before merging the original PR.
