### PR TITLE
fix: apply reviewed maintenance repairs for #3073

### DIFF
--- a/hub/agents/gaia/python/tests/test_sd_tools_do_not_rewrite_the_prompt.py
+++ b/hub/agents/gaia/python/tests/test_sd_tools_do_not_rewrite_the_prompt.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import contextlib
 
+import numpy as np
 import pytest
 from gaia_agent.agent import GaiaAgent, GaiaAgentConfig
 
@@ -38,7 +39,7 @@ def _isolated_registry():
 
 
 @pytest.fixture(scope="module")
-def flagship():
+def flagship(tmp_path_factory):
     """The built agent, plus a SNAPSHOT of the registry it was built with.
 
     ``select`` scores against whatever registry it is handed, and sibling test
@@ -49,25 +50,28 @@ def flagship():
     """
     with _isolated_registry(), pytest.MonkeyPatch.context() as mp:
         mp.setenv("GAIA_MEMORY_DISABLED", "1")
+        mp.setattr("gaia.config.GAIA_CONFIG_DIR", tmp_path_factory.mktemp("sd-output"))
         agent = GaiaAgent(config=GaiaAgentConfig(silent_mode=True))
         agent._registry_snapshot = dict(agent._tools_registry)
         yield agent
 
 
 def _select_fresh(agent, query):
-    """First-turn selection for ``query``, independent of test order.
+    """Pin bundle admission with deterministic scores; live scoring needs an eval."""
 
-    Skips when the embedder is unreachable: scoring a real query against real
-    tool descriptions needs live embeddings, and a plain CI runner has no
-    Lemonade. Keyed off the loader's own ``session_disabled`` flag rather than
-    a bare ``None``, so a genuine selection regression still fails here.
-    """
+    def embed(text):
+        is_image = text.split(":", 1)[0] in SD_TOOLS or text.startswith(
+            ("draw me a picture", "generate an image")
+        )
+        return np.array([1.0, 0.0] if is_image else [0.0, 1.0], dtype=np.float32)
+
     agent.tool_loader.reset_session()
-    selected = agent.tool_loader.select(query, agent._registry_snapshot)
-    if selected is None:
-        if agent.tool_loader.session_disabled:
-            pytest.skip("semantic tool selection needs a reachable embedder")
-        pytest.fail("select() returned None with the session still enabled")
+    agent.tool_loader._embed_cache.clear()
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(agent.tool_loader, "_embed_fn", embed)
+        mp.setattr(agent.tool_loader, "_embed_batch_fn", None)
+        selected = agent.tool_loader.select(query, agent._registry_snapshot)
+    assert selected is not None
     return selected
 
 

--- a/hub/skills/image-gen/SKILL.md
+++ b/hub/skills/image-gen/SKILL.md
@@ -71,12 +71,12 @@ user explicitly wants photorealism and has accepted the wait.
 
 ## Iterate instead of starting over
 
-`get_generation_history()` returns this session's generations with the exact
-prompt, model, size and seed of each. When the user says "same but at sunset"
-or "make it wider", read the previous entry, change the one thing they asked
-about, and keep everything else — including the `seed`. Reusing the seed is
-what makes the second image recognisably the same picture rather than an
-unrelated one that happens to match the words.
+`get_generation_history()` returns this session's prompts, models, sizes and
+requested seeds. When the user says "same but at sunset" or "make it wider",
+read the previous entry and keep the unchanged settings. Reuse a concrete
+`seed` when the entry has one. A null seed means the server chose it without
+reporting it, so the next generation can differ substantially; explain that
+limitation instead of promising the same image with a small edit.
 
 Rewriting the prompt from scratch throws away everything that was already
 working, and the user has to re-explain the parts they liked.
@@ -95,9 +95,10 @@ The common failures and what to say:
 
 - **Cannot reach Lemonade Server** — inference is not running. Tell them to
   start it; nothing here works until it is up.
-- **Timed out** — usually the first use of a model, downloading several GB.
-  The server is fine. Tell them to pre-fetch it (`lemonade-server pull
-  <model>`) and retry, rather than restarting anything.
+- **Timed out** — first use may be downloading several GB; a connection timeout
+  can also mean the server is unreachable. Follow the tool's actual diagnostic
+  and installation-aware remedy command. Do not invent a legacy CLI command or
+  claim the server is healthy when no connection was established.
 - **Invalid model or size** — you passed something outside the supported set.
   Call `list_sd_models()` and pick from what it returned.
 

--- a/src/gaia/sd/mixin.py
+++ b/src/gaia/sd/mixin.py
@@ -444,10 +444,16 @@ class SDToolsMixin:
         raw = str(error)
         lowered = raw.lower()
 
