### PR TITLE
fix: apply reviewed maintenance repairs for #3122

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -2641,6 +2641,8 @@ contract; every route needs `Authorization: Bearer <token>` from
 | Route | Purpose |
 |-------|---------|
 | `GET /daemon/v1/status` | pid / port / uptime / API version |
+| `POST /daemon/v1/lemonade/start` | Start or attach the local model server; returns 503 with actionable detail on refusal. Host API ≥ 1.2 |
+| `GET /daemon/v1/lemonade/status` | Whether this daemon supervises a server, its PID, and its log path. Host API ≥ 1.2 |
 | `POST /daemon/v1/shutdown` | graceful drain + exit |
 | `GET /daemon/v1/agents` | registered sidecars — never the bearer token |
 | `POST /daemon/v1/agents/{id}/ensure` | spawn-or-attach; the body carries the sidecar token |
@@ -2787,20 +2789,15 @@ one-shot over the daemon transport (the agents the background service supervises
 runs the same readiness check the interactive launch's gate runs — background
 service, sidecar, local model server, model, and for email the mailbox — and if
 one of them is not ready it prints that row and its remedy to stderr and exits
-non-zero. Against an unreachable dependency that is about a second; the ceiling
-is the time it takes to start the sidecar. Nothing is sent to the agent, and the
+non-zero. A stopped local model server is started through the daemon before
+readiness is decided; this cold-start check can take up to 210 seconds after
+sidecar setup. Nothing is sent to the agent until it is ready, and the
 gate screen is never rendered: a script has nobody to press a key. The flagship
 runs as a local subprocess and is checked the same way, just with its own
 three-row gate (agent binary, Lemonade, models) instead of the daemon's five.
 
-```bash
-$ gaia tui run email --query "triage my inbox"   # with the model server down
-❌ Email is not ready — Local AI: not running at http://localhost:8000/api/v1
-   GAIA needs a local model server. It runs on your machine; no message text ever leaves it.
-…
-        run: <the start command resolved for this machine>
-$ echo $?   # 1, after about a second
-```
+If startup fails, stderr names the failing readiness row, the recovery action,
+and the relevant log. A stopped server alone is no longer an immediate refusal.
 
 The turn itself is bounded — 15 minutes by default, `--timeout 90s` / `--timeout
 2h` to change it — so an agent that accepts the query and then stops answering is

--- a/hub/agents/email/python/tests/test_query_route.py
+++ b/hub/agents/email/python/tests/test_query_route.py
@@ -475,7 +475,7 @@ def _assert_actionable_lemonade_detail(detail: str) -> None:
     # command: the manual fallback is resolved per machine (CLAUDE.md — never
     # hardcode how Lemonade is started), so pinning a literal here is how a
     # command that exists on no modern install stayed asserted-as-real.
-    assert any(c in lower for c in ("gaia daemon start", "gaia init", "lemonade"))
+    assert any(c in lower for c in ("gaia daemon start", "gaia init"))
     assert "amd-gaia.ai/docs/guides/email" in lower  # where to look
 
 

--- a/tests/unit/test_lemonade_supervisor.py
+++ b/tests/unit/test_lemonade_supervisor.py
@@ -509,15 +509,14 @@ def test_a_real_spawn_inherits_the_parent_environment_and_carries_the_ctx_window
     argv, so a spawn that dropped it would come up health-green and then fail
     every long request.
     """
-    import shutil
     import sys
 
     # Named so resolve_lemonade classifies the override as MODERN — the form
-    # whose ctx_size rides in the environment. The binary is just a Python
-    # interpreter; only the env is under test, so the argv is redirected to the
-    # probe script below while spec.env is left exactly as the launcher built it.
+    # whose ctx_size rides in the environment. The placeholder exercises real
+    # resolution; argv then uses this environment's Python to run the probe,
+    # while spec.env is left exactly as the launcher built it.
     fake_server = tmp_path / ("lemonade.exe" if os.name == "nt" else "lemond")
-    shutil.copy(sys.executable, fake_server)
+    fake_server.touch()
 
     out = tmp_path / "child-env.txt"
     probe = tmp_path / "probe.py"
@@ -536,7 +535,8 @@ def test_a_real_spawn_inherits_the_parent_environment_and_carries_the_ctx_window
             "the launcher did not put the context window in the environment, so "
             "this test would pass for the wrong reason"
         )
-        spec.argv[1:] = [str(probe), str(out)]
+        # A copied Windows venv launcher cannot locate its Python installation.
+        spec.argv[:] = [sys.executable, str(probe), str(out)]
         return spec
 
     monkeypatch.setattr(sup, "build_start_command", redirect_argv_keep_env)

--- a/tui/internal/ui/oneshot.go
+++ b/tui/internal/ui/oneshot.go
@@ -500,9 +500,9 @@ const (
 	// refuse a cold start the hub completes on the same machine.
 	readinessEnsureTimeout = 15 * time.Minute
 	// readinessCheckTimeout bounds the readiness probe. Same value as the gate's
-	// checkTimeout, over the same call — two paths asking the same question must
+	// CheckTimeout, over the same call — two paths asking the same question must
 	// not disagree about how long the answer may take.
-	readinessCheckTimeout = 90 * time.Second
+	readinessCheckTimeout = preflight.CheckTimeout
 	// DefaultOneShotTimeout bounds one whole non-interactive turn. The relay
 	// reads with a 300s idle timeout per chunk and an agent loop can take several
 	// steps, so this sits well above a healthy-but-slow run — including one whose

--- a/tui/internal/ui/preflight/autostart_test.go
+++ b/tui/internal/ui/preflight/autostart_test.go
@@ -280,8 +280,8 @@ func TestTheStartCallOutlastsTheDaemonsOwnStartBudget(t *testing.T) {
 	}
 	// The gate's overall deadline has to cover the call it makes, or the same
 	// abort happens one level up.
-	if checkTimeout <= lemonadeStartHeaderTimeout {
+	if CheckTimeout <= lemonadeStartHeaderTimeout {
 		t.Errorf("checkTimeout %s does not cover the start call's %s",
-			checkTimeout, lemonadeStartHeaderTimeout)
+			CheckTimeout, lemonadeStartHeaderTimeout)
 	}
 }

--- a/tui/internal/ui/preflight/model.go
+++ b/tui/internal/ui/preflight/model.go
@@ -28,14 +28,14 @@ type ConnectMailboxMsg struct {
 // Timeouts for the work the screen kicks off. Each is bounded so a wedged
 // daemon or sidecar surfaces as an actionable row instead of a frozen screen.
 const (
-	// checkTimeout has to cover the one thing the walk DOES rather than merely
+	// CheckTimeout has to cover the one thing the walk DOES rather than merely
 	// probes: starting the local model server when it is down (checkInit ->
 	// autoStartLemonade). The starter's own budget is 120s
 	// (lemonade_supervisor.DEFAULT_START_TIMEOUT_S), so a client deadline under
 	// that would abort a start that was about to succeed and then report the
 	// wrong cause. It costs the common path nothing — a deadline is a ceiling,
 	// and an all-green walk still finishes in well under a second.
-	checkTimeout     = 210 * time.Second
+	CheckTimeout     = 210 * time.Second
 	startTimeout     = 60 * time.Second
 	ensureTimeout    = 15 * time.Minute
 	provisionTimeout = 60 * time.Minute
@@ -259,7 +259,7 @@ func (m Model) begin(timeout time.Duration) context.Context {
 }
 
 func (m Model) checkCmd() tea.Cmd {
-	ctx := m.begin(checkTimeout)
+	ctx := m.begin(CheckTimeout)
 	r, cfg := m.r, m.cfg
 	return func() tea.Msg { return reportMsg{rep: r.Check(ctx, cfg)} }
 }


### PR DESCRIPTION
Follow-up fixes for #3122. Unified one-shot and interactive readiness deadlines at 210 seconds, matching the intended cold-start window. Strengthened the email test to demand an actionable startup command. Updated CLI docs to describe the real daemon API and wait behavior. Corrected the existing child-environment test on Windows: copying a venv Python launcher loses its installation, so the test resolves a placeholder Lemonade binary but launches the real interpreter with the actual generated environment.

This PR targets the original feature branch because the current account cannot push to `amd/gaia`. It carries the prepared maintenance changes for that PR.

## Test plan

- [x] Previously completed local validation: Validation: both full affected Go packages (internal/ui/preflight and internal/ui) passed; four affected Python suites 43 passed; targeted email startup tests 3 passed. Black, isort, Flake8 with repository settings, and diff checks passed.
- [ ] Fresh CI on the combined feature branch.
- [ ] Remaining live-model, hardware or platform checks described in the original PR, where applicable.
- [ ] Human review before merging the original PR.