+        if "connect timeout" in lowered or "connecttimeout" in lowered:
+            return (
+                f"Timed out connecting to Lemonade Server for {model}. "
+                "Check the server address and network connection, and verify "
+                f"Lemonade is running ({describe_start_hint().instruction}). ({raw})"
+            )
         if "timed out" in lowered or "timeout" in lowered:
             return (
-                f"Timed out waiting for {model}; the server is running but did "
-                "not answer in time. First use of an SD model both downloads "
+                f"Timed out waiting for {model}; the server did not answer in "
+                "time. First use of an SD model both downloads "
                 "and loads several GB. Pre-fetch it "
                 f"({describe_client_hint('pull', model).instruction}), confirm "
                 f"it loads ({describe_client_hint('load', model).instruction}), "

--- a/tests/unit/test_profilespec_characterization.py
+++ b/tests/unit/test_profilespec_characterization.py
@@ -56,6 +56,13 @@ FIXTURE_DIR = (
 _PROFILES_WITHOUT_VLM = frozenset({"chat"})
 
 
+class _FixtureHome(type(Path())):
+    """Keep the fixed Linux prompt's home spelling on Windows hosts too."""
+
+    def __str__(self):
+        return super().__str__().replace("\\", "/")
+
+
 @contextlib.contextmanager
 def chat_agent_build_context(
     profile: str,
@@ -109,6 +116,8 @@ def chat_agent_build_context(
 
         with _isolated_registry():
             stack = contextlib.ExitStack()
+            if enable_sd_tools and cwd is not None:
+                stack.enter_context(patch("gaia.config.GAIA_CONFIG_DIR", cwd))
             stack.enter_context(
                 patch("gaia.agents.base.agent.Agent.__init__", return_value=None)
             )
@@ -125,7 +134,7 @@ def chat_agent_build_context(
             )
             stack.enter_context(patch("platform.machine", return_value="x86_64"))
             stack.enter_context(
-                patch.object(Path, "home", return_value=Path("/fake/home"))
+                patch.object(Path, "home", return_value=_FixtureHome("/fake/home"))
             )
             with stack:
                 agent = ChatAgent.__new__(ChatAgent)
@@ -264,8 +273,7 @@ def test_profile_prompt_and_tools_match_golden(row_id, kwargs, tmp_path):
     """
     build_kwargs = dict(kwargs)
     if build_kwargs.get("enable_sd_tools"):
-        # init_sd() mkdir's a *relative* ".gaia/cache/sd/images" — redirect
-        # into a throwaway dir so this test never litters the real worktree.
+        # Redirect both the working directory and SD's absolute config root.
         build_kwargs["cwd"] = tmp_path
 
     prompt, tools = build_agent_for_row(**build_kwargs)

--- a/tests/unit/test_sd_error_messages.py
+++ b/tests/unit/test_sd_error_messages.py
@@ -64,6 +64,15 @@ def test_a_refused_connection_says_the_server_is_not_running(modern_linux):
     assert "timed out" not in message.lower()
 
 
+def test_connect_timeout_does_not_claim_the_server_is_running(modern_linux):
+    error = LemonadeClientError("Connection to host timed out. (connect timeout=5)")
+    message = SDToolsMixin._describe_client_error(error, model="SDXL-Turbo")
+    assert "Timed out connecting" in message
+    assert "server is running" not in message
+    assert "network connection" in message
+    assert str(error) in message
+
+
 def test_the_remedies_never_name_a_binary_a_modern_install_lacks(modern_linux):
     """`lemonade-server` was removed in Lemonade 10.7 — pointing a user at it
     is advice that fails at the shell. Both branches must route through the


### PR DESCRIPTION
Follow-up fixes for #3073. Fixed connection-timeout diagnostics to distinguish unreachable servers from slow generation without claiming the server is healthy. Image skill instructions now use installation-aware diagnostics and explain that a null server-selected seed cannot reproduce an image. Flagship image tests use isolated config directories and deterministic embedding scores so bundle-admission checks cannot silently skip for a missing live embedder; live semantic ranking remains an eval responsibility.

This PR targets the original feature branch because the current account cannot push to `amd/gaia`. It carries the prepared maintenance changes for that PR.

## Test plan

- [x] Previously completed local validation: Validation: all 31 image-error, flagship prompt/selection, and profile characterization tests passed, with no skips. Applied the independently reviewed Windows fixture-home representation fix from #3602; all golden prompts pass unchanged. Black, isort and diff checks passed. No live image generation or model-ranking eval was run.
- [ ] Fresh CI on the combined feature branch.
- [ ] Remaining live-model, hardware or platform checks described in the original PR, where applicable.
- [ ] Human review before merging the original PR.
