### PR TITLE
feat(slack): drive the flagship agent from Slack, set up in the TUI

### DIFF
--- a/.security-suppressions.json
+++ b/.security-suppressions.json
@@ -1,14 +1,35 @@
 {
-  "_comment": "Approved security suppressions. Every '# noqa: S<n>' (flake8-bandit) and '# nosec' (bandit) comment in src/ or hub/ MUST be listed here with a justification, or CI fails (util/check_security_gates.py, run by util/lint.py). Adding an entry requires PR review — this is the gate that would have caught the GAIA hub tar-slip (CWE-22), where a '# noqa: S202 - hub artifacts are trusted' silenced an unvalidated tarfile.extractall. Keyed by (path, rule), not line number. See SECURITY.md.",
+  "_comment": "Approved security suppressions. Every '# noqa: S<n>' (flake8-bandit) and '# nosec' (bandit) comment in src/ or hub/ MUST be listed here with a justification, or CI fails (util/check_security_gates.py, run by util/lint.py). Adding an entry requires PR review \u2014 this is the gate that would have caught the GAIA hub tar-slip (CWE-22), where a '# noqa: S202 - hub artifacts are trusted' silenced an unvalidated tarfile.extractall. Keyed by (path, rule), not line number. See SECURITY.md.",
   "suppressions": [
-    {"path": "src/gaia/eval/scorecard_gate.py", "rule": "S603", "justification": "git is a fixed, trusted executable; args are a constructed list, never shell-interpreted"},
-    {"path": "src/gaia/hub/installer.py", "rule": "S603", "justification": "'uv pip install' args are a constructed list (no user string), never shell-interpreted"},
-    {"path": "src/gaia/hub/native_launcher.py", "rule": "S603", "justification": "native binary path is an installed hub artifact (operator-controlled); args are constructed, not shell"},
-    {"path": "src/gaia/mcp/mcp_bridge.py", "rule": "B104", "justification": "binds 0.0.0.0 only on explicit caller opt-in (documented flag), never by default"},
     {
       "path": "src/gaia/agents/tools/shell_tools.py",
       "rule": "B602",
       "justification": "Sandboxed shell tool. Every command (and each pipeline segment) is validated against a whitelist via _validate_command before execution; shell=True is enabled ONLY on Windows so cmd.exe can resolve built-ins (dir/cd/type) and pipes that Git-for-Windows tools rely on. Converting to args-list would break piped/whitelisted commands the tool exists to run."
+    },
+    {
+      "path": "src/gaia/eval/scorecard_gate.py",
+      "rule": "S603",
+      "justification": "git is a fixed, trusted executable; args are a constructed list, never shell-interpreted"
+    },
+    {
+      "path": "src/gaia/hub/installer.py",
+      "rule": "S603",
+      "justification": "'uv pip install' args are a constructed list (no user string), never shell-interpreted"
+    },
+    {
+      "path": "src/gaia/hub/native_launcher.py",
+      "rule": "S603",
+      "justification": "native binary path is an installed hub artifact (operator-controlled); args are constructed, not shell"
+    },
+    {
+      "path": "src/gaia/mcp/mcp_bridge.py",
+      "rule": "B104",
+      "justification": "binds 0.0.0.0 only on explicit caller opt-in (documented flag), never by default"
+    },
+    {
+      "path": "src/gaia/messaging/bridge.py",
+      "rule": "S603",
+      "justification": "The agent child's argv is built from a constant default (DEFAULT_AGENT_BINARY) or an operator's --agent-command, split with shlex; a Slack message's text never reaches it. shell=False, so nothing in argv is shell-interpreted."
     }
   ]
 }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -103,6 +103,7 @@
                     "pages": [
                       "guides/email",
                       "guides/email-integration",
+                      "guides/slack",
                       "guides/telegram-adapter"
                     ]
                   },
@@ -401,6 +402,7 @@
               "plans/email-calendar-integration",
               "plans/email-triage-agent",
               "plans/messaging-integrations-plan",
+              "plans/slack-tui-integration",
               "plans/autonomy-engine"
             ]
           },

--- a/docs/guides/slack.mdx
+++ b/docs/guides/slack.mdx
@@ -1,0 +1,156 @@
+---
+title: "Slack"
+description: "Drive the flagship GAIA agent from a Slack DM — set it up from the terminal in about ninety seconds."
+icon: "slack"
+---
+
+<Info>
+  **First time here?** Complete the [Setup](/setup) guide first to install GAIA and its dependencies.
+</Info>
+
+Message GAIA from Slack on your phone and it answers from your desktop — reading your
+files, searching your documents, and sending results back as Slack uploads. The agent runs
+locally the whole time; Slack carries the conversation, not the work.
+
+<Warning>
+  **This bridge drives the real agent, not a chat-only session.** Unlike the
+  [Telegram adapter](/guides/telegram-adapter) — where a message reaches a session with no
+  tool loop at all — a Slack message reaches the flagship agent's full tool surface.
+
+  Shell commands, file writes, and code execution **pause and ask you first**: they arrive
+  in Slack as Allow / Deny buttons, and nothing runs until you press one. **Reading does
+  not ask.** Anyone on the allowlist can read the files the agent can read — your home
+  directory, by default — and your indexed documents. Put only yourself on the allowlist
+  unless you mean otherwise.
+</Warning>
+
+## Why Socket Mode
+
+The bridge connects *outward* over a WebSocket. There is no inbound port, no public URL,
+no tunnel, and no request-signing secret that could leak — which is what makes it safe to
+run on a laptop behind a home router.
+
+## Setup
+
+Slack apps can only be created from api.slack.com, so this is not fully automatic. GAIA
+fills in the manifest; you paste two tokens back.
+
+```bash
+gaia slack setup
+```
+
+That opens Slack's create-app page with the scopes, Socket Mode, and the DM event
+subscription already filled in. Then:
+
+1. Pick your workspace and click **Create**.
+2. Under **Basic Information → App-Level Tokens**, click Generate, add the
+   `connections:write` scope, and copy the `xapp-` token.
+3. Under **OAuth & Permissions**, click **Install to Workspace**, then copy the `xoxb-`
+   Bot User OAuth Token.
+4. Paste both back into the terminal.
+
+Tokens are validated against Slack and stored in your OS keyring — never in a config file.
+
+### Start it
+
+```bash
+gaia slack start --allowed-users U024BE7LH
+```
+
+Find your member ID in Slack: your avatar → **Profile** → the `...` menu → **Copy member
+ID**. A display name or an email address will not work.
+
+The bridge **refuses to start without an allowlist**. Every member of a workspace can DM a
+bot, so an empty list would offer your local agent to all of them.
+
+## What the scopes are for
+
+| Scope | Why |
+|---|---|
+| `chat:write` | Post the reply and edit it as tokens stream in |
+| `im:history` | Read the DMs addressed to the bot |
+| `im:write` | Open a DM to reach you |
+| `files:read` | Download a document or image you share, for indexing |
+| `files:write` | Send back a file the agent produced |
+| `users:read` | Show the allowlist in names rather than raw IDs |
+
+No channel scopes are requested. The app subscribes to `message.im` and nothing else.
+
+## Using it
+
+Send a direct message. The reply streams in place, and a line underneath names the tools
+that ran.
+
+- **Share a file** and it is indexed — documents into RAG, images through the vision model
+  — so you can ask about it in the same conversation.
+- **Ask for a file back** and anything the agent writes under an upload root (your home
+  directory by default) is uploaded to the thread.
+- **A message sent mid-answer is queued**, not dropped. The agent handles one turn at a
+  time, and you are told where you are in line.
+
+### Approving a tool
+
+When the agent wants to run a command or write a file, the turn pauses and Slack shows the
+action with **Allow**, **Deny**, and sometimes **Always allow**. Nothing runs until you
+choose. Only people on the allowlist can press the buttons — someone else viewing the
+conversation cannot approve a command on your machine.
+
+**Always allow** appears only when the agent offers a specific scope to grant. When it
+does not, that call has no boundary narrow enough to grant standing permission to, so only
+one-time Allow is offered.
+
+To run the bridge with no tool access at all:
+
+```bash
+gaia slack start --allowed-users U024BE7LH --deny-gated-tools
+```
+
+Every gated tool is then refused outright rather than offered, and Slack becomes a
+read-only window onto your documents.
+
+## Commands
+
+| Command | What it does |
+|---|---|
+| `gaia slack setup` | Create the Slack app and store its tokens |
+| `gaia slack start --allowed-users <ids>` | Run the bridge (blocks until Ctrl-C) |
+| `gaia slack stop` | Stop a bridge started with `--background` |
+| `gaia slack status` | Show detection, configuration, and liveness |
+
+Useful flags on `start`:
+
+- `--deny-gated-tools` — refuse every tool that would ask, instead of offering buttons.
+- `--upload-root PATH` — restrict where a file may be uploaded from (repeatable).
+- `--agent-command` — point at a specific agent build instead of `gaia-agent` on PATH.
+- `--background` — write a PID file so `gaia slack stop` can find the process.
+
+Tokens can also come from `GAIA_SLACK_BOT_TOKEN` and `GAIA_SLACK_APP_TOKEN`, which take
+precedence over the keyring — that is how a container supplies them with no keyring at all.
+
+## Troubleshooting
+
+**"no allowed-users configured"** — expected. Pass `--allowed-users` with your member ID.
+
+**"Slack rejected the bot token"** — the two tokens are easy to swap. The `xoxb-` one goes
+in the bot field, the `xapp-` one in the app-level field.
+
+**Nothing happens when I DM the bot** — the bridge answers direct messages only. In a
+channel it stays silent by design.
+
+**The buttons do nothing** — interactivity must be enabled on the app. The generated
+manifest turns it on; an app created by hand may not have it.
+
+**`slack-sdk is required`** — install the extra:
+
+```bash
+pip install "amd-gaia[slack]"
+```
+
+## Limits
+
+- One conversation at a time. The agent processes one turn at a time, so a second message
+  waits rather than running in parallel.
+- Direct messages only. Channels and `@mentions` need their own threat model and are not
+  supported yet.
+- Uploads are capped at 25 MB, downloads at 100 MB, and a reply longer than Slack's
+  message limit is truncated with a note.

--- a/docs/plans/slack-tui-integration.mdx
+++ b/docs/plans/slack-tui-integration.mdx
@@ -1,0 +1,292 @@
+---
+title: "Slack via the TUI"
+description: "Drive the flagship GAIA agent from Slack, set up from the terminal UI in about ninety seconds"
+icon: "slack"
+---
+
+# Slack integration, driven from the TUI
+
+> **Status:** Phases 0-3 implemented; Phase 4 (Signal) not started
+>
+> **Priority:** P1 — consumer track
+>
+> **Related issues:** #635 (messaging adapters), #690 (messaging tool restriction + sanitization),
+> #689 (adapter rate limiting), #693 (Signal), #2062 (Telegram has no e2e coverage)
+>
+> **Related plans:** [Messaging Integrations](/plans/messaging-integrations-plan),
+> [Security Model](/plans/security-model), [TUI User Journey](/plans/tui-user-journey)
+
+---
+
+## 1. What the user gets
+
+Today the flagship agent only answers someone sitting at the machine it runs on. After this,
+you message GAIA from the Slack app on your phone and it answers from your desktop — reading
+your files, searching your documents, and sending results back as Slack file uploads. The
+setup is offered to you rather than hunted for: the TUI notices Slack is installed and asks
+once whether to connect it.
+
+The hard part is not the Slack API. It is that the flagship agent can run shell commands and
+write files, and Slack is a remote surface in a workspace with other people in it. Everything
+in §5 exists because of that, and it is the work that actually decides whether this ships.
+
+---
+
+## 2. What already exists
+
+Almost every piece has a home already. This is mostly wiring, not invention.
+
+| Need | Already in the tree | Note |
+|---|---|---|
+| Detect Slack is installed | `SystemDiscovery.scan_installed_apps()` (`src/gaia/agents/base/discovery.py:1290`) | macOS `.app` bundles, Windows registry + Start Menu, Linux `.desktop`. Already categorises Slack as "Communication" (`tests/unit/agents/test_discovery.py:148`). Do not write a second detector. |
+| Talk to the flagship agent | `gaia_agent.stdio` (`hub/agents/gaia/python/gaia_agent/stdio.py`) | Newline-delimited JSON: one query per stdin line, canonical `status`/`tool_call`/`tool_result`/`token`/`final`/`error` events back. The TUI's `client.SubprocessClient` is the reference consumer. |
+| Ask permission for a tool | `gaia_control` back-channel, same file | A JSON line with a `gaia_control` key, read by a dedicated thread so it lands *during* a turn. Decisions are `allow` / `always` / `deny`. This is the piece Telegram never used. |
+| A messaging adapter to copy | `src/gaia/messaging/telegram.py` | Allowlist enforcement, PID file, health port, background thread, streaming via message edits. Copy the shape; do not copy the tool posture (§5.1). |
+| Ingest what a user sends | `ingest_document_to_rag` / `ingest_image_to_vlm` (`src/gaia/messaging/ingest.py`) | Already used by Telegram for photos and documents. |
+| Store the tokens | connectors keyring (`src/gaia/connectors/_keyring.py`) | OS keyring. Tokens never land in a config file. |
+| An optional readiness row | `preflight.ExtraCheck{Optional: true}` (`tui/internal/ui/preflight/check.go:23`) | Already means "gates a capability, not the launch" — exactly what a Slack offer is. |
+
+**What does not exist and has to be built:** the Socket Mode client, the turn queue, the Block
+Kit renderer, the approval marshalling, the manifest-assisted setup flow, and the TUI screens.
+
+---
+
+## 3. Where the bridge runs
+
+**`gaia slack` is its own long-lived process and owns its own `gaia_agent.stdio` child.** It
+does not route through the TUI, and it does not need the TUI to be running.
+
+This is the decision with the most consequences, so the reasoning matters. The flagship agent
+is **not** a daemon sidecar today — the TUI spawns it directly as a stdio subprocess and keeps
+it. Three options and why one wins:
+
+- **Reuse the TUI's child.** Rejected: Slack would only work while a terminal is open, and
+  remote turns would interleave into the conversation the local user is looking at.
+- **Drive the TUI's control API** (`tui/internal/control/`). Rejected: that API injects
+  keystrokes and returns rendered frames. Screen-scraping a terminal is not a transport.
+- **Own a peer child.** Chosen: same transport as the TUI, separate conversation, independent
+  lifetime. The TUI becomes the *control plane* — discover, configure, start, stop, status —
+  and never the data plane.
+
+```
+Slack (Socket Mode, outbound WS)
+   │
+   ▼
+gaia slack ──spawns──> gaia_agent.stdio  ──> Lemonade
+   │                    (its own GaiaAgent)
+   └── control plane: gaia config / the TUI (start, stop, status, tokens)
+```
+
+### 3.1 The prerequisite nobody can skip — answered
+
+Two `GaiaAgent` processes now share `~/.gaia`: the memory store, the FAISS RAG and code
+indexes, and the scratchpad SQLite DB. Phase 0 asked whether concurrent writes there are safe.
+**They are, and no lock is needed** — but for three different reasons, and the weakest one is
+worth knowing:
+
+| Shared state | Behaviour under two writers | Verdict |
+|---|---|---|
+| `~/.gaia/memory.db` | WAL mode plus `busy_timeout=5000`, added precisely so the dashboard and an agent could share it (`memory_store.py:414`) | Safe by design |
+| Code index | `_save_atomic` writes a temp file and `Path.replace`s it (`code_index/sdk.py:964`) | No torn file. Two writers can leave index and metadata mismatched, which `_load_metadata`'s `ntotal` check already detects and rebuilds |
+| RAG document cache | Plain `open(..., "wb")`, *not* atomic (`rag/sdk.py:370`) — but every cache is HMAC-signed | A torn write fails verification loudly and is rebuilt, rather than being read back as truth |
+
+So the worst case is a wasted re-index, never a silently wrong answer. That is the bar the
+no-silent-fallbacks rule sets, so the bridge runs its own agent child without a lock. If the
+RAG cache is ever made unsigned, this conclusion expires with it.
+
+### 3.2 One conversation, one turn at a time
+
+`gaia_agent.stdio` is a single agent that processes one turn at a time. So v1 is one Slack
+conversation, and a message arriving mid-turn is queued with an :hourglass: reaction rather
+than dropped or run concurrently.
+
+Thread-per-session needs the agent's HTTP surface instead (`server.py`, which already has
+`session_registry` and `/query/{run_id}/respond`). That is a real upgrade path, but it pulls in
+the daemon sidecar layer the flagship deliberately does not use today, so it is Phase 5 at the
+earliest and only if demand shows up.
+
+---
+
+## 4. The user journey
+
+### 4.1 First boot, Slack already installed
+
+The readiness screen already walks a ladder of checks. Slack becomes one more row, marked
+`Optional` so a failure never blocks the launch:
+
+```
+  ✓  Lemonade running
+  ✓  Model downloaded
+  ✓  Memory index ready
+  ○  Slack detected — not connected      [enter] set up   [s] skip   [n] never ask
+```
+
+### 4.2 Setup — and the part we cannot automate
+
+**A Slack app cannot be created without a human at api.slack.com.** Saying "automatic
+configuration" in the UI would be a lie, and users find that out thirty seconds later. What we
+*can* do is make it one click and two pastes, about ninety seconds:
+
+1. The TUI generates the app manifest — bot scopes, Socket Mode on, the `message.im` event
+   subscription — and opens `https://api.slack.com/apps?new_app=1&manifest_json=<urlencoded>`.
+   One click creates an app that is already configured correctly.
+2. The user generates an app-level token (`xapp-…`, scope `connections:write`) and clicks
+   **Install to Workspace** for the bot token (`xoxb-…`).
+3. Both are pasted into the TUI, validated with `auth.test`, and stored in the OS keyring.
+
+Slack's `apps.manifest.create` API does not remove that step — the configuration token it needs
+is itself obtained by hand. Not worth the complexity for v1.
+
+The confirmation screen states the blast radius in plain words before anything starts:
+
+> Connected to **acme.slack.com** as **@gaia**. Only **you** (`U024BE7LH`) can message it.
+> It can read and search your documents. It will ask before running a command or writing a file.
+
+### 4.3 Slack installed later, or a mind changed
+
+Three persisted states in `~/.gaia/config.json`, plus the timestamp detection last succeeded:
+
+| State | Behaviour on next TUI boot |
+|---|---|
+| `connected` | Row shows connected; no prompt |
+| `skipped` | Silent — **except** the one boot where detection flips absent → present, which re-offers once |
+| `never` | Never prompts again; `/slack` still works |
+
+`/slack` in the command palette re-runs setup at any time, which is the "go back to the
+configuration option" path. `gaia slack {setup,start,stop,status}` mirrors all of it for people
+who never open the TUI, matching `gaia telegram`'s shape.
+
+---
+
+## 5. Security
+
+A Slack message is untrusted input reaching an agent that holds shell and file-write tools.
+Telegram dodged this by constructing a plain `AgentSDK` with no tool loop at all. That dodge is
+not available here — tool access *is* the feature — so each layer below is load-bearing.
+
+### 5.1 Layers
+
+1. **Socket Mode only.** An outbound WebSocket: no inbound port, no public URL, no webhook
+   signing secret to leak, nothing for a home router to forward.
+2. **Allowlist with no permissive default.** Refuse to start without one, mirroring
+   `TelegramAllowlistError`. Default is the installing user alone. Pin the `team_id` too, so a
+   token that ends up in another workspace is refused rather than served.
+3. **DMs only in v1.** Anyone in a channel can address a bot in it. Channels and `@mentions`
+   are Phase 5 and need their own threat model.
+4. **Per-call approval over Block Kit.** A `tool_call` event renders as a message with
+   **Allow** / **Always allow** / **Deny** buttons; the click becomes a `gaia_control`
+   `tool_decision` line. No answer inside the timeout is a deny. This is the single most
+   valuable thing in the plan — it is what lets a remote surface hold real tools honestly.
+5. **Bypass is unreachable from Slack.** Not a button, not a command, not a config key the
+   bridge reads. It is set locally or not at all, and the existing audit logger records it.
+6. **A read-only tool profile by default** (#690): documents, search, web. Shell and file
+   writes are opt-in at start time via `--allow-tools` — and even then still pass through
+   per-call approval, so opting in widens what *can* be asked, never what happens unasked.
+7. **Outbound file upload is exfiltration.** A file leaving the user's disk for Slack's servers
+   is approval-gated like any other side effect, and restricted to an allowlisted set of roots.
+8. **Input sanitization** (#690): strip Slack markup, cap length, and never let message text
+   influence tool policy or bypass state.
+
+### 5.2 Transport shape
+
+- **Streaming:** `chat.update` is rate-limited near one call per second per channel. Post a
+  placeholder, update at most once a second with accumulated text, then a final update. Tool
+  activity renders as a context-block trail rather than more messages.
+- **Files in:** download the share, hand to `ingest_document_to_rag` / `ingest_image_to_vlm`.
+- **Files out:** `files.uploadV2` (`files.getUploadURLExternal` + `completeUploadExternal`).
+  The old `files.upload` is retired — do not reach for the example in an old tutorial.
+- **Health port:** Socket Mode needs no inbound port, but the `/healthz` probe does. Add
+  `SLACK_HEALTH_PORT = 8769` to `src/gaia/mcp/ports.py`; 8765–8768 are taken and #3604 was the
+  last collision.
+
+---
+
+## 6. Build the seam once
+
+Signal is next (#693) and Telegram already exists, so the transport-agnostic half belongs in
+`src/gaia/messaging/bridge.py` from the start: the stdio child lifecycle, the turn queue, the
+approval marshalling, the streaming throttle, and file ingest. Per-platform adapters supply
+only what is genuinely platform-specific — the socket, the message renderer, and identity.
+
+Doing this in Phase 1 rather than after makes Signal roughly a three-day addition instead of a
+second bridge, and gives Telegram a supported path to gaining tools later instead of staying
+permanently neutered.
+
+---
+
+## 7. Phases
+
+| Phase | Scope | Estimate |
+|---|---|---|
+| **0 — Spike (blocking)** | Concurrent `~/.gaia` writes from two `GaiaAgent` processes. | ✅ Done — see §3.1 |
+| **1 — Bridge** | `gaia slack` + the shared `bridge.py` seam. Socket Mode, DM-only, allowlist, stdio child, turn queue, throttled streaming. | ✅ Done |
+| **2 — TUI onboarding** | The one-time offer, manifest one-click, token capture to keyring, `/slack`, the three persisted states, start/stop/status. | ✅ Done |
+| **3 — Tools and files** | Block Kit approvals over `gaia_control`, file in/out, `--deny-gated-tools`. | ✅ Done |
+| **4 — Signal** | Second adapter on the same seam (#693). | Not started — 3 d |
+
+**What shipped differently from the plan.** Two things:
+
+- **The read-only tool profile inverted.** The plan assumed a curated allowlist of safe tools
+  per #690. The base agent already gates every shell, file-write and code-execution tool
+  behind `TOOLS_REQUIRING_CONFIRMATION`, so the useful knob turned out to be the other end:
+  `--deny-gated-tools` refuses that whole set outright. The default asks; the flag refuses.
+  Reads stay ungated either way, which §5 now says plainly instead of implying otherwise.
+- **The readiness row became a chat offer.** `preflight.ExtraCheck` runs against a sidecar's
+  `/v1/<agent>/init` endpoint, and the flagship has no sidecar — it is a stdio child. So the
+  offer renders in the chat view at launch instead, gated on the same
+  `gaia slack status --json` answer.
+
+**WhatsApp stays deferred.** That decision is already made and documented in
+[`docs/spec/whatsapp-evaluation.md`](/spec/whatsapp-evaluation) (issue #891, closed): every
+path is bad for a local-first product — the community libraries (`whatsapp-web.js`, Baileys)
+violate WhatsApp's terms and get accounts banned, and the Business Cloud API needs Meta
+business verification, a separate phone number, and template-gated conversations that make
+streaming replies awkward. Nothing has changed since. Revisit on concrete user demand, not on
+completeness.
+
+---
+
+## 8. Testing
+
+#2062 is the warning: the Telegram adapter shipped with no end-to-end coverage, so "does it
+actually work" is still unanswered. Do not repeat that.
+
+- **Unit:** allowlist enforcement per handler (Slack routes commands and messages separately,
+  the same trap `require_allowed` exists for in Telegram); manifest generation; the three
+  onboarding states; the turn queue under a mid-turn message.
+- **Contract:** assert the *shape* of outgoing Slack calls, not merely that a stub was called —
+  `files.uploadV2`'s two-step handshake and `chat.update`'s throttle are exactly the kind of
+  thing a hardcoded-success mock proves nothing about (CLAUDE.md's boundary-validity rule).
+- **End-to-end:** a real Socket Mode connection against a scratch workspace — send a message,
+  get a streamed reply, approve a gated tool, receive a file.
+- **Cold-state:** run setup on a machine with no prior `~/.gaia/config.json` and no keyring
+  entry. A warm dev box hides every first-run bug in this flow.
+- **Eval:** not required — nothing here touches a system prompt or the tool schema. If the
+  Slack path ever injects context into the prompt, it does.
+
+---
+
+## 9. Decisions taken, and what is still open
+
+**Settled during implementation:**
+
+1. **The bridge does not auto-start.** `gaia slack start` is explicit. A background process
+   spawned at TUI launch would be convenient and surprising, and this one can run shell
+   commands.
+2. **A bot token, not a user token.** A user token would let GAIA act *as you* in Slack — a
+   different product with a much larger threat model.
+3. **Tools are on by default, behind per-call approval.** The alternative made the first Slack
+   session weaker than the terminal for no security gain, since the approval gate is what
+   actually stops an unattended command. `--deny-gated-tools` is there for anyone who disagrees.
+
+**Still open:**
+
+4. **Where the approval renderer lives when Signal arrives.** Block Kit is Slack-shaped; Signal
+   has no buttons and needs a reply-with-a-word fallback. The decision protocol is already
+   shared in `bridge.py`; only the rendering is per-adapter, and whether that is enough
+   structure will not be clear until the second adapter exists.
+5. **Channel support.** Deliberately out of scope: anyone in a channel can address a bot in it,
+   so the allowlist would become the only boundary. It needs its own threat model.
+6. **Multi-conversation sessions.** One agent child means one turn at a time. Thread-per-session
+   needs the agent's HTTP surface and its `session_registry`, which pulls in the daemon sidecar
+   layer the flagship does not use.

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,8 @@ setup(
         "gaia.web",
         "gaia.code_index",
         "gaia.apps.webui",
+        "gaia.messaging",
+        "gaia.messaging.slack",
         "gaia.connectors",
         "gaia.connectors.catalog",
         "gaia.connectors.providers",
@@ -231,6 +233,9 @@ setup(
         ],
         "telegram": [
             "python-telegram-bot>=20.3",
+        ],
+        "slack": [
+            "slack-sdk>=3.27",
         ],
         "litellm": [
             "litellm>=1.35.0,<2.0",

--- a/src/gaia/cli.py
+++ b/src/gaia/cli.py
@@ -1691,6 +1691,90 @@ def build_parser():
 
     telegram_parser.set_defaults(action="telegram")
 
+    # Slack command — drive the flagship agent from a Slack DM (Socket Mode)
+    slack_parser = subparsers.add_parser(
+        "slack",
+        help="Drive the GAIA agent from Slack (setup|start|stop|status)",
+        parents=[parent_parser],
+    )
+    slack_subparsers = slack_parser.add_subparsers(
+        dest="slack_action", help="slack action to perform"
+    )
+
+    s_setup = slack_subparsers.add_parser(
+        "setup", help="Create the Slack app and store its tokens"
+    )
+    s_setup.add_argument(
+        "--no-browser",
+        action="store_true",
+        help="Print the create-app URL instead of opening a browser",
+    )
+
+    s_start = slack_subparsers.add_parser("start", help="Start the Slack bridge")
+    # Not argparse-required: the adapter's own refusal explains *why* an
+    # allowlist is mandatory and how to build one, which "the following
+    # arguments are required" does not.
+    s_start.add_argument(
+        "--allowed-users",
+        help=(
+            "Comma-separated Slack member IDs allowed to use the agent "
+            "(required — every member of a workspace can DM a bot). Find "
+            "yours under your avatar -> Profile -> ... -> Copy member ID."
+        ),
+    )
+    s_start.add_argument(
+        "--agent-command",
+        help=(
+            "Command that starts the agent child (default: gaia-agent). Use "
+            "this to point at a specific build."
+        ),
+    )
+    s_start.add_argument(
+        "--deny-gated-tools",
+        action="store_true",
+        help=(
+            "Run read-only: auto-deny every tool that would ask for "
+            "confirmation, instead of offering Allow/Deny buttons in Slack."
+        ),
+    )
+    s_start.add_argument(
+        "--upload-root",
+        action="append",
+        help=(
+            "Directory a file may be uploaded back to Slack from (repeatable; "
+            "default: your home directory). Files the agent writes outside "
+            "these roots are never sent."
+        ),
+    )
+    s_start.add_argument(
+        "--background",
+        action="store_true",
+        help="Record a PID file so `gaia slack stop` can find this process",
+    )
+
+    slack_subparsers.add_parser("stop", help="Stop a backgrounded Slack bridge")
+
+    s_decline = slack_subparsers.add_parser(
+        "decline", help="Record that you do not want Slack set up"
+    )
+    s_decline.add_argument(
+        "--never",
+        action="store_true",
+        help=(
+            "Never offer Slack setup again. Without this, the offer returns "
+            "once if you install Slack later."
+        ),
+    )
+
+    s_status = slack_subparsers.add_parser(
+        "status", help="Show Slack detection, configuration, and liveness"
+    )
+    s_status.add_argument(
+        "--json", action="store_true", help="Emit machine-readable JSON"
+    )
+
+    slack_parser.set_defaults(action="slack")
+
     # Schedule command — cron-based recurring skill/prompt dispatch (issue #892)
     schedule_parser = subparsers.add_parser(
         "schedule",
@@ -3292,6 +3376,12 @@ def main():
             webui_dist=getattr(args, "ui_dist", None),
         )
         return
+
+    # Handle slack command — see gaia.messaging.slack.cli for the flow
+    if args.action == "slack":
+        from gaia.messaging.slack.cli import main as slack_main
+
+        sys.exit(slack_main(args))
 
     # Handle telegram scaffold command
     if args.action == "telegram":

--- a/src/gaia/mcp/ports.py
+++ b/src/gaia/mcp/ports.py
@@ -11,9 +11,13 @@ Port map (each surface binds loopback by default):
 - 8768 ``TELEGRAM_HEALTH_PORT`` — Telegram adapter ``/healthz`` probe. Every
   surface gets its own default so the MCP bridge and the Telegram health
   server do not collide on one machine; pass ``--health-port`` to move it.
+- 8769 ``SLACK_HEALTH_PORT`` — Slack adapter ``/healthz`` probe. Socket Mode
+  itself needs no inbound port (the connection is an outbound WebSocket);
+  this is only so a supervisor can ask whether the bridge is alive.
 """
 
 MCP_BRIDGE_PORT = 8765
 AGENT_UI_MCP_PORT = 8766
 TUI_MCP_PORT = 8767
 TELEGRAM_HEALTH_PORT = 8768
+SLACK_HEALTH_PORT = 8769

--- a/src/gaia/messaging/__init__.py
+++ b/src/gaia/messaging/__init__.py
@@ -1,0 +1,3 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Messaging adapters that let a remote chat surface drive a local GAIA agent."""

--- a/src/gaia/messaging/bridge.py
+++ b/src/gaia/messaging/bridge.py
@@ -1,0 +1,445 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Transport-agnostic half of a messaging bridge to the flagship agent.
+
+A messaging adapter (Slack today, Signal next) needs the same five things, none
+of which are platform-specific: a long-lived ``gaia-agent`` child, one turn at a
+time through it, an approval that can be answered *while* a turn is running, a
+throttle so streamed tokens do not exceed a platform's edit rate, and a terminal
+event for every turn even when the child dies. They live here so a second
+adapter is a renderer and a socket, not a second bridge.
+
+The wire is ``gaia_agent.stdio``'s: newline-delimited JSON, one query per stdin
+line, canonical ``status`` / ``tool_call`` / ``tool_result`` /
+``needs_confirmation`` / ``token`` / ``final`` / ``error`` events back, and a
+``gaia_control`` line carrying an approval decision. The constants below are a
+cross-process contract with that module, kept as literals rather than imported
+because core must not depend on a hub wheel; ``tests/unit/messaging/
+test_bridge_contract.py`` pins them against the real definitions.
+
+Security posture: this module exposes no way to turn permission bypass on.
+``gaia_agent.stdio`` accepts a ``bypass`` control verb, and a remote surface must
+never be able to send it — an allowlisted user is trusted to ask for a tool, not
+to silently disarm the gate for every later one. Bypass stays a local decision,
+and ``tests/unit/messaging/test_bridge.py`` pins its absence.
+"""
+
+from __future__ import annotations
+
+import json
+import queue
+import subprocess
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+from gaia.logger import get_logger
+
+log = get_logger(__name__)
+
+#: Discriminator marking a stdin line as control rather than a query.
+#: Contract with ``gaia_agent.stdio.CONTROL_KEY``.
+CONTROL_KEY = "gaia_control"
+
+#: Wrapper for a query whose text contains newlines — stdin is read a line at a
+#: time, so an unwrapped multi-line question becomes several unrelated turns.
+#: Contract with ``gaia_agent.stdio.QUERY_KEY``.
+QUERY_KEY = "gaia_query"
+
+#: Control verb answering the confirmation currently pending.
+CONTROL_TOOL_DECISION = "tool_decision"
+
+DECISION_ALLOW = "allow"
+DECISION_DENY = "deny"
+DECISION_ALWAYS = "always"
+
+#: Every decision the agent accepts. Anything else fails closed to a deny — the
+#: agent does the same on its side, so a typo cannot become consent.
+VALID_DECISIONS = frozenset({DECISION_ALLOW, DECISION_DENY, DECISION_ALWAYS})
+
+#: The two events that END a turn. Exactly one arrives per turn.
+TERMINAL_EVENTS = frozenset({"final", "error"})
+
+#: The event that pauses a turn until a decision arrives.
+NEEDS_CONFIRMATION = "needs_confirmation"
+
+#: Console script installed by the ``gaia-agent-gaia`` wheel
+#: (``[project.scripts] gaia-agent = "gaia_agent.stdio:main"``).
+DEFAULT_AGENT_BINARY = "gaia-agent"
+
+
+class AgentChannelError(RuntimeError):
+    """The agent child could not be started, or died and cannot be used."""
+
+
+@dataclass
+class Turn:
+    """One question and whatever the adapter needs to answer it.
+
+    ``context`` is opaque here on purpose: Slack puts a channel id and a message
+    timestamp in it, Signal would put a recipient. The bridge only carries it
+    back to the adapter's callbacks.
+    """
+
+    text: str
+    context: Any = None
+    #: Who asked, for the audit line. Never used for authorization — the
+    #: adapter has already decided that before a Turn exists.
+    sender: str = ""
+
+
+@dataclass
+class _TurnState:
+    """Bookkeeping for the turn currently in flight."""
+
+    turn: Turn
+    saw_terminal: bool = False
+    pending_confirm_ids: List[str] = field(default_factory=list)
+
+
+class StreamThrottle:
+    """Rate-limit edits of a streamed reply.
+
+    Every messaging platform caps how often one message may be edited (Slack's
+    ``chat.update`` is near one call per second per channel). Sending an edit per
+    token gets the adapter rate-limited and the user a reply that arrives later
+    than if it had not streamed at all.
+
+    Accumulated text is flushed at most once per ``interval`` seconds, and
+    :meth:`finish` always flushes whatever is left — the last token must never be
+    the one the throttle swallowed.
+    """
+
+    def __init__(
+        self,
+        flush: Callable[[str], None],
+        interval: float = 1.0,
+        now: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._flush = flush
+        self._interval = interval
+        self._now = now
+        self._text = ""
+        self._flushed = ""
+        self._last = 0.0
+
+    @property
+    def text(self) -> str:
+        """Everything accumulated so far, flushed or not."""
+        return self._text
+
+    def add(self, chunk: str) -> None:
+        """Accumulate a token, flushing if the interval has elapsed."""
+        self._text += chunk
+        now = self._now()
+        if now - self._last >= self._interval:
+            self._emit(now)
+
+    def finish(self) -> None:
+        """Flush any text the interval held back."""
+        self._emit(self._now())
+
+    def _emit(self, now: float) -> None:
+        # An unchanged body is not worth an API call, and on Slack an edit that
+        # changes nothing still counts against the channel's rate limit.
+        if self._text == self._flushed:
+            self._last = now
+            return
+        self._flush(self._text)
+        self._flushed = self._text
+        self._last = now
+
+
+class AgentChannel:
+    """One long-lived ``gaia-agent`` child, driven one turn at a time.
+
+    The child is a single ``GaiaAgent`` that processes one query at a time, so
+    turns are serialized here rather than raced: a message that arrives mid-turn
+    is queued, and the adapter is told so it can say as much.
+
+    Threads, and why there are three:
+
+    * the **writer** pulls one turn off the queue, writes it, and waits for that
+      turn's terminal event before pulling the next;
+    * the **reader** owns stdout and dispatches every event;
+    * the **caller's** thread posts decisions, which must land *while* a turn is
+      in flight — that is the only moment an approval is worth anything.
+    """
+
+    def __init__(
+        self,
+        *,
+        on_event: Callable[[Dict[str, Any], Turn], None],
+        argv: Optional[Sequence[str]] = None,
+        env: Optional[Dict[str, str]] = None,
+        spawn: Optional[Callable[..., Any]] = None,
+        on_busy: Optional[Callable[[Turn, int], None]] = None,
+    ) -> None:
+        self._argv = list(argv) if argv else [DEFAULT_AGENT_BINARY]
+        self._env = env
+        self._on_event = on_event
+        self._on_busy = on_busy
+        # Injectable so tests drive a fake child instead of spawning a real
+        # agent, which costs ~42s to build before it answers anything.
+        self._spawn = spawn or self._default_spawn
+        self._proc: Any = None
+        self._queue: "queue.Queue[Optional[Turn]]" = queue.Queue()
+        self._active: Optional[_TurnState] = None
+        self._active_lock = threading.RLock()
+        self._turn_done = threading.Event()
+        self._write_lock = threading.Lock()
+        self._reader: Optional[threading.Thread] = None
+        self._writer: Optional[threading.Thread] = None
+        self._closing = threading.Event()
+        self._depth = 0
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def _default_spawn(self) -> Any:
+        try:
+            return subprocess.Popen(  # noqa: S603 - argv is ours, never user text
+                self._argv,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                env=self._env,
+                text=True,
+                bufsize=1,
+                encoding="utf-8",
+            )
+        except FileNotFoundError as e:
+            raise AgentChannelError(
+                f"The agent binary '{self._argv[0]}' is not on PATH, so no "
+                f"message can be answered. Install it with "
+                f"`gaia init --profile gaia`, or pass --agent-command with the "
+                f"path to it. Docs: https://amd-gaia.ai/docs/guides/install"
+            ) from e
+        except OSError as e:
+            raise AgentChannelError(
+                f"Could not start the agent binary '{self._argv[0]}': {e}. "
+                f"Check that it is executable, then retry."
+            ) from e
+
+    def start(self) -> None:
+        """Spawn the child and begin serving turns."""
+        if self._proc is not None:
+            raise AgentChannelError(
+                "This AgentChannel is already started. Build a second channel "
+                "rather than starting one twice."
+            )
+        self._proc = self._spawn()
+        self._reader = threading.Thread(
+            target=self._read_loop, name="gaia-bridge-reader", daemon=True
+        )
+        self._writer = threading.Thread(
+            target=self._write_loop, name="gaia-bridge-writer", daemon=True
+        )
+        self._reader.start()
+        self._writer.start()
+        log.info("Agent channel started: %s", " ".join(self._argv))
+
+    def close(self) -> None:
+        """Stop serving turns and terminate the child."""
+        if self._closing.is_set():
+            return
+        self._closing.set()
+        self._queue.put(None)
+        proc = self._proc
+        if proc is not None:
+            try:
+                if proc.stdin is not None:
+                    proc.stdin.close()
+            except (OSError, ValueError) as e:
+                log.debug("Agent stdin already closed: %s", e)
+            try:
+                proc.terminate()
+            except (OSError, AttributeError) as e:
+                log.debug("Agent child already gone: %s", e)
+        # Unblock a writer parked on a turn that will never terminate.
+        self._turn_done.set()
+
+    # ------------------------------------------------------------------
+    # Submitting work
+    # ------------------------------------------------------------------
+
+    def submit(self, turn: Turn) -> int:
+        """Queue a turn. Returns how many turns are ahead of it (0 = starting now).
+
+        A non-zero return is the adapter's cue to tell the user their message is
+        waiting rather than lost — silence while a previous turn runs reads as a
+        broken bot.
+        """
+        if self._closing.is_set():
+            raise AgentChannelError(
+                "The agent channel is shutting down and cannot take new "
+                "messages. Restart the adapter to serve again."
+            )
+        if self._proc is None:
+            raise AgentChannelError(
+                "The agent channel was never started — call start() before "
+                "submitting a turn."
+            )
+        with self._active_lock:
+            ahead = self._depth
+            self._depth += 1
+        self._queue.put(turn)
+        if ahead and self._on_busy is not None:
+            self._on_busy(turn, ahead)
+        return ahead
+
+    def decide(self, decision: str, confirm_id: Optional[str] = None) -> None:
+        """Answer the confirmation currently pending.
+
+        An unrecognized decision is sent as a deny rather than dropped: a
+        decision that never arrives leaves the turn parked until it times out,
+        which is a worse outcome than a clear refusal. The agent fails closed the
+        same way on its side.
+        """
+        if decision not in VALID_DECISIONS:
+            log.warning(
+                "Unknown tool decision %r from the messaging surface — "
+                "denying. Valid decisions: %s",
+                decision,
+                ", ".join(sorted(VALID_DECISIONS)),
+            )
+            decision = DECISION_DENY
+        message: Dict[str, Any] = {
+            CONTROL_KEY: CONTROL_TOOL_DECISION,
+            "decision": decision,
+        }
+        if confirm_id:
+            message["confirm_id"] = confirm_id
+        self._write_line(json.dumps(message))
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _write_line(self, line: str) -> None:
+        proc = self._proc
+        if proc is None or proc.stdin is None:
+            raise AgentChannelError(
+                "The agent child has no input stream — it was never started, "
+                "or it has already exited. Restart the adapter."
+            )
+        with self._write_lock:
+            try:
+                proc.stdin.write(line + "\n")
+                proc.stdin.flush()
+            except (OSError, ValueError) as e:
+                raise AgentChannelError(
+                    f"Could not reach the agent child: {e}. It has most likely "
+                    f"exited; restart the adapter and resend the message."
+                ) from e
+
+    def _write_loop(self) -> None:
+        while not self._closing.is_set():
+            turn = self._queue.get()
+            if turn is None:
+                return
+            self._turn_done.clear()
+            with self._active_lock:
+                self._active = _TurnState(turn=turn)
+            try:
+                # Always wrapped: a bare line carrying a newline would be read as
+                # several unrelated questions, and the agent would answer only
+                # the first while insisting it had seen everything.
+                self._write_line(json.dumps({QUERY_KEY: turn.text}))
+            except AgentChannelError as e:
+                self._dispatch_terminal_error(str(e))
+                self._finish_turn()
+                continue
+            # The reader sets this on the turn's one terminal event.
+            self._turn_done.wait()
+            self._finish_turn()
+
+    def _finish_turn(self) -> None:
+        with self._active_lock:
+            self._active = None
+            if self._depth:
+                self._depth -= 1
+
+    def _read_loop(self) -> None:
+        proc = self._proc
+        stdout = getattr(proc, "stdout", None)
+        if stdout is None:
+            return
+        try:
+            # readline-until-empty rather than `for raw in stdout`: a pipe's
+            # file iterator read-ahead can hold a line back until the buffer
+            # fills, which on a streaming turn shows up as the reply arriving
+            # all at once instead of token by token.
+            for raw in iter(stdout.readline, ""):
+                line = raw.strip()
+                if not line:
+                    continue
+                self._handle_line(line)
+        except (OSError, ValueError) as e:
+            log.debug("Agent stdout closed: %s", e)
+        # The stream ended. If a turn was still running, it will never get its
+        # terminal event from the child, so synthesize one — a turn that just
+        # goes quiet is the failure mode the daemon relay exists to prevent.
+        if not self._closing.is_set():
+            self._dispatch_terminal_error(
+                "The agent stopped responding mid-answer and the reply is "
+                "incomplete. It most likely crashed — check "
+                "~/.gaia/logs, then resend the message."
+            )
+        self._turn_done.set()
+
+    def _handle_line(self, line: str) -> None:
+        try:
+            event = json.loads(line)
+        except ValueError:
+            # The agent writes JSON lines only; anything else is a stray print
+            # from a dependency, and dropping it silently would hide a crash
+            # banner. Log it and keep the stream in sync.
+            log.warning("Ignored a non-JSON line from the agent: %.200s", line)
+            return
+        if not isinstance(event, dict):
+            log.warning("Ignored a non-object event from the agent: %.200s", line)
+            return
+
+        with self._active_lock:
+            state = self._active
+        if state is None:
+            # Events only flow between a query and its terminal event, so one
+            # arriving outside a turn means the streams desynchronised.
+            log.warning(
+                "Dropped an agent event of type %r that arrived with no turn "
+                "running",
+                event.get("type"),
+            )
+            return
+
+        etype = event.get("type")
+        if etype == NEEDS_CONFIRMATION:
+            confirm_id = event.get("confirm_id")
+            if confirm_id:
+                state.pending_confirm_ids.append(str(confirm_id))
+
+        try:
+            self._on_event(event, state.turn)
+        except Exception:
+            # A renderer that raises must not wedge the reader thread — the turn
+            # would then never terminate and the channel would stop serving.
+            log.exception("Messaging adapter raised while rendering an event")
+
+        if etype in TERMINAL_EVENTS:
+            state.saw_terminal = True
+            self._turn_done.set()
+
+    def _dispatch_terminal_error(self, detail: str) -> None:
+        with self._active_lock:
+            state = self._active
+        if state is None or state.saw_terminal:
+            return
+        state.saw_terminal = True
+        try:
+            self._on_event({"type": "error", "detail": detail}, state.turn)
+        except Exception:
+            log.exception("Messaging adapter raised while rendering a crash")
+        self._turn_done.set()

--- a/src/gaia/messaging/slack/__init__.py
+++ b/src/gaia/messaging/slack/__init__.py
@@ -1,0 +1,56 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Slack Socket Mode bridge to the flagship GAIA agent.
+
+Submodules are imported lazily by their callers: ``adapter`` pulls in
+``slack_sdk`` and the RAG ingestion path, which a caller that only wants the
+manifest or the onboarding state should not pay for.
+"""
+
+from gaia.messaging.slack.manifest import (
+    APP_TOKEN_PREFIX,
+    BOT_SCOPES,
+    BOT_TOKEN_PREFIX,
+    SETUP_STEPS,
+    TokenFormatError,
+    build_manifest,
+    create_app_url,
+    validate_tokens,
+)
+from gaia.messaging.slack.onboarding import (
+    STATE_CONNECTED,
+    STATE_NEVER,
+    STATE_SKIPPED,
+    STATE_UNSET,
+    OnboardingState,
+    OnboardingStateError,
+    detect_slack,
+    load_state,
+    record_decision,
+    save_state,
+    should_offer,
+    slack_is_installed,
+)
+
+__all__ = [
+    "APP_TOKEN_PREFIX",
+    "BOT_SCOPES",
+    "BOT_TOKEN_PREFIX",
+    "SETUP_STEPS",
+    "STATE_CONNECTED",
+    "STATE_NEVER",
+    "STATE_SKIPPED",
+    "STATE_UNSET",
+    "OnboardingState",
+    "OnboardingStateError",
+    "TokenFormatError",
+    "build_manifest",
+    "create_app_url",
+    "detect_slack",
+    "load_state",
+    "record_decision",
+    "save_state",
+    "should_offer",
+    "slack_is_installed",
+    "validate_tokens",
+]

--- a/src/gaia/messaging/slack/adapter.py
+++ b/src/gaia/messaging/slack/adapter.py
@@ -1,0 +1,809 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Slack Socket Mode adapter — drive the flagship agent from a Slack DM.
+
+Unlike the Telegram adapter, which reaches a bare ``AgentSDK`` with no tool loop,
+this one drives the real flagship agent: it can read your files, search your
+documents, and run commands. That is the feature, and it is why the guard rails
+below are not optional extras.
+
+**The gate that makes this safe is the one that already exists.** The base agent
+puts every shell, file-write and code-execution tool behind
+``TOOLS_REQUIRING_CONFIRMATION``, which pauses the turn and emits a
+``needs_confirmation`` event. This adapter renders that pause as Block Kit
+buttons and sends the click back over the bridge's control channel. So a remote
+message can *ask* for a dangerous tool; it cannot *run* one unattended.
+
+What remains reachable without a prompt is reading — files under the agent's
+``allowed_paths`` (the user's home by default), indexed documents, and the web.
+An allowlisted Slack user can therefore read your files. That is stated plainly
+in the setup confirmation rather than buried, because it is the real boundary.
+
+Three further rules, each load-bearing:
+
+* **Socket Mode only.** An outbound WebSocket: no inbound port, no public URL,
+  no request-signing secret to leak.
+* **DM-only, allowlisted, one workspace.** The adapter refuses to start without
+  an allowlist, ignores anything that is not a direct message, and drops traffic
+  from a workspace other than the one it was set up for.
+* **Bypass is unreachable.** The bridge exposes no way to send the agent's
+  ``bypass`` control verb, so no Slack message or button can disarm the gate.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Sequence, Set
+
+from gaia.logger import get_logger
+from gaia.messaging.bridge import (
+    DECISION_ALLOW,
+    DECISION_ALWAYS,
+    DECISION_DENY,
+    AgentChannel,
+    StreamThrottle,
+    Turn,
+)
+from gaia.messaging.ingest import ingest_document_to_rag, ingest_image_to_vlm
+
+log = get_logger(__name__)
+
+#: Audit trail for every authorization decision this adapter makes. Pinned at
+#: WARNING so a refusal survives the default log level — a silent refusal is
+#: indistinguishable from a broken bot.
+audit = get_logger("gaia.messaging.slack.audit")
+
+#: What an unauthorized sender is told. Deliberately says nothing about who IS
+#: allowed: a stranger who found the bot learns only that they are not.
+UNAUTHORIZED_REPLY = "Sorry — you're not authorized to use this GAIA agent."
+
+#: Refusal text when no allowlist is configured. One string so the CLI and the
+#: exception cannot drift.
+NO_ALLOWLIST_ERROR = (
+    "Slack adapter refused to start: no allowed-users configured.\n"
+    "\n"
+    "This bridge drives the full GAIA agent, which can read your files and "
+    "ask to run commands. Everyone in the workspace can DM a bot, so an empty "
+    "allowlist would offer that to all of them.\n"
+    "Pass the Slack member IDs permitted to use it:\n"
+    "\n"
+    "  gaia slack start --allowed-users U024BE7LH,U0G9QF9C6\n"
+    "\n"
+    "Find your own ID in Slack: click your avatar -> Profile -> the ... menu "
+    "-> Copy member ID.\n"
+    "Docs: https://amd-gaia.ai/docs/guides/slack"
+)
+
+#: Largest file uploaded back to Slack. Slack's own ceiling is 1 GB, but a
+#: multi-hundred-MB upload from a chat reply is far more likely to be a mistake
+#: than an intent, and it would block the turn while it transferred.
+MAX_UPLOAD_BYTES = 25 * 1024 * 1024
+
+#: Largest inbound file accepted for ingestion, for the same reason.
+MAX_DOWNLOAD_BYTES = 100 * 1024 * 1024
+
+#: Slack hard-caps a message at 4000 characters; past that ``chat.update``
+#: rejects the edit outright and the reply would vanish at the finish line.
+SLACK_MESSAGE_LIMIT = 3900
+
+#: Seconds between streamed edits. ``chat.update`` is rate-limited at roughly
+#: one call per second per channel.
+EDIT_INTERVAL = 1.0
+
+#: Block action ids for the three answers to a confirmation.
+ACTION_ALLOW = "gaia_allow"
+ACTION_ALWAYS = "gaia_always"
+ACTION_DENY = "gaia_deny"
+
+_ACTION_DECISIONS = {
+    ACTION_ALLOW: DECISION_ALLOW,
+    ACTION_ALWAYS: DECISION_ALWAYS,
+    ACTION_DENY: DECISION_DENY,
+}
+
+
+class SlackAllowlistError(ValueError):
+    """The adapter was asked to run without an allowlist.
+
+    Subclasses ``ValueError`` so the CLI can catch this specific failure rather
+    than any ``ValueError`` raised while connecting.
+    """
+
+
+class SlackDependencyError(RuntimeError):
+    """``slack_sdk`` is not installed."""
+
+
+@dataclass
+class ReplyTarget:
+    """Where one turn's output goes, and the live state of that reply."""
+
+    channel: str
+    #: Timestamp of the user's message — replies thread under it, so a busy
+    #: channel does not interleave two conversations.
+    thread_ts: str
+    #: Timestamp of the placeholder being edited as tokens arrive.
+    reply_ts: str = ""
+    throttle: Optional[StreamThrottle] = None
+    #: Tool names seen this turn, rendered as a trail under the reply.
+    tools: List[str] = field(default_factory=list)
+    #: Files already uploaded this turn, so a re-reported path is not sent twice.
+    uploaded: Set[str] = field(default_factory=set)
+
+
+def _truncate(text: str) -> str:
+    """Clip a reply to Slack's message ceiling, saying so."""
+    if len(text) <= SLACK_MESSAGE_LIMIT:
+        return text
+    return text[:SLACK_MESSAGE_LIMIT] + "\n\n_…truncated — ask for the rest._"
+
+
+def confirmation_blocks(
+    action: str, summary: str, always_scope: str = ""
+) -> List[dict]:
+    """Render a pending tool approval as Block Kit.
+
+    ``always_scope`` decides whether "Always allow" appears at all. The agent
+    supplies it only when the call has a scope narrow enough to grant standing
+    permission to; offering the button without one would grant far more than the
+    user believes they are granting.
+    """
+    elements = [
+        {
+            "type": "button",
+            "action_id": ACTION_ALLOW,
+            "text": {"type": "plain_text", "text": "Allow"},
+            "style": "primary",
+        }
+    ]
+    if always_scope:
+        elements.append(
+            {
+                "type": "button",
+                "action_id": ACTION_ALWAYS,
+                "text": {"type": "plain_text", "text": f"Always allow {always_scope}"},
+            }
+        )
+    elements.append(
+        {
+            "type": "button",
+            "action_id": ACTION_DENY,
+            "text": {"type": "plain_text", "text": "Deny"},
+            "style": "danger",
+        }
+    )
+    body = f"*GAIA wants to {action}*"
+    if summary:
+        body += f"\n```{summary}```"
+    return [
+        {"type": "section", "text": {"type": "mrkdwn", "text": body}},
+        {"type": "actions", "elements": elements},
+    ]
+
+
+class SlackAdapter:
+    """Bridge a Slack workspace to one local flagship agent."""
+
+    def __init__(
+        self,
+        bot_token: str,
+        app_token: str,
+        allowed_users: Optional[Set[str]] = None,
+        *,
+        team_id: Optional[str] = None,
+        agent_argv: Optional[Sequence[str]] = None,
+        upload_roots: Optional[Sequence[str]] = None,
+        deny_gated_tools: bool = False,
+        channel_factory: Optional[Callable[..., AgentChannel]] = None,
+        web_client: Any = None,
+    ) -> None:
+        # Refused here rather than in start(): an adapter that should serve
+        # nobody must never exist, so no later caller can reach a permissive one.
+        if not allowed_users:
+            raise SlackAllowlistError(NO_ALLOWLIST_ERROR)
+        # A bare string would iterate into single characters and deny everyone,
+        # which reads as "the bot is broken" rather than "wrong type".
+        if isinstance(allowed_users, (str, bytes)):
+            raise TypeError(
+                "allowed_users must be a collection of Slack member IDs, got "
+                f"{type(allowed_users).__name__}. Pass {{'U024BE7LH'}}, not "
+                "'U024BE7LH'."
+            )
+        self.bot_token = bot_token
+        self.app_token = app_token
+        self.allowed_users = set(allowed_users)
+        self.team_id = team_id
+        self.deny_gated_tools = deny_gated_tools
+        # Default to the same scope the agent itself reads from, so a file the
+        # user asked the agent to write can be handed back without extra setup.
+        self.upload_roots = [
+            Path(p).expanduser().resolve() for p in (upload_roots or [str(Path.home())])
+        ]
+        self._web = web_client
+        self._socket: Any = None
+        self._agent_argv = list(agent_argv) if agent_argv else None
+        self._channel_factory = channel_factory or AgentChannel
+        self._channel: Optional[AgentChannel] = None
+        self._targets: Dict[str, ReplyTarget] = {}
+        self._lock = threading.RLock()
+        #: Message ts of each posted confirmation, keyed by confirm_id, so the
+        #: buttons can be replaced with the decision once one is made.
+        self._confirmations: Dict[str, tuple] = {}
+        audit.info(
+            "Slack adapter configured for %d allowed member id(s)%s",
+            len(self.allowed_users),
+            f", workspace {team_id}" if team_id else "",
+        )
+
+    # ------------------------------------------------------------------
+    # Authorization
+    # ------------------------------------------------------------------
+
+    def _allowed(self, user_id: Optional[str]) -> bool:
+        """Membership only — an empty allowlist admits nobody.
+
+        Defence in depth: ``__init__`` already refuses an empty allowlist, so
+        this only matters if one is emptied after construction.
+        """
+        return bool(user_id) and user_id in self.allowed_users
+
+    def _same_workspace(self, team_id: Optional[str]) -> bool:
+        """True when the traffic came from the workspace this was set up for.
+
+        Unpinned (``team_id=None``) accepts any, which is only the case before a
+        first successful ``auth.test``. Once pinned, a token that has been
+        installed elsewhere is refused rather than served.
+        """
+        if not self.team_id:
+            return True
+        return team_id == self.team_id
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def _build_web_client(self) -> Any:
+        if self._web is not None:
+            return self._web
+        try:
+            from slack_sdk import WebClient
+        except ImportError as e:
+            raise SlackDependencyError(
+                "slack-sdk is required for Slack support. Install it with: "
+                'pip install "amd-gaia[slack]" '
+                "(see https://amd-gaia.ai/docs/guides/slack)"
+            ) from e
+        self._web = WebClient(token=self.bot_token)
+        return self._web
+
+    def verify(self) -> Dict[str, Any]:
+        """Prove the bot token works and learn which workspace it belongs to.
+
+        Called before the socket opens so a bad token fails with Slack's own
+        reason rather than as an opaque WebSocket handshake failure.
+        """
+        web = self._build_web_client()
+        response = web.auth_test()
+        data = response.data if hasattr(response, "data") else response
+        if not data.get("ok", False):
+            raise RuntimeError(
+                f"Slack rejected the bot token: {data.get('error', 'unknown error')}. "
+                f"Re-copy the 'xoxb-' token from OAuth & Permissions, or re-run "
+                f"`gaia slack setup`."
+            )
+        if not self.team_id:
+            self.team_id = data.get("team_id")
+        return dict(data)
+
+    def start(self, *, connect: bool = True) -> None:
+        """Verify the token, start the agent child, and open the socket."""
+        self.verify()
+        self._channel = self._channel_factory(
+            on_event=self._on_agent_event,
+            argv=self._agent_argv,
+            on_busy=self._on_busy,
+        )
+        self._channel.start()
+        if connect:
+            self._connect()
+
+    def _connect(self) -> None:
+        try:
+            from slack_sdk.socket_mode import SocketModeClient
+        except ImportError as e:
+            raise SlackDependencyError(
+                "slack-sdk is required for Slack support. Install it with: "
+                'pip install "amd-gaia[slack]" '
+                "(see https://amd-gaia.ai/docs/guides/slack)"
+            ) from e
+        self._socket = SocketModeClient(
+            app_token=self.app_token, web_client=self._build_web_client()
+        )
+        self._socket.socket_mode_request_listeners.append(self.handle_request)
+        self._socket.connect()
+        log.info("Slack Socket Mode connected for workspace %s", self.team_id)
+
+    def _agent(self) -> AgentChannel:
+        """The agent channel, or an actionable error if start() never ran.
+
+        Not an ``assert``: ``python -O`` strips those, and this would then
+        surface as ``NoneType has no attribute submit`` from inside a Slack
+        event handler, naming neither the cause nor the fix.
+        """
+        if self._channel is None:
+            raise RuntimeError(
+                "The Slack adapter has no agent channel — start() was never "
+                "called, or it failed. Restart with `gaia slack start "
+                "--allowed-users <ids>`."
+            )
+        return self._channel
+
+    def close(self) -> None:
+        """Disconnect and stop the agent child."""
+        if self._socket is not None:
+            try:
+                self._socket.close()
+            except Exception as e:  # noqa: BLE001 - shutdown must not raise
+                log.debug("Slack socket already closed: %s", e)
+        if self._channel is not None:
+            self._channel.close()
+
+    # ------------------------------------------------------------------
+    # Inbound
+    # ------------------------------------------------------------------
+
+    def handle_request(self, client: Any, req: Any) -> None:
+        """Dispatch one Socket Mode request.
+
+        Every request is acknowledged first: Slack retries anything unacked
+        within three seconds, and a turn takes far longer than that, so a late
+        ack turns one question into three.
+        """
+        self._ack(client, req)
+        try:
+            if req.type == "events_api":
+                self._handle_event(req.payload or {})
+            elif req.type == "interactive":
+                self._handle_interactive(req.payload or {})
+        except Exception:
+            # A raised handler kills the socket's listener thread and the bot
+            # goes quiet with no indication why.
+            log.exception("Slack request handler failed for type %r", req.type)
+
+    @staticmethod
+    def _ack(client: Any, req: Any) -> None:
+        try:
+            from slack_sdk.socket_mode.response import SocketModeResponse
+
+            client.send_socket_mode_response(
+                SocketModeResponse(envelope_id=req.envelope_id)
+            )
+        except ImportError:
+            log.debug("slack_sdk missing while acking — test context")
+        except Exception as e:  # noqa: BLE001 - a failed ack must not drop the event
+            log.warning("Could not acknowledge Slack request: %s", e)
+
+    def _handle_event(self, payload: Dict[str, Any]) -> None:
+        event = payload.get("event") or {}
+        if event.get("type") != "message":
+            return
+        # A bot's own replies come back as events; answering them is an infinite
+        # loop with a local LLM at the bottom of it.
+        if event.get("bot_id") or event.get("subtype") in {
+            "bot_message",
+            "message_changed",
+            "message_deleted",
+        }:
+            return
+        # DM-only. Anyone in a channel can address a bot in it, so channels are
+        # a separate security decision, not a configuration one.
+        if event.get("channel_type") != "im":
+            audit.warning(
+                "Ignored a Slack message in channel_type=%r — this bridge "
+                "answers direct messages only",
+                event.get("channel_type"),
+            )
+            return
+
+        team = payload.get("team_id") or event.get("team")
+        if not self._same_workspace(team):
+            audit.warning(
+                "Refused a Slack message from workspace %r — this bridge is "
+                "bound to %r",
+                team,
+                self.team_id,
+            )
+            return
+
+        user = event.get("user")
+        channel = event.get("channel")
+        ts = event.get("ts", "")
+        if not self._allowed(user):
+            audit.warning(
+                "Refused a Slack message from unauthorized member %s "
+                "(allowlist holds %d id(s)) — add the id to --allowed-users if "
+                "this refusal is wrong",
+                user,
+                len(self.allowed_users),
+            )
+            self._post(channel, UNAUTHORIZED_REPLY, thread_ts=ts)
+            return
+
+        audit.info("Authorized Slack member %s in %s", user, channel)
+        text = (event.get("text") or "").strip()
+        note = self._ingest_files(event.get("files") or [])
+        question = f"{text} {note}".strip()
+        if not question:
+            self._post(
+                channel,
+                "I got an empty message — send me a question.",
+                thread_ts=ts,
+            )
+            return
+
+        target = ReplyTarget(channel=channel, thread_ts=ts)
+        target.reply_ts = self._post(channel, "_Thinking…_", thread_ts=ts)
+        target.throttle = StreamThrottle(
+            flush=lambda body: self._update(target, body),
+            interval=EDIT_INTERVAL,
+        )
+        self._agent().submit(Turn(text=question, context=target, sender=user or ""))
+
+    def _ingest_files(self, files: Sequence[Dict[str, Any]]) -> str:
+        """Download shared files and hand them to RAG or the VLM.
+
+        Reuses the ingestion the Telegram adapter already uses, so a document
+        arriving over Slack lands in the same index as one added locally.
+        """
+        notes: List[str] = []
+        for meta in files:
+            name = meta.get("name") or meta.get("id") or "file"
+            size = meta.get("size") or 0
+            if size and size > MAX_DOWNLOAD_BYTES:
+                notes.append(f"[{name} skipped — larger than 100 MB]")
+                continue
+            url = meta.get("url_private_download") or meta.get("url_private")
+            if not url:
+                notes.append(f"[{name} skipped — Slack gave no download URL]")
+                continue
+            try:
+                path = self._download(url, name)
+            except Exception as e:  # noqa: BLE001 - one bad file must not kill the turn
+                log.warning("Could not download Slack file %s: %s", name, e)
+                notes.append(f"[{name} could not be downloaded]")
+                continue
+            mimetype = str(meta.get("mimetype") or "")
+            if mimetype.startswith("image/"):
+                result = ingest_image_to_vlm(path)
+                if result.get("status") == "success":
+                    excerpt = (result.get("text") or "").strip()
+                    notes.append(
+                        f"[image {name}: {excerpt[:400]}]"
+                        if excerpt
+                        else f"[image {name} processed]"
+                    )
+                else:
+                    notes.append(f"[image {name} — the vision model could not read it]")
+            else:
+                result = ingest_document_to_rag(path)
+                notes.append(
+                    f"[file indexed: {name}]"
+                    if result.get("success")
+                    else f"[file {name} — indexing failed]"
+                )
+        return " ".join(notes)
+
+    def _download(self, url: str, name: str) -> str:
+        """Fetch a private Slack file to a temp path using the bot token."""
+        import requests
+
+        response = requests.get(
+            url,
+            headers={"Authorization": f"Bearer {self.bot_token}"},
+            timeout=60,
+            stream=True,
+        )
+        response.raise_for_status()
+        suffix = Path(name).suffix
+        handle, path = tempfile.mkstemp(prefix="gaia_slack_", suffix=suffix)
+        written = 0
+        with os.fdopen(handle, "wb") as fh:
+            for chunk in response.iter_content(chunk_size=65536):
+                written += len(chunk)
+                if written > MAX_DOWNLOAD_BYTES:
+                    raise ValueError(
+                        f"{name} exceeded the {MAX_DOWNLOAD_BYTES} byte download cap"
+                    )
+                fh.write(chunk)
+        return path
+
+    def _handle_interactive(self, payload: Dict[str, Any]) -> None:
+        """Answer a tool confirmation from a Block Kit button click."""
+        user = (payload.get("user") or {}).get("id")
+        team = (payload.get("team") or {}).get("id")
+        if not self._same_workspace(team):
+            audit.warning("Refused a Slack button click from workspace %r", team)
+            return
+        if not self._allowed(user):
+            # The buttons are visible to anyone who can see the DM, and a shared
+            # channel or a workspace admin viewing it must not be able to
+            # approve a command on the owner's machine.
+            audit.warning("Refused a tool approval from unauthorized member %s", user)
+            return
+        for action in payload.get("actions") or []:
+            action_id = action.get("action_id")
+            decision = _ACTION_DECISIONS.get(action_id)
+            if decision is None:
+                continue
+            confirm_id = action.get("value") or ""
+            audit.warning(
+                "Slack member %s answered %r for confirmation %s",
+                user,
+                decision,
+                confirm_id or "(none pending)",
+            )
+            self._agent().decide(decision, confirm_id or None)
+            self._settle_confirmation(confirm_id, decision, user)
+
+    def _settle_confirmation(
+        self, confirm_id: str, decision: str, user: Optional[str]
+    ) -> None:
+        """Replace a confirmation's buttons with the decision that was made.
+
+        Without this the buttons stay live after the turn moved on, and a second
+        click looks like it did something when it did not.
+        """
+        with self._lock:
+            posted = self._confirmations.pop(confirm_id, None)
+        if not posted:
+            return
+        channel, ts, action = posted
+        verb = {
+            DECISION_ALLOW: "Allowed",
+            DECISION_ALWAYS: "Always allowed",
+            DECISION_DENY: "Denied",
+        }[decision]
+        self._edit(
+            channel,
+            ts,
+            f"*{verb}* — {action}" + (f"  (by <@{user}>)" if user else ""),
+            blocks=[],
+        )
+
+    def _on_busy(self, turn: Turn, ahead: int) -> None:
+        """Tell the sender their message is queued behind a running turn."""
+        target = turn.context
+        if not isinstance(target, ReplyTarget):
+            return
+        self._update(
+            target,
+            f"_Queued — finishing {ahead} earlier message"
+            f"{'s' if ahead != 1 else ''} first…_",
+        )
+
+    # ------------------------------------------------------------------
+    # Outbound — rendering agent events
+    # ------------------------------------------------------------------
+
+    def _on_agent_event(self, event: Dict[str, Any], turn: Turn) -> None:
+        target = turn.context
+        if not isinstance(target, ReplyTarget):
+            log.warning("Dropped an agent event with no Slack reply target")
+            return
+        etype = event.get("type")
+        if etype == "token":
+            if target.throttle is not None:
+                target.throttle.add(str(event.get("text") or event.get("token") or ""))
+        elif etype == "status":
+            # Only shown while nothing has streamed yet; once tokens arrive,
+            # replacing the answer with a status line is a regression.
+            if target.throttle is not None and not target.throttle.text:
+                self._update(target, f"_{event.get('message') or 'Working…'}_")
+        elif etype == "tool_call":
+            self._note_tool(target, str(event.get("tool") or "a tool"))
+        elif etype == "tool_result":
+            self._maybe_upload(target, event)
+        elif etype == "needs_confirmation":
+            self._ask_confirmation(target, event)
+        elif etype == "final":
+            self._finish(target, str(event.get("answer") or ""))
+        elif etype == "error":
+            self._finish(
+                target,
+                f":warning: {event.get('detail') or 'The agent failed.'}",
+            )
+
+    def _note_tool(self, target: ReplyTarget, tool: str) -> None:
+        """Show what the agent is doing while it is doing it."""
+        if tool not in target.tools:
+            target.tools.append(tool)
+        if target.throttle is not None and not target.throttle.text:
+            self._update(target, f"_Using `{tool}`…_")
+
+    def _ask_confirmation(self, target: ReplyTarget, event: Dict[str, Any]) -> None:
+        """Post the approval buttons — or refuse outright when locked down."""
+        action = str(event.get("action") or "run a tool")
+        summary = str(event.get("summary") or "")
+        confirm_id = str(event.get("confirm_id") or "")
+        if self.deny_gated_tools:
+            audit.warning(
+                "Auto-denied %r: this bridge runs with --deny-gated-tools", action
+            )
+            self._agent().decide(DECISION_DENY, confirm_id or None)
+            self._post(
+                target.channel,
+                f"_Refused *{action}* — this Slack bridge is running read-only "
+                f"(`--deny-gated-tools`)._",
+                thread_ts=target.thread_ts,
+            )
+            return
+        blocks = confirmation_blocks(
+            action, summary, str(event.get("always_scope") or "")
+        )
+        for block in blocks:
+            for element in block.get("elements", []):
+                # The decision has to name WHICH prompt it answers, or a late
+                # click resolves whatever confirmation replaced the one it was
+                # typed for.
+                element["value"] = confirm_id
+        ts = self._post(
+            target.channel,
+            f"GAIA wants to {action}",
+            thread_ts=target.thread_ts,
+            blocks=blocks,
+        )
+        if confirm_id and ts:
+            with self._lock:
+                self._confirmations[confirm_id] = (target.channel, ts, action)
+
+    def _maybe_upload(self, target: ReplyTarget, event: Dict[str, Any]) -> None:
+        """Send back a file the agent just wrote.
+
+        Only paths the agent itself reported, only under an upload root, only
+        once per turn, and only within the size cap. Writing the file was
+        already approved through the confirmation gate, so handing back what the
+        user asked for needs no second prompt — but a path outside the roots is
+        refused, because that approval covered a write, not a transfer.
+        """
+        data = event.get("data")
+        if not isinstance(data, dict):
+            return
+        raw = data.get("file_path")
+        if not raw or not isinstance(raw, str):
+            return
+        try:
+            path = Path(raw).expanduser().resolve()
+        except OSError:
+            return
+        key = str(path)
+        if key in target.uploaded or not path.is_file():
+            return
+        if not any(path == root or root in path.parents for root in self.upload_roots):
+            audit.warning(
+                "Refused to upload %s — outside the allowed upload roots %s",
+                path,
+                ", ".join(str(r) for r in self.upload_roots),
+            )
+            return
+        if path.stat().st_size > MAX_UPLOAD_BYTES:
+            log.info("Skipped uploading %s — larger than the 25 MB cap", path)
+            return
+        target.uploaded.add(key)
+        try:
+            self._upload(target, path)
+        except Exception as e:  # noqa: BLE001 - a failed upload must not kill the turn
+            log.warning("Could not upload %s to Slack: %s", path, e)
+
+    def _upload(self, target: ReplyTarget, path: Path) -> None:
+        """Upload one file. ``files_upload_v2`` — ``files.upload`` is retired."""
+        web = self._build_web_client()
+        web.files_upload_v2(
+            channel=target.channel,
+            thread_ts=target.thread_ts,
+            file=str(path),
+            filename=path.name,
+            initial_comment=f"Here's `{path.name}`.",
+        )
+        log.info("Uploaded %s to Slack channel %s", path.name, target.channel)
+
+    def _finish(self, target: ReplyTarget, answer: str) -> None:
+        """Write the final answer, replacing whatever was streaming."""
+        if target.throttle is not None and answer:
+            # The final answer is authoritative — the streamed text can be a
+            # partial render of the same content.
+            self._update(target, answer)
+        elif target.throttle is not None:
+            target.throttle.finish()
+        trail = ", ".join(f"`{t}`" for t in target.tools)
+        if trail:
+            self._post(
+                target.channel,
+                f"_Used {trail}_",
+                thread_ts=target.thread_ts,
+            )
+
+    # ------------------------------------------------------------------
+    # Slack primitives
+    # ------------------------------------------------------------------
+
+    def _post(
+        self,
+        channel: str,
+        text: str,
+        *,
+        thread_ts: str = "",
+        blocks: Optional[List[dict]] = None,
+    ) -> str:
+        """Post a message, returning its timestamp (empty string on failure)."""
+        web = self._build_web_client()
+        kwargs: Dict[str, Any] = {"channel": channel, "text": _truncate(text)}
+        if thread_ts:
+            kwargs["thread_ts"] = thread_ts
+        if blocks is not None:
+            kwargs["blocks"] = blocks
+        try:
+            response = web.chat_postMessage(**kwargs)
+        except Exception as e:  # noqa: BLE001 - a failed post must not kill the turn
+            log.warning("Could not post to Slack channel %s: %s", channel, e)
+            return ""
+        data = response.data if hasattr(response, "data") else response
+        return str(data.get("ts") or "")
+
+    def _edit(
+        self,
+        channel: str,
+        ts: str,
+        text: str,
+        blocks: Optional[List[dict]] = None,
+    ) -> None:
+        web = self._build_web_client()
+        kwargs: Dict[str, Any] = {"channel": channel, "ts": ts, "text": _truncate(text)}
+        if blocks is not None:
+            kwargs["blocks"] = blocks
+        try:
+            web.chat_update(**kwargs)
+        except Exception as e:  # noqa: BLE001 - rate limits must not kill the turn
+            log.debug("Could not edit Slack message %s: %s", ts, e)
+
+    def _update(self, target: ReplyTarget, text: str) -> None:
+        """Edit the turn's reply in place, posting one if there is none yet."""
+        if not target.reply_ts:
+            target.reply_ts = self._post(
+                target.channel, text, thread_ts=target.thread_ts
+            )
+            return
+        self._edit(target.channel, target.reply_ts, text)
+
+
+def run_slack(
+    bot_token: str,
+    app_token: str,
+    allowed_users: Optional[Set[str]] = None,
+    *,
+    team_id: Optional[str] = None,
+    agent_argv: Optional[Sequence[str]] = None,
+    deny_gated_tools: bool = False,
+    upload_roots: Optional[Sequence[str]] = None,
+) -> SlackAdapter:
+    """Build and start a Slack adapter.
+
+    Raises:
+        SlackAllowlistError: if ``allowed_users`` is empty. Every member of a
+            workspace can DM a bot, so an empty allowlist would offer the local
+            agent to all of them.
+    """
+    adapter = SlackAdapter(
+        bot_token=bot_token,
+        app_token=app_token,
+        allowed_users=allowed_users,
+        team_id=team_id,
+        agent_argv=agent_argv,
+        deny_gated_tools=deny_gated_tools,
+        upload_roots=upload_roots,
+    )
+    adapter.start()
+    return adapter

--- a/src/gaia/messaging/slack/cli.py
+++ b/src/gaia/messaging/slack/cli.py
@@ -1,0 +1,379 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""``gaia slack`` — setup, start, stop, status.
+
+Kept out of ``gaia/cli.py`` so that file stays a parser rather than a program,
+and so the TUI can drive the same flow: every screen it needs is a function
+here, not a block of argparse handling.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import sys
+import webbrowser
+from pathlib import Path
+from typing import Callable, List, Optional, Sequence, Set
+
+from gaia.logger import get_logger
+from gaia.messaging.slack import credentials, manifest, onboarding
+
+log = get_logger(__name__)
+
+#: Where a backgrounded bridge records its pid, matching the Telegram adapter's
+#: layout so one supervisor convention covers both.
+PID_PATH = Path.home() / ".gaia" / "slack.pid"
+
+
+def parse_allowed_users(raw: Optional[str]) -> Set[str]:
+    """Split a comma-separated allowlist into Slack member IDs.
+
+    Slack member IDs are opaque strings (``U024BE7LH``), not numbers, so the
+    only validation available is non-emptiness — and the shape check below,
+    which catches the common paste of a @handle or an email instead of the ID.
+    """
+    if not raw:
+        return set()
+    ids = {part.strip() for part in raw.split(",") if part.strip()}
+    wrong = sorted(i for i in ids if not i[:1].isalpha() or "@" in i)
+    if wrong:
+        raise ValueError(
+            f"These do not look like Slack member IDs: {', '.join(wrong)}. "
+            f"A member ID looks like 'U024BE7LH' — find yours in Slack under "
+            f"your avatar -> Profile -> the ... menu -> Copy member ID. A "
+            f"display name or an email address will not work."
+        )
+    return ids
+
+
+def run_setup(
+    *,
+    prompt: Callable[[str], str] = input,
+    emit: Callable[[str], None] = print,
+    open_browser: bool = True,
+    app_name: str = manifest.DEFAULT_APP_NAME,
+) -> int:
+    """Walk the user through creating the Slack app and store its tokens.
+
+    Injectable ``prompt``/``emit`` so the TUI and the tests drive the same flow
+    the CLI does, rather than a second copy of it that can disagree.
+    """
+    url = manifest.create_app_url(app_name)
+    emit("")
+    emit("Connecting GAIA to Slack.")
+    emit("")
+    emit(
+        "Slack apps can only be created from api.slack.com, so this cannot be "
+        "fully automatic. The manifest is filled in for you; you paste two "
+        "tokens back. About ninety seconds."
+    )
+    emit("")
+    for step in manifest.SETUP_STEPS:
+        emit(f"  {step}")
+    emit("")
+    emit(f"Create-app URL:\n  {url}")
+    emit("")
+
+    if open_browser:
+        try:
+            webbrowser.open(url)
+        except Exception as e:  # noqa: BLE001 - a headless box has no browser
+            log.debug("Could not open a browser: %s", e)
+            emit("(Could not open a browser — copy the URL above.)")
+
+    app_token = prompt("App-level token (xapp-…): ").strip()
+    bot_token = prompt("Bot user OAuth token (xoxb-…): ").strip()
+
+    try:
+        manifest.validate_tokens(bot_token, app_token)
+    except manifest.TokenFormatError as e:
+        emit(f"\n❌ {e}")
+        return 2
+
+    # Prove the token works BEFORE storing it, so a typo is caught here rather
+    # than at the next start with an opaque WebSocket failure.
+    from gaia.messaging.slack.adapter import SlackAdapter
+
+    probe = SlackAdapter(
+        bot_token=bot_token,
+        app_token=app_token,
+        # The probe never serves anyone; the allowlist is a placeholder that
+        # satisfies the constructor's refusal to exist without one.
+        allowed_users={"__setup_probe__"},
+    )
+    try:
+        identity = probe.verify()
+    except Exception as e:  # noqa: BLE001 - surfaced verbatim below
+        emit(f"\n❌ Slack rejected the tokens: {e}")
+        emit("Re-copy both tokens and run `gaia slack setup` again.")
+        return 1
+
+    credentials.save(bot_token=bot_token, app_token=app_token)
+    team = identity.get("team") or identity.get("team_id") or "your workspace"
+    user_id = identity.get("user_id") or ""
+    onboarding.record_decision(
+        onboarding.STATE_CONNECTED,
+        detected=True,
+        team_name=str(team),
+    )
+
+    emit("")
+    emit(f"✅ Connected to {team} as {identity.get('user', 'GAIA')}.")
+    emit("")
+    emit("Before you start it, decide who may use it. Everyone in a workspace")
+    emit("can DM a bot, and this bridge drives the full agent — it can read")
+    emit("your files and ask to run commands.")
+    emit("")
+    emit("  gaia slack start --allowed-users <your member ID>")
+    emit("")
+    emit(
+        "Find your member ID in Slack: your avatar -> Profile -> the ... menu "
+        "-> Copy member ID."
+    )
+    if user_id:
+        emit(f"(The bot itself is {user_id} — that is not the ID you want.)")
+    return 0
+
+
+def run_start(
+    *,
+    allowed_users: Optional[str],
+    agent_command: Optional[str] = None,
+    deny_gated_tools: bool = False,
+    upload_roots: Optional[Sequence[str]] = None,
+    background: bool = False,
+    emit: Callable[[str], None] = print,
+) -> int:
+    """Start the bridge. Blocks until interrupted unless ``background``."""
+    from gaia.messaging.slack.adapter import (
+        SlackAdapter,
+        SlackAllowlistError,
+        SlackDependencyError,
+    )
+
+    try:
+        allowed = parse_allowed_users(allowed_users)
+    except ValueError as e:
+        emit(f"❌ {e}")
+        return 2
+
+    try:
+        creds = credentials.load()
+    except credentials.SlackCredentialsError as e:
+        emit(f"❌ {e}")
+        return 2
+
+    agent_argv: Optional[List[str]] = None
+    if agent_command:
+        import shlex
+
+        agent_argv = shlex.split(agent_command)
+
+    try:
+        adapter = SlackAdapter(
+            bot_token=creds.bot_token,
+            app_token=creds.app_token,
+            allowed_users=allowed,
+            agent_argv=agent_argv,
+            deny_gated_tools=deny_gated_tools,
+            upload_roots=upload_roots,
+        )
+    except SlackAllowlistError as e:
+        emit(f"❌ {e}")
+        return 2
+
+    if background:
+        _write_pid()
+    try:
+        adapter.start()
+    except SlackDependencyError as e:
+        emit(f"❌ {e}")
+        _clear_pid(background)
+        return 1
+    except Exception as e:  # noqa: BLE001 - surfaced with its own message
+        emit(f"❌ Could not start the Slack bridge: {e}")
+        _clear_pid(background)
+        return 1
+
+    emit(
+        f"✅ Slack bridge running for {len(allowed)} allowed member(s) in "
+        f"workspace {adapter.team_id}."
+    )
+    emit(
+        "   Direct messages only. Shell and file writes will ask before " "running."
+        if not deny_gated_tools
+        else "   Direct messages only. Running read-only — every gated tool is "
+        "auto-denied."
+    )
+    emit("   Press Ctrl-C to stop.")
+
+    try:
+        _sleep_forever()
+    except KeyboardInterrupt:
+        emit("\nStopping…")
+    finally:
+        adapter.close()
+        _clear_pid(background)
+    return 0
+
+
+def _sleep_forever() -> None:
+    """Block until interrupted.
+
+    ``threading.Event().wait()`` rather than ``signal.pause()``: Windows has no
+    ``pause``, and an unbounded ``wait()`` still raises KeyboardInterrupt in the
+    main thread on both platforms.
+    """
+    import threading
+
+    threading.Event().wait()
+
+
+def _write_pid() -> None:
+    PID_PATH.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        PID_PATH.write_text(str(os.getpid()), encoding="utf-8")
+    except OSError as e:
+        # The pid file is load-bearing in background mode: without it nothing
+        # can find or stop this process.
+        raise RuntimeError(
+            f"Could not write the Slack pid file at {PID_PATH}: {e}. Ensure "
+            f"~/.gaia is writable, or start without --background."
+        ) from e
+
+
+def _clear_pid(background: bool) -> None:
+    if not background:
+        return
+    try:
+        PID_PATH.unlink(missing_ok=True)
+    except OSError as e:
+        log.warning("Could not remove the Slack pid file: %s", e)
+
+
+def run_stop(*, emit: Callable[[str], None] = print) -> int:
+    """Stop a backgrounded bridge."""
+    try:
+        pid = int(PID_PATH.read_text(encoding="utf-8").strip())
+    except FileNotFoundError:
+        emit("No backgrounded Slack bridge is recorded as running.")
+        return 0
+    except (OSError, ValueError) as e:
+        emit(f"❌ Could not read the Slack pid file at {PID_PATH}: {e}")
+        return 1
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        emit(f"No process {pid} — clearing the stale pid file.")
+        PID_PATH.unlink(missing_ok=True)
+        return 0
+    except OSError as e:
+        emit(f"❌ Could not stop process {pid}: {e}")
+        return 1
+    PID_PATH.unlink(missing_ok=True)
+    emit(f"Stopped the Slack bridge (pid {pid}).")
+    return 0
+
+
+def run_decline(*, never: bool = False, emit: Callable[[str], None] = print) -> int:
+    """Record that the user does not want Slack set up.
+
+    ``never`` is the difference between "not now" and "stop asking". A plain
+    decline is reconsidered exactly once, if Slack appears on a machine that
+    did not have it when the answer was given; ``--never`` is honoured forever.
+
+    Exists as a command so the TUI records the decision through the same state
+    machine the CLI uses, rather than writing the file itself and drifting from
+    it.
+    """
+    detected = onboarding.detect_slack()
+    state = onboarding.STATE_NEVER if never else onboarding.STATE_SKIPPED
+    onboarding.record_decision(state, detected=detected)
+    if never:
+        emit("Won't ask about Slack again. `gaia slack setup` still works.")
+    else:
+        emit(
+            "Skipped Slack setup."
+            + (
+                ""
+                if detected
+                else " You'll be offered it once if you install Slack later."
+            )
+        )
+    return 0
+
+
+def status(detect: bool = True) -> dict:
+    """Everything a status line or a TUI row needs, as plain data."""
+    state = onboarding.load_state()
+    creds = credentials.load_optional()
+    detected = onboarding.detect_slack() if detect else False
+    return {
+        "slack_installed": detected,
+        "configured": creds is not None,
+        "onboarding_state": state.state,
+        "team_name": state.team_name,
+        "should_offer_setup": onboarding.should_offer(state, detected),
+        "running": _pid_alive(),
+    }
+
+
+def _pid_alive() -> bool:
+    try:
+        pid = int(PID_PATH.read_text(encoding="utf-8").strip())
+    except (OSError, ValueError):
+        return False
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def run_status(*, as_json: bool = False, emit: Callable[[str], None] = print) -> int:
+    """Print the bridge's configuration and liveness."""
+    info = status()
+    if as_json:
+        emit(json.dumps(info, indent=2))
+        return 0
+    emit(
+        f"Slack app installed on this machine: {'yes' if info['slack_installed'] else 'no'}"
+    )
+    emit(
+        f"GAIA configured for Slack:           {'yes' if info['configured'] else 'no'}"
+    )
+    if info["team_name"]:
+        emit(f"Workspace:                           {info['team_name']}")
+    emit(f"Bridge running (backgrounded):       {'yes' if info['running'] else 'no'}")
+    if info["should_offer_setup"]:
+        emit("")
+        emit("Slack is installed but not connected. Run `gaia slack setup`.")
+    return 0
+
+
+def main(args) -> int:
+    """Dispatch one ``gaia slack <action>`` invocation."""
+    action = getattr(args, "slack_action", None)
+    if action == "setup":
+        return run_setup(open_browser=not getattr(args, "no_browser", False))
+    if action == "start":
+        return run_start(
+            allowed_users=getattr(args, "allowed_users", None),
+            agent_command=getattr(args, "agent_command", None),
+            deny_gated_tools=getattr(args, "deny_gated_tools", False),
+            upload_roots=getattr(args, "upload_root", None),
+            background=getattr(args, "background", False),
+        )
+    if action == "stop":
+        return run_stop()
+    if action == "decline":
+        return run_decline(never=getattr(args, "never", False))
+    if action == "status":
+        return run_status(as_json=getattr(args, "json", False))
+    print(
+        "No slack action specified. Use: gaia slack setup|start|stop|status|decline",
+        file=sys.stderr,
+    )
+    return 2

--- a/src/gaia/messaging/slack/credentials.py
+++ b/src/gaia/messaging/slack/credentials.py
@@ -1,0 +1,123 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Where the two Slack tokens live.
+
+The OS keyring, never a file. A bot token is a standing grant to post as GAIA in
+the user's workspace and an app-level token opens the socket that carries their
+messages; both belong with the credentials the connectors framework already
+stores, and neither belongs in a JSON file that a backup or a screen-share would
+carry off the machine.
+
+Tokens can also arrive from the environment (``GAIA_SLACK_BOT_TOKEN`` /
+``GAIA_SLACK_APP_TOKEN``), which is how a container or a CI job supplies them
+without a keyring at all. The environment wins over the keyring, so an operator
+overriding a stored token does not have to clear it first.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+from gaia.logger import get_logger
+
+log = get_logger(__name__)
+
+#: Shared with the connectors framework so GAIA has one credential service on
+#: the user's keyring rather than two.
+SERVICE_NAME = "gaia.connections"
+
+BOT_TOKEN_KEY = "slack:bot_token"
+APP_TOKEN_KEY = "slack:app_token"
+
+BOT_TOKEN_ENV_VAR = "GAIA_SLACK_BOT_TOKEN"
+APP_TOKEN_ENV_VAR = "GAIA_SLACK_APP_TOKEN"
+
+
+class SlackCredentialsError(RuntimeError):
+    """The Slack tokens are missing or could not be reached."""
+
+
+@dataclass(frozen=True)
+class SlackCredentials:
+    """The pair of tokens the adapter needs."""
+
+    bot_token: str
+    app_token: str
+
+
+def _keyring():
+    """Import keyring through the connectors guard for an actionable error."""
+    from gaia.connectors._keyring import keyring, normalize_keyring_backend_env
+
+    normalize_keyring_backend_env()
+    return keyring
+
+
+def save(bot_token: str, app_token: str) -> None:
+    """Store both tokens in the OS keyring."""
+    keyring = _keyring()
+    keyring.set_password(SERVICE_NAME, BOT_TOKEN_KEY, bot_token)
+    keyring.set_password(SERVICE_NAME, APP_TOKEN_KEY, app_token)
+    log.info("Stored Slack tokens in the OS keyring under %s", SERVICE_NAME)
+
+
+def clear() -> None:
+    """Remove both tokens. Missing entries are not an error."""
+    keyring = _keyring()
+    for key in (BOT_TOKEN_KEY, APP_TOKEN_KEY):
+        try:
+            keyring.delete_password(SERVICE_NAME, key)
+        except keyring.errors.PasswordDeleteError:
+            # Already absent — the desired end state either way.
+            log.debug("No stored Slack credential for %s", key)
+
+
+def load() -> SlackCredentials:
+    """Return both tokens, environment first, then the keyring.
+
+    Raises:
+        SlackCredentialsError: when either token is missing, naming the command
+            that creates them rather than failing later inside a socket
+            handshake with an opaque error.
+    """
+    bot = os.environ.get(BOT_TOKEN_ENV_VAR)
+    app = os.environ.get(APP_TOKEN_ENV_VAR)
+    if not (bot and app):
+        try:
+            keyring = _keyring()
+            bot = bot or keyring.get_password(SERVICE_NAME, BOT_TOKEN_KEY)
+            app = app or keyring.get_password(SERVICE_NAME, APP_TOKEN_KEY)
+        except Exception as e:  # noqa: BLE001 - re-raised with the remedy below
+            raise SlackCredentialsError(
+                f"Could not read the Slack tokens from the OS keyring: {e}. "
+                f"Set {BOT_TOKEN_ENV_VAR} and {APP_TOKEN_ENV_VAR} in the "
+                f"environment instead, or re-run `gaia slack setup`."
+            ) from e
+
+    missing = [
+        name
+        for name, value in ((BOT_TOKEN_ENV_VAR, bot), (APP_TOKEN_ENV_VAR, app))
+        if not value
+    ]
+    if missing:
+        raise SlackCredentialsError(
+            f"Slack is not set up on this machine: no "
+            f"{' and no '.join(missing)}. Run `gaia slack setup` to create the "
+            f"app and store its tokens, or export them directly. "
+            f"Docs: https://amd-gaia.ai/docs/guides/slack"
+        )
+    return SlackCredentials(bot_token=bot, app_token=app)
+
+
+def load_optional() -> Optional[SlackCredentials]:
+    """Return the tokens, or ``None`` when Slack has not been set up.
+
+    For callers that ask "is this configured?" — a status line, the TUI's
+    readiness row — where absence is an answer rather than a failure.
+    """
+    try:
+        return load()
+    except SlackCredentialsError:
+        return None

--- a/src/gaia/messaging/slack/manifest.py
+++ b/src/gaia/messaging/slack/manifest.py
@@ -1,0 +1,151 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""The Slack app manifest GAIA needs, and the one-click URL that creates it.
+
+Setup cannot be fully automatic and this module is where that limit lives. A
+Slack app can only be created by a human at api.slack.com — Slack's own
+``apps.manifest.create`` API does not help, because the configuration token it
+requires is itself obtained by hand from that same page. What *is* automatable is
+everything after the click: :func:`create_app_url` opens the "create an app"
+page with a manifest that already has the right scopes, Socket Mode on, and the
+DM event subscribed, so the user never edits a settings form.
+
+Socket Mode is not a preference. It makes the connection an OUTBOUND WebSocket,
+so a local agent needs no public URL, no inbound port, no tunnel, and no request
+signing secret that could leak. A request-URL app would need all four.
+"""
+
+from __future__ import annotations
+
+import json
+from urllib.parse import urlencode
+
+#: What the user sees the app called in their workspace.
+DEFAULT_APP_NAME = "GAIA"
+
+#: Bot scopes, each tied to something the bridge actually does. Anything not
+#: needed is absent: the manifest is what the user is asked to approve, and an
+#: unexplained scope in it is a reason to refuse.
+BOT_SCOPES: tuple[str, ...] = (
+    # Post the reply and edit it as tokens stream in.
+    "chat:write",
+    # Read the DMs addressed to the bot.
+    "im:history",
+    # Open a DM to reach the user.
+    "im:write",
+    # Download a document or image the user shares, for RAG/VLM ingestion.
+    "files:read",
+    # Upload a file the agent produced back to the user.
+    "files:write",
+    # Resolve a user id to a name, so the allowlist can be shown in words.
+    "users:read",
+)
+
+#: The only event subscribed. ``message.im`` is DMs to the bot and nothing else:
+#: no channel history, no group messages. Widening this is a security decision,
+#: not a configuration one — see the adapter's DM-only rule.
+BOT_EVENTS: tuple[str, ...] = ("message.im",)
+
+#: Slack's app-creation page. ``new_app=1`` plus a manifest opens the create
+#: dialog pre-filled instead of the app list.
+CREATE_APP_ENDPOINT = "https://api.slack.com/apps"
+
+
+def build_manifest(app_name: str = DEFAULT_APP_NAME) -> dict:
+    """Return the app manifest describing a Socket Mode GAIA bot.
+
+    ``interactivity`` is enabled because tool approvals are Block Kit buttons;
+    without it Slack drops the button click and every gated tool would sit until
+    it timed out and denied.
+    """
+    return {
+        "display_information": {
+            "name": app_name,
+            "description": "Your local GAIA agent, reachable from Slack.",
+            "background_color": "#1a1a2e",
+        },
+        "features": {
+            "bot_user": {
+                "display_name": app_name,
+                # The bridge is started on demand, so claiming always-online
+                # would show a green dot while nothing is listening.
+                "always_online": False,
+            }
+        },
+        "oauth_config": {"scopes": {"bot": list(BOT_SCOPES)}},
+        "settings": {
+            "event_subscriptions": {"bot_events": list(BOT_EVENTS)},
+            "interactivity": {"is_enabled": True},
+            "org_deploy_enabled": False,
+            "socket_mode_enabled": True,
+            "token_rotation_enabled": False,
+        },
+    }
+
+
+def create_app_url(app_name: str = DEFAULT_APP_NAME) -> str:
+    """Return the URL that opens Slack's create-app dialog, manifest pre-filled."""
+    manifest = json.dumps(build_manifest(app_name), separators=(",", ":"))
+    return (
+        f"{CREATE_APP_ENDPOINT}?{urlencode({'new_app': 1, 'manifest_json': manifest})}"
+    )
+
+
+#: The two tokens the user pastes back, and how each is recognised. Both are
+#: checked before anything is stored: a bot token pasted into the app-token field
+#: is the single most common setup mistake, and it fails at connect time with an
+#: error that names neither field.
+BOT_TOKEN_PREFIX = "xoxb-"
+APP_TOKEN_PREFIX = "xapp-"
+
+
+class TokenFormatError(ValueError):
+    """A pasted token is not the kind of token that field needs."""
+
+
+def validate_tokens(bot_token: str, app_token: str) -> None:
+    """Raise :class:`TokenFormatError` unless both tokens look like their kind.
+
+    This is a shape check, not an authenticity check — the caller still proves
+    the tokens work by calling ``auth.test``. It exists to catch the swap before
+    a network round-trip turns it into a confusing 401.
+    """
+    bot_token = (bot_token or "").strip()
+    app_token = (app_token or "").strip()
+    if not bot_token.startswith(BOT_TOKEN_PREFIX):
+        hint = (
+            " That looks like the app-level token — it goes in the other field."
+            if bot_token.startswith(APP_TOKEN_PREFIX)
+            else ""
+        )
+        raise TokenFormatError(
+            f"The bot token must start with '{BOT_TOKEN_PREFIX}'.{hint} Find it "
+            f"under OAuth & Permissions → Bot User OAuth Token, after clicking "
+            f"Install to Workspace."
+        )
+    if not app_token.startswith(APP_TOKEN_PREFIX):
+        hint = (
+            " That looks like the bot token — it goes in the other field."
+            if app_token.startswith(BOT_TOKEN_PREFIX)
+            else ""
+        )
+        raise TokenFormatError(
+            f"The app-level token must start with '{APP_TOKEN_PREFIX}'.{hint} "
+            f"Generate it under Basic Information → App-Level Tokens with the "
+            f"'connections:write' scope."
+        )
+
+
+#: Printed by `gaia slack setup` and rendered by the TUI. Two manual steps is
+#: the floor; stating them plainly beats promising "automatic" and stranding the
+#: user on a settings page thirty seconds later.
+SETUP_STEPS = (
+    "1. A browser opens Slack's create-app page with the manifest filled in. "
+    "Pick your workspace and click Create.",
+    "2. On Basic Information → App-Level Tokens, click Generate, add the "
+    "'connections:write' scope, and copy the 'xapp-' token.",
+    "3. On OAuth & Permissions, click Install to Workspace, then copy the "
+    "'xoxb-' Bot User OAuth Token.",
+    "4. Paste both tokens here. They are stored in your OS keyring, never in a "
+    "config file.",
+)

--- a/src/gaia/messaging/slack/onboarding.py
+++ b/src/gaia/messaging/slack/onboarding.py
@@ -1,0 +1,214 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""When to offer Slack setup, and remembering the answer.
+
+The rule this module exists to encode: **offer once, then only again when
+something changed.** A prompt on every launch trains the user to dismiss it, and
+a prompt that never returns strands the user who installed Slack after saying no.
+So the decision is stored alongside whether Slack was detected *at the time it
+was made*, and a ``skipped`` answer is reconsidered exactly when detection flips
+from absent to present.
+
+Detection itself is not implemented here. ``SystemDiscovery.scan_installed_apps``
+already inventories installed applications on Windows, macOS and Linux and
+already categorises Slack; a second detector would be a second thing to be wrong
+on someone's machine.
+
+State lives in its own file rather than in ``GaiaConfig``: that dataclass has a
+fixed field set and ``save()`` writes only known fields, so a nested key added to
+it would be silently dropped by the next ``gaia config set``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+from gaia.logger import get_logger
+
+log = get_logger(__name__)
+
+#: Never offered, never asked. The starting point for every install.
+STATE_UNSET = "unset"
+#: Tokens are stored and the bridge can run.
+STATE_CONNECTED = "connected"
+#: "Not now." Reconsidered only when Slack appears on a machine that lacked it.
+STATE_SKIPPED = "skipped"
+#: "Stop asking." Honoured forever; `gaia slack setup` still works on demand.
+STATE_NEVER = "never"
+
+VALID_STATES = frozenset({STATE_UNSET, STATE_CONNECTED, STATE_SKIPPED, STATE_NEVER})
+
+#: The normalized entity slug ``scan_installed_apps`` stamps on a Slack record.
+#: Records look like ``{"entity": "app:slack", "content": "Installed app: Slack
+#: [Communication]"}`` — a memory *fact*, not an app row with a ``name`` field.
+#: Matching the slug exactly is both the cheapest check and the strictest: it
+#: cannot be fooled by "Slackware Tools" the way a substring search would be.
+_SLACK_ENTITY = "app:slack"
+
+#: Fallback for a record with no entity slug: the app name as it appears in the
+#: rendered ``content`` line. Anchored on word boundaries for the same reason.
+_SLACK_CONTENT = re.compile(r"^installed app:\s*slack\b", re.IGNORECASE)
+
+
+def _state_path() -> Path:
+    """Where the onboarding decision is stored.
+
+    Honours ``GAIA_CONFIG_DIR`` so a test — and a user with a relocated GAIA
+    home — never writes to the real one.
+    """
+    base = os.environ.get("GAIA_CONFIG_DIR")
+    root = Path(base) if base else Path.home() / ".gaia"
+    return root / "slack" / "onboarding.json"
+
+
+@dataclass
+class OnboardingState:
+    """The stored decision, plus what was true when it was made."""
+
+    state: str = STATE_UNSET
+    #: Whether Slack was installed at the moment the decision was recorded. This
+    #: is the whole mechanism behind "ask again if they install it later".
+    detected_when_decided: bool = False
+    #: Workspace the tokens belong to, shown in the TUI so a user with several
+    #: workspaces can tell which one is wired up. Never used for authorization.
+    team_name: str = ""
+    updated_at: float = 0.0
+
+    def __post_init__(self) -> None:
+        if self.state not in VALID_STATES:
+            raise ValueError(
+                f"Unknown Slack onboarding state {self.state!r}. "
+                f"Valid states: {', '.join(sorted(VALID_STATES))}."
+            )
+
+
+class OnboardingStateError(RuntimeError):
+    """The stored decision exists but cannot be read."""
+
+
+def slack_is_installed(apps: Iterable[Dict[str, Any]]) -> bool:
+    """True when an installed-app inventory contains Slack.
+
+    Takes the inventory rather than calling the scanner, so the caller decides
+    when to pay for a filesystem walk and a test needs no fake home directory.
+
+    Reads ``entity`` first and ``content`` only as a fallback, because that is
+    the shape ``scan_installed_apps`` actually returns — discovery facts, not
+    rows with a ``name``. Pinned by
+    ``tests/unit/messaging/test_slack_onboarding.py`` against a record captured
+    from a real scan, so a change to the discovery format fails here rather than
+    silently reporting that nobody has Slack.
+    """
+    for app in apps:
+        entity = str(app.get("entity") or "").strip().lower()
+        if entity == _SLACK_ENTITY:
+            return True
+        if not entity and _SLACK_CONTENT.match(str(app.get("content") or "").strip()):
+            return True
+    return False
+
+
+def detect_slack() -> bool:
+    """Scan this machine for Slack via the shared installed-app inventory.
+
+    Imported lazily: ``SystemDiscovery`` pulls in sqlite, plistlib and a registry
+    reader, none of which a caller that already has an inventory should pay for.
+    """
+    from gaia.agents.base.discovery import SystemDiscovery
+
+    return slack_is_installed(SystemDiscovery().scan_installed_apps())
+
+
+def load_state(path: Optional[Path] = None) -> OnboardingState:
+    """Read the stored decision. A missing file means "never asked".
+
+    A file that exists but is unreadable or malformed raises rather than
+    defaulting: silently resetting to "unset" would re-prompt a user who
+    explicitly said never, which is the one outcome the state exists to prevent.
+    """
+    state_file = path or _state_path()
+    try:
+        text = state_file.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return OnboardingState()
+    except OSError as e:
+        raise OnboardingStateError(
+            f"Cannot read the Slack onboarding state at {state_file}: {e}. "
+            f"Check permissions, or delete the file to be asked again."
+        ) from e
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as e:
+        raise OnboardingStateError(
+            f"The Slack onboarding state at {state_file} is not valid JSON: {e}. "
+            f"Delete the file to be asked again."
+        ) from e
+    if not isinstance(data, dict):
+        raise OnboardingStateError(
+            f"The Slack onboarding state at {state_file} must be a JSON object, "
+            f"got {type(data).__name__}. Delete the file to be asked again."
+        )
+
+    known = {"state", "detected_when_decided", "team_name", "updated_at"}
+    try:
+        return OnboardingState(**{k: v for k, v in data.items() if k in known})
+    except (TypeError, ValueError) as e:
+        raise OnboardingStateError(
+            f"The Slack onboarding state at {state_file} is not usable: {e}. "
+            f"Delete the file to be asked again."
+        ) from e
+
+
+def save_state(state: OnboardingState, path: Optional[Path] = None) -> None:
+    """Persist the decision, stamping the time it was made."""
+    state_file = path or _state_path()
+    state.updated_at = time.time()
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    state_file.write_text(json.dumps(asdict(state), indent=2) + "\n", encoding="utf-8")
+    log.debug("Saved Slack onboarding state %r to %s", state.state, state_file)
+
+
+def record_decision(
+    state_name: str,
+    *,
+    detected: bool,
+    team_name: str = "",
+    path: Optional[Path] = None,
+) -> OnboardingState:
+    """Store one answer to the setup offer."""
+    state = OnboardingState(
+        state=state_name, detected_when_decided=detected, team_name=team_name
+    )
+    save_state(state, path)
+    return state
+
+
+def should_offer(state: OnboardingState, detected: bool) -> bool:
+    """Whether to put the setup offer in front of the user right now.
+
+    ================  ==========  ====================================
+    Stored state      Detected    Offer?
+    ================  ==========  ====================================
+    ``unset``         yes         yes — the first-boot offer
+    ``unset``         no          no — nothing to connect to
+    ``skipped``       yes         only if Slack was ABSENT when skipped
+    ``never``         either      no, forever
+    ``connected``     either      no — already wired up
+    ================  ==========  ====================================
+    """
+    if not detected:
+        return False
+    if state.state == STATE_UNSET:
+        return True
+    if state.state == STATE_SKIPPED:
+        # The user said no on a machine without Slack; they have since installed
+        # it, so the answer they gave was to a different question.
+        return not state.detected_when_decided
+    return False

--- a/tests/unit/messaging/test_bridge.py
+++ b/tests/unit/messaging/test_bridge.py
@@ -1,0 +1,340 @@
+"""AgentChannel and StreamThrottle — the transport-agnostic half of a bridge.
+
+Driven against a fake child rather than a real ``gaia-agent``: the real one
+costs ~42s to construct before it answers anything, and none of the behaviour
+under test here is the agent's.
+"""
+
+import json
+import threading
+import time
+
+import pytest
+
+from gaia.messaging.bridge import (
+    CONTROL_KEY,
+    CONTROL_TOOL_DECISION,
+    DECISION_ALLOW,
+    DECISION_DENY,
+    QUERY_KEY,
+    AgentChannel,
+    AgentChannelError,
+    StreamThrottle,
+    Turn,
+)
+
+
+class FakeStdin:
+    """Captures every line the bridge writes to the child."""
+
+    def __init__(self):
+        self.lines = []
+        self.closed = False
+
+    def write(self, data):
+        self.lines.append(data.rstrip("\n"))
+
+    def flush(self):
+        pass
+
+    def close(self):
+        self.closed = True
+
+
+class FakeStdout:
+    """A blocking line iterator the test feeds events into."""
+
+    def __init__(self):
+        self._queue = []
+        self._cv = threading.Condition()
+        self._eof = False
+
+    def emit(self, event):
+        with self._cv:
+            self._queue.append(json.dumps(event) + "\n")
+            self._cv.notify_all()
+
+    def emit_raw(self, line):
+        with self._cv:
+            self._queue.append(line + "\n")
+            self._cv.notify_all()
+
+    def eof(self):
+        with self._cv:
+            self._eof = True
+            self._cv.notify_all()
+
+    def readline(self):
+        """Block for the next line; empty string means EOF, as a real pipe does."""
+        with self._cv:
+            while not self._queue and not self._eof:
+                self._cv.wait(timeout=2)
+            if self._queue:
+                return self._queue.pop(0)
+            return ""
+
+
+class FakeProc:
+    def __init__(self):
+        self.stdin = FakeStdin()
+        self.stdout = FakeStdout()
+        self.terminated = False
+
+    def terminate(self):
+        self.terminated = True
+
+
+@pytest.fixture
+def channel():
+    """A started channel plus its fake child and a record of dispatched events."""
+    proc = FakeProc()
+    seen = []
+    ch = AgentChannel(
+        on_event=lambda event, turn: seen.append((event, turn)),
+        spawn=lambda: proc,
+    )
+    ch.start()
+    yield ch, proc, seen
+    ch.close()
+
+
+def _wait_for(predicate, timeout=3.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+# ----------------------------------------------------------------------
+# Wire format
+# ----------------------------------------------------------------------
+
+
+def test_query_is_wrapped_so_a_multiline_question_stays_one_turn(channel):
+    """An unwrapped newline would become several unrelated questions."""
+    ch, proc, _ = channel
+    ch.submit(Turn(text="line one\nline two"))
+    assert _wait_for(lambda: proc.stdin.lines)
+    assert json.loads(proc.stdin.lines[0]) == {QUERY_KEY: "line one\nline two"}
+
+
+def test_decision_names_the_confirmation_it_answers(channel):
+    """Without confirm_id a late click resolves whatever replaced its prompt."""
+    ch, proc, _ = channel
+    ch.decide(DECISION_ALLOW, "confirm-7")
+    assert json.loads(proc.stdin.lines[-1]) == {
+        CONTROL_KEY: CONTROL_TOOL_DECISION,
+        "decision": DECISION_ALLOW,
+        "confirm_id": "confirm-7",
+    }
+
+
+def test_unknown_decision_fails_closed_to_deny(channel):
+    """A garbled decision must never be read as consent."""
+    ch, proc, _ = channel
+    ch.decide("maybe", "c1")
+    assert json.loads(proc.stdin.lines[-1])["decision"] == DECISION_DENY
+
+
+def test_channel_exposes_no_way_to_enable_bypass():
+    """The agent accepts a `bypass` verb; a remote surface must not reach it.
+
+    An allowlisted user is trusted to ask for one tool, not to disarm the gate
+    for every later one. Bypass stays a local decision.
+    """
+    public = {name for name in dir(AgentChannel) if not name.startswith("_")}
+    assert not {n for n in public if "bypass" in n.lower()}
+    source = AgentChannel.decide.__doc__ or ""
+    assert "bypass" not in source.lower()
+
+
+# ----------------------------------------------------------------------
+# Turn lifecycle
+# ----------------------------------------------------------------------
+
+
+def test_events_reach_the_adapter_with_their_turn(channel):
+    ch, proc, seen = channel
+    turn = Turn(text="hi", context={"channel": "D1"})
+    ch.submit(turn)
+    assert _wait_for(lambda: proc.stdin.lines)
+    proc.stdout.emit({"type": "token", "text": "he"})
+    proc.stdout.emit({"type": "final", "answer": "hello"})
+    assert _wait_for(lambda: len(seen) == 2)
+    assert [e["type"] for e, _ in seen] == ["token", "final"]
+    assert all(t.context == {"channel": "D1"} for _, t in seen)
+
+
+def test_a_second_message_waits_for_the_running_turn(channel):
+    """The agent handles one query at a time; racing them would interleave."""
+    ch, proc, seen = channel
+    ch.submit(Turn(text="first"))
+    assert _wait_for(lambda: len(proc.stdin.lines) == 1)
+
+    ahead = ch.submit(Turn(text="second"))
+    assert ahead == 1, "the caller must learn its message is queued"
+    time.sleep(0.15)
+    assert len(proc.stdin.lines) == 1, "second query must not be written yet"
+
+    proc.stdout.emit({"type": "final", "answer": "one"})
+    assert _wait_for(lambda: len(proc.stdin.lines) == 2)
+    assert json.loads(proc.stdin.lines[1]) == {QUERY_KEY: "second"}
+
+
+def test_on_busy_fires_only_for_a_queued_turn():
+    proc = FakeProc()
+    busy = []
+    ch = AgentChannel(
+        on_event=lambda e, t: None,
+        spawn=lambda: proc,
+        on_busy=lambda turn, ahead: busy.append((turn.text, ahead)),
+    )
+    ch.start()
+    try:
+        ch.submit(Turn(text="first"))
+        assert _wait_for(lambda: proc.stdin.lines)
+        assert busy == [], "the first turn starts immediately"
+        ch.submit(Turn(text="second"))
+        assert busy == [("second", 1)]
+    finally:
+        ch.close()
+
+
+def test_a_crashed_child_still_terminates_the_turn(channel):
+    """A turn that just goes quiet leaves the user staring at 'Thinking…'."""
+    ch, proc, seen = channel
+    ch.submit(Turn(text="hi"))
+    assert _wait_for(lambda: proc.stdin.lines)
+    proc.stdout.emit({"type": "token", "text": "partial"})
+    proc.stdout.eof()
+    assert _wait_for(lambda: any(e["type"] == "error" for e, _ in seen))
+    detail = [e for e, _ in seen if e["type"] == "error"][0]["detail"]
+    assert "stopped responding" in detail
+    assert "~/.gaia/logs" in detail, "an error must say where to look next"
+
+
+def test_a_crash_does_not_double_report_after_a_terminal_event(channel):
+    ch, proc, seen = channel
+    ch.submit(Turn(text="hi"))
+    assert _wait_for(lambda: proc.stdin.lines)
+    proc.stdout.emit({"type": "final", "answer": "done"})
+    assert _wait_for(lambda: len(seen) == 1)
+    proc.stdout.eof()
+    time.sleep(0.15)
+    assert [e["type"] for e, _ in seen] == ["final"]
+
+
+def test_a_raising_renderer_does_not_wedge_the_channel():
+    """A renderer that throws must not stop the turn from terminating."""
+    proc = FakeProc()
+    calls = []
+
+    def boom(event, turn):
+        calls.append(event["type"])
+        raise RuntimeError("renderer exploded")
+
+    ch = AgentChannel(on_event=boom, spawn=lambda: proc)
+    ch.start()
+    try:
+        ch.submit(Turn(text="first"))
+        assert _wait_for(lambda: proc.stdin.lines)
+        proc.stdout.emit({"type": "final", "answer": "a"})
+        ch.submit(Turn(text="second"))
+        assert _wait_for(lambda: len(proc.stdin.lines) == 2), "channel still serving"
+    finally:
+        ch.close()
+
+
+def test_non_json_output_is_skipped_without_desynchronising(channel):
+    """A stray print from a dependency must not be read as an event."""
+    ch, proc, seen = channel
+    ch.submit(Turn(text="hi"))
+    assert _wait_for(lambda: proc.stdin.lines)
+    proc.stdout.emit_raw("WARNING: some library said something")
+    proc.stdout.emit({"type": "final", "answer": "ok"})
+    assert _wait_for(lambda: len(seen) == 1)
+    assert seen[0][0]["type"] == "final"
+
+
+def test_submitting_before_start_is_refused_with_a_remedy():
+    ch = AgentChannel(on_event=lambda e, t: None, spawn=lambda: FakeProc())
+    with pytest.raises(AgentChannelError) as excinfo:
+        ch.submit(Turn(text="hi"))
+    assert "start()" in str(excinfo.value)
+
+
+def test_starting_twice_is_refused(channel):
+    ch, _, _ = channel
+    with pytest.raises(AgentChannelError):
+        ch.start()
+
+
+def test_submitting_after_close_is_refused(channel):
+    ch, _, _ = channel
+    ch.close()
+    with pytest.raises(AgentChannelError) as excinfo:
+        ch.submit(Turn(text="hi"))
+    assert "shutting down" in str(excinfo.value)
+
+
+def test_missing_agent_binary_names_the_fix():
+    def explode():
+        raise FileNotFoundError(2, "No such file")
+
+    ch = AgentChannel(on_event=lambda e, t: None)
+    ch._spawn = lambda: ch._default_spawn()
+    ch._argv = ["definitely-not-a-real-binary-xyz"]
+    with pytest.raises(AgentChannelError) as excinfo:
+        ch.start()
+    message = str(excinfo.value)
+    assert "not on PATH" in message
+    assert "gaia init" in message, "an error must name what to do about it"
+
+
+# ----------------------------------------------------------------------
+# StreamThrottle
+# ----------------------------------------------------------------------
+
+
+def test_throttle_batches_edits_within_the_interval():
+    clock = [100.0]
+    flushed = []
+    throttle = StreamThrottle(flushed.append, interval=1.0, now=lambda: clock[0])
+    throttle.add("a")
+    throttle.add("b")
+    throttle.add("c")
+    assert flushed == ["a"], "only the first add crosses the interval boundary"
+
+
+def test_throttle_emits_again_once_the_interval_passes():
+    clock = [100.0]
+    flushed = []
+    throttle = StreamThrottle(flushed.append, interval=1.0, now=lambda: clock[0])
+    throttle.add("a")
+    clock[0] += 1.5
+    throttle.add("b")
+    assert flushed == ["a", "ab"], "each flush carries everything so far"
+
+
+def test_throttle_finish_flushes_the_tail():
+    """The last token must never be the one the throttle swallowed."""
+    clock = [100.0]
+    flushed = []
+    throttle = StreamThrottle(flushed.append, interval=1.0, now=lambda: clock[0])
+    throttle.add("a")
+    throttle.add("tail")
+    throttle.finish()
+    assert flushed[-1] == "atail"
+
+
+def test_throttle_skips_an_edit_that_would_change_nothing():
+    """An unchanged body still costs a call against the channel's rate limit."""
+    clock = [100.0]
+    flushed = []
+    throttle = StreamThrottle(flushed.append, interval=0.0, now=lambda: clock[0])
+    throttle.add("a")
+    throttle.finish()
+    throttle.finish()
+    assert flushed == ["a"]

--- a/tests/unit/messaging/test_bridge_contract.py
+++ b/tests/unit/messaging/test_bridge_contract.py
@@ -1,0 +1,145 @@
+"""Pin the bridge's wire literals against the real ``gaia_agent.stdio``.
+
+The bridge keeps the protocol constants as its own literals rather than
+importing them, because core must not depend on a hub wheel. That is the right
+layering and it is also exactly how two sides of a contract drift apart without
+anyone noticing: every unit test in ``test_bridge.py`` asserts the bridge agrees
+with *itself*.
+
+So this file asserts the bridge agrees with the agent. If the agent renames a
+verb or adds a decision, this fails here — loudly, at build time — instead of in
+production as a confirmation that silently never resolves.
+
+Skipped only when the flagship agent package is not installed; the conftest
+redirects an existing install to this checkout but will not create one.
+"""
+
+import pytest
+
+from gaia.messaging import bridge
+
+stdio = pytest.importorskip(
+    "gaia_agent.stdio",
+    reason="the flagship agent package is not installed in this environment",
+)
+
+
+def test_control_key_matches():
+    assert bridge.CONTROL_KEY == stdio.CONTROL_KEY
+
+
+def test_query_key_matches():
+    assert bridge.QUERY_KEY == stdio.QUERY_KEY
+
+
+def test_tool_decision_verb_matches():
+    assert bridge.CONTROL_TOOL_DECISION == stdio.CONTROL_TOOL_DECISION
+
+
+@pytest.mark.parametrize(
+    "ours, theirs",
+    [
+        ("DECISION_ALLOW", "DECISION_ALLOW"),
+        ("DECISION_DENY", "DECISION_DENY"),
+        ("DECISION_ALWAYS", "DECISION_ALWAYS"),
+    ],
+)
+def test_decision_values_match(ours, theirs):
+    assert getattr(bridge, ours) == getattr(stdio, theirs)
+
+
+def test_valid_decisions_is_exactly_what_the_agent_accepts():
+    """The agent denies anything outside this set; the bridge must agree.
+
+    A decision the bridge considers valid but the agent does not would be sent
+    verbatim and silently downgraded to a deny — an approval the user watched
+    themselves give, that never took effect.
+    """
+    agent_side = {
+        stdio.DECISION_ALLOW,
+        stdio.DECISION_DENY,
+        stdio.DECISION_ALWAYS,
+    }
+    assert bridge.VALID_DECISIONS == agent_side
+
+
+def test_a_decision_the_bridge_builds_is_one_the_agent_parses():
+    """Validity of the CALL, not merely that we made one.
+
+    ``apply_control`` is the agent's real parser. Feeding it the bridge's own
+    output proves the message is accepted and routed to a tool decision, which a
+    stub returning success could never show.
+    """
+    import json
+
+    captured = {}
+
+    class RecordingState:
+        def resolve(self, decision, confirm_id):
+            captured["decision"] = decision
+            captured["confirm_id"] = confirm_id
+
+        def set_bypass(self, enabled):  # pragma: no cover - must never be hit
+            raise AssertionError("the bridge must never send a bypass verb")
+
+    sent = []
+
+    class Recorder:
+        stdin = type(
+            "S",
+            (),
+            {"write": lambda self, d: sent.append(d), "flush": lambda self: None},
+        )()
+        stdout = None
+
+    channel = bridge.AgentChannel(on_event=lambda e, t: None, spawn=Recorder)
+    channel._proc = Recorder()
+    channel.decide(bridge.DECISION_ALLOW, "confirm-42")
+
+    message = json.loads(sent[-1])
+    stdio.apply_control(message, RecordingState())
+    assert captured == {"decision": stdio.DECISION_ALLOW, "confirm_id": "confirm-42"}
+
+
+def test_a_garbled_decision_reaches_the_agent_as_a_deny():
+    """Fail-closed has to hold across the boundary, not just inside the bridge."""
+    import json
+
+    captured = {}
+
+    class RecordingState:
+        def resolve(self, decision, confirm_id):
+            captured["decision"] = decision
+
+        def set_bypass(self, enabled):  # pragma: no cover
+            raise AssertionError("the bridge must never send a bypass verb")
+
+    sent = []
+
+    class Recorder:
+        stdin = type(
+            "S",
+            (),
+            {"write": lambda self, d: sent.append(d), "flush": lambda self: None},
+        )()
+        stdout = None
+
+    channel = bridge.AgentChannel(on_event=lambda e, t: None, spawn=Recorder)
+    channel._proc = Recorder()
+    channel.decide("sure-why-not", "c1")
+    stdio.apply_control(json.loads(sent[-1]), RecordingState())
+    assert captured["decision"] == stdio.DECISION_DENY
+
+
+def test_the_agent_unwraps_the_query_the_bridge_wraps():
+    """A multi-line question must survive the round trip as ONE question."""
+    import json
+
+    question = "summarize this\nand that"
+    wire = json.dumps({bridge.QUERY_KEY: question})
+    assert stdio.parse_query(wire) == question
+
+
+def test_terminal_events_match_the_agent_vocabulary():
+    """The bridge waits for exactly these to end a turn."""
+    assert bridge.TERMINAL_EVENTS == {"final", "error"}

--- a/tests/unit/messaging/test_slack_adapter.py
+++ b/tests/unit/messaging/test_slack_adapter.py
@@ -1,0 +1,600 @@
+"""The Slack adapter's guard rails and rendering.
+
+This bridge drives the REAL flagship agent — shell, file writes, the lot — so
+the authorization tests here are the ones that decide whether the feature is
+shippable. Unlike Telegram's adapter, which reaches a tool-less ``AgentSDK``,
+nothing structural stops a message from reaching a dangerous tool: only the
+allowlist, the DM rule, the workspace pin, and the confirmation gate do.
+"""
+
+import pytest
+
+from gaia.messaging.bridge import DECISION_ALLOW, DECISION_ALWAYS, DECISION_DENY
+from gaia.messaging.slack import adapter as ad
+from gaia.messaging.slack.adapter import (
+    ReplyTarget,
+    SlackAdapter,
+    SlackAllowlistError,
+    confirmation_blocks,
+)
+
+ALLOWED = "U024BE7LH"
+STRANGER = "U999NOPE"
+TEAM = "T01TEAM"
+
+
+class FakeWeb:
+    """Records every Slack API call instead of making one."""
+
+    def __init__(self, team_id=TEAM):
+        self.posted = []
+        self.updated = []
+        self.uploads = []
+        self._team_id = team_id
+        self._ts = 0
+
+    def auth_test(self):
+        return {
+            "ok": True,
+            "team_id": self._team_id,
+            "team": "Acme",
+            "user": "gaia",
+            "user_id": "U0BOT",
+        }
+
+    def chat_postMessage(self, **kwargs):
+        self._ts += 1
+        ts = f"{self._ts}.000"
+        self.posted.append({**kwargs, "ts": ts})
+        return {"ok": True, "ts": ts}
+
+    def chat_update(self, **kwargs):
+        self.updated.append(kwargs)
+        return {"ok": True}
+
+    def files_upload_v2(self, **kwargs):
+        self.uploads.append(kwargs)
+        return {"ok": True}
+
+
+class FakeChannel:
+    """Stands in for AgentChannel — records turns and decisions."""
+
+    def __init__(self, **kwargs):
+        self.on_event = kwargs.get("on_event")
+        self.on_busy = kwargs.get("on_busy")
+        self.turns = []
+        self.decisions = []
+        self.started = False
+        self.closed = False
+
+    def start(self):
+        self.started = True
+
+    def submit(self, turn):
+        self.turns.append(turn)
+        return 0
+
+    def decide(self, decision, confirm_id=None):
+        self.decisions.append((decision, confirm_id))
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture
+def adapter():
+    """A started adapter wired to fakes, with its channel reachable."""
+    web = FakeWeb()
+    made = {}
+
+    def factory(**kwargs):
+        made["channel"] = FakeChannel(**kwargs)
+        return made["channel"]
+
+    a = SlackAdapter(
+        bot_token="xoxb-t",
+        app_token="xapp-t",
+        allowed_users={ALLOWED},
+        web_client=web,
+        channel_factory=factory,
+    )
+    a.start(connect=False)
+    return a, web, made["channel"]
+
+
+def dm_event(user=ALLOWED, text="hello", team=TEAM, **extra):
+    return {
+        "team_id": team,
+        "event": {
+            "type": "message",
+            "channel_type": "im",
+            "channel": "D1",
+            "user": user,
+            "text": text,
+            "ts": "111.000",
+            **extra,
+        },
+    }
+
+
+# ----------------------------------------------------------------------
+# Construction guards
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("empty", [set(), None, [], frozenset()])
+def test_empty_allowlist_is_refused_at_construction(empty):
+    """An adapter that should serve nobody must never exist."""
+    with pytest.raises(SlackAllowlistError) as excinfo:
+        SlackAdapter("xoxb-t", "xapp-t", allowed_users=empty)
+    assert "--allowed-users" in str(excinfo.value)
+
+
+def test_omitted_allowlist_is_refused():
+    with pytest.raises(SlackAllowlistError):
+        SlackAdapter("xoxb-t", "xapp-t")
+
+
+def test_refusal_is_a_valueerror_for_callers_catching_the_base():
+    with pytest.raises(ValueError):
+        SlackAdapter("xoxb-t", "xapp-t")
+
+
+def test_a_string_allowlist_is_rejected_rather_than_split_into_characters():
+    """'U024BE7LH' would become {'U','0','2',...} and deny everyone."""
+    with pytest.raises(TypeError) as excinfo:
+        SlackAdapter("xoxb-t", "xapp-t", allowed_users=ALLOWED)
+    assert "U024BE7LH" in str(excinfo.value)
+
+
+def test_the_refusal_explains_why_a_workspace_is_not_an_allowlist():
+    with pytest.raises(SlackAllowlistError) as excinfo:
+        SlackAdapter("xoxb-t", "xapp-t", allowed_users=set())
+    message = str(excinfo.value)
+    assert "read your files" in message
+    assert "Everyone in the workspace" in message
+
+
+# ----------------------------------------------------------------------
+# Authorization on the message path
+# ----------------------------------------------------------------------
+
+
+def test_an_allowlisted_member_reaches_the_agent(adapter):
+    a, web, channel = adapter
+    a._handle_event(dm_event())
+    assert [t.text for t in channel.turns] == ["hello"]
+
+
+def test_a_stranger_never_reaches_the_agent(adapter):
+    a, web, channel = adapter
+    a._handle_event(dm_event(user=STRANGER))
+    assert channel.turns == []
+    assert any(ad.UNAUTHORIZED_REPLY in p["text"] for p in web.posted)
+
+
+def test_a_message_with_no_user_is_refused(adapter):
+    a, web, channel = adapter
+    a._handle_event(dm_event(user=None))
+    assert channel.turns == []
+
+
+def test_a_message_from_another_workspace_is_dropped(adapter):
+    """A token installed elsewhere must not be served, even for an id that
+    happens to match the allowlist."""
+    a, web, channel = adapter
+    a._handle_event(dm_event(team="T_OTHER"))
+    assert channel.turns == []
+    assert web.posted == [], "a foreign workspace gets no reply at all"
+
+
+def test_a_channel_message_is_ignored(adapter):
+    """Anyone in a channel can address a bot in it."""
+    a, web, channel = adapter
+    event = dm_event()
+    event["event"]["channel_type"] = "channel"
+    a._handle_event(event)
+    assert channel.turns == []
+
+
+@pytest.mark.parametrize("channel_type", ["group", "mpim", "channel", None])
+def test_only_direct_messages_are_served(adapter, channel_type):
+    a, web, channel = adapter
+    event = dm_event()
+    event["event"]["channel_type"] = channel_type
+    a._handle_event(event)
+    assert channel.turns == []
+
+
+def test_the_bots_own_message_does_not_start_a_turn(adapter):
+    """Answering your own reply is an infinite loop with an LLM at the bottom."""
+    a, web, channel = adapter
+    a._handle_event(dm_event(bot_id="B1"))
+    assert channel.turns == []
+
+
+@pytest.mark.parametrize(
+    "subtype", ["bot_message", "message_changed", "message_deleted"]
+)
+def test_edits_and_deletions_do_not_start_a_turn(adapter, subtype):
+    a, web, channel = adapter
+    a._handle_event(dm_event(subtype=subtype))
+    assert channel.turns == []
+
+
+def test_an_empty_message_asks_for_a_question_instead_of_running_a_turn(adapter):
+    a, web, channel = adapter
+    a._handle_event(dm_event(text="   "))
+    assert channel.turns == []
+    assert any("empty message" in p["text"] for p in web.posted)
+
+
+def test_allowed_predicate_admits_nobody_when_emptied_after_construction(adapter):
+    """Defence in depth behind the constructor's refusal."""
+    a, _, _ = adapter
+    a.allowed_users.clear()
+    assert a._allowed(ALLOWED) is False
+
+
+# ----------------------------------------------------------------------
+# Authorization on the button path
+# ----------------------------------------------------------------------
+
+
+def _click(action_id=ad.ACTION_ALLOW, user=ALLOWED, team=TEAM, value="c1"):
+    return {
+        "user": {"id": user},
+        "team": {"id": team},
+        "actions": [{"action_id": action_id, "value": value}],
+    }
+
+
+def test_an_allowlisted_member_can_approve(adapter):
+    a, web, channel = adapter
+    a._handle_interactive(_click())
+    assert channel.decisions == [(DECISION_ALLOW, "c1")]
+
+
+def test_a_stranger_cannot_approve_a_tool(adapter):
+    """The buttons are visible to anyone who can see the conversation; a
+    workspace admin reading it must not be able to run a command on the
+    owner's machine."""
+    a, web, channel = adapter
+    a._handle_interactive(_click(user=STRANGER))
+    assert channel.decisions == []
+
+
+def test_a_click_from_another_workspace_is_dropped(adapter):
+    a, web, channel = adapter
+    a._handle_interactive(_click(team="T_OTHER"))
+    assert channel.decisions == []
+
+
+@pytest.mark.parametrize(
+    "action_id, expected",
+    [
+        (ad.ACTION_ALLOW, DECISION_ALLOW),
+        (ad.ACTION_ALWAYS, DECISION_ALWAYS),
+        (ad.ACTION_DENY, DECISION_DENY),
+    ],
+)
+def test_each_button_maps_to_its_decision(adapter, action_id, expected):
+    a, web, channel = adapter
+    a._handle_interactive(_click(action_id=action_id))
+    assert channel.decisions == [(expected, "c1")]
+
+
+def test_an_unrecognised_action_is_ignored(adapter):
+    """A button from some other app's message must not answer our prompt."""
+    a, web, channel = adapter
+    a._handle_interactive(_click(action_id="someone_elses_button"))
+    assert channel.decisions == []
+
+
+def test_answering_replaces_the_buttons_with_the_decision(adapter):
+    """Live buttons after the turn moved on look like they still do something."""
+    a, web, channel = adapter
+    target = ReplyTarget(channel="D1", thread_ts="111.000")
+    a._ask_confirmation(
+        target,
+        {"action": "run a shell command", "summary": "ls", "confirm_id": "c1"},
+    )
+    a._handle_interactive(_click(value="c1"))
+    assert web.updated, "the confirmation message must be edited"
+    assert "Allowed" in web.updated[-1]["text"]
+    assert web.updated[-1]["blocks"] == []
+
+
+# ----------------------------------------------------------------------
+# The confirmation prompt
+# ----------------------------------------------------------------------
+
+
+def test_confirmation_buttons_carry_the_confirm_id(adapter):
+    """Without it a late click resolves whatever prompt replaced this one."""
+    a, web, channel = adapter
+    target = ReplyTarget(channel="D1", thread_ts="111.000")
+    a._ask_confirmation(
+        target, {"action": "write a file", "summary": "/tmp/x", "confirm_id": "c7"}
+    )
+    blocks = web.posted[-1]["blocks"]
+    values = {e["value"] for e in blocks[1]["elements"]}
+    assert values == {"c7"}
+
+
+def test_always_allow_is_offered_only_with_a_scope():
+    """Offering it without one grants far more than the user believes."""
+    with_scope = confirmation_blocks("run", "ls -la", "ls")
+    without = confirmation_blocks("run", "ls -la", "")
+    assert ad.ACTION_ALWAYS in {e["action_id"] for e in with_scope[1]["elements"]}
+    assert ad.ACTION_ALWAYS not in {e["action_id"] for e in without[1]["elements"]}
+
+
+def test_deny_gated_tools_refuses_without_ever_showing_a_button():
+    """The read-only posture: a gated tool is denied, not offered."""
+    web = FakeWeb()
+    made = {}
+    a = SlackAdapter(
+        "xoxb-t",
+        "xapp-t",
+        allowed_users={ALLOWED},
+        web_client=web,
+        deny_gated_tools=True,
+        channel_factory=lambda **kw: made.setdefault("c", FakeChannel(**kw)),
+    )
+    a.start(connect=False)
+    target = ReplyTarget(channel="D1", thread_ts="111.000")
+    a._ask_confirmation(target, {"action": "run a shell command", "confirm_id": "c1"})
+    assert made["c"].decisions == [(DECISION_DENY, "c1")]
+    assert all("blocks" not in p for p in web.posted)
+    assert any("read-only" in p["text"] for p in web.posted)
+
+
+# ----------------------------------------------------------------------
+# Rendering
+# ----------------------------------------------------------------------
+
+
+def _target_for(adapter_tuple):
+    a, web, channel = adapter_tuple
+    a._handle_event(dm_event())
+    return channel.turns[-1]
+
+
+def test_the_final_answer_replaces_the_streamed_text(adapter):
+    a, web, channel = adapter
+    turn = _target_for(adapter)
+    channel.on_event({"type": "token", "text": "partial"}, turn)
+    channel.on_event({"type": "final", "answer": "the whole answer"}, turn)
+    assert any(u["text"] == "the whole answer" for u in web.updated)
+
+
+def test_an_error_is_rendered_as_a_warning(adapter):
+    a, web, channel = adapter
+    turn = _target_for(adapter)
+    channel.on_event({"type": "error", "detail": "Lemonade is not running"}, turn)
+    assert any("Lemonade is not running" in u["text"] for u in web.updated)
+
+
+def test_a_status_does_not_overwrite_text_that_already_streamed(adapter):
+    """Replacing a partial answer with 'Working…' is a visible regression."""
+    a, web, channel = adapter
+    turn = _target_for(adapter)
+    channel.on_event({"type": "token", "text": "some answer"}, turn)
+    before = len(web.updated)
+    channel.on_event({"type": "status", "message": "Thinking harder"}, turn)
+    assert len(web.updated) == before
+
+
+def test_the_tools_used_are_listed_after_the_answer(adapter):
+    a, web, channel = adapter
+    turn = _target_for(adapter)
+    channel.on_event({"type": "tool_call", "tool": "query_documents"}, turn)
+    channel.on_event({"type": "final", "answer": "done"}, turn)
+    assert any("query_documents" in p["text"] for p in web.posted)
+
+
+def test_a_long_answer_is_truncated_rather_than_rejected(adapter):
+    """Past 4000 characters chat.update rejects the edit and the reply vanishes."""
+    a, web, channel = adapter
+    turn = _target_for(adapter)
+    channel.on_event({"type": "final", "answer": "x" * 9000}, turn)
+    body = web.updated[-1]["text"]
+    assert len(body) <= ad.SLACK_MESSAGE_LIMIT + 60
+    assert "truncated" in body
+
+
+def test_a_queued_message_tells_the_sender_it_is_waiting(adapter):
+    """Silence while a previous turn runs reads as a broken bot."""
+    a, web, channel = adapter
+    turn = _target_for(adapter)
+    a._on_busy(turn, 2)
+    assert any("Queued" in u["text"] for u in web.updated)
+
+
+# ----------------------------------------------------------------------
+# Uploading files back
+# ----------------------------------------------------------------------
+
+
+def test_a_file_the_agent_wrote_under_an_upload_root_is_sent_back(tmp_path):
+    web = FakeWeb()
+    made = {}
+    a = SlackAdapter(
+        "xoxb-t",
+        "xapp-t",
+        allowed_users={ALLOWED},
+        web_client=web,
+        upload_roots=[str(tmp_path)],
+        channel_factory=lambda **kw: made.setdefault("c", FakeChannel(**kw)),
+    )
+    a.start(connect=False)
+    written = tmp_path / "summary.md"
+    written.write_text("hello", encoding="utf-8")
+    target = ReplyTarget(channel="D1", thread_ts="1.0")
+    a._maybe_upload(
+        target, {"type": "tool_result", "data": {"file_path": str(written)}}
+    )
+    assert [u["filename"] for u in web.uploads] == ["summary.md"]
+
+
+def test_a_file_outside_the_upload_roots_is_refused(tmp_path):
+    """The write was approved; shipping it off the machine was not."""
+    web = FakeWeb()
+    a = SlackAdapter(
+        "xoxb-t",
+        "xapp-t",
+        allowed_users={ALLOWED},
+        web_client=web,
+        upload_roots=[str(tmp_path / "allowed")],
+        channel_factory=lambda **kw: FakeChannel(**kw),
+    )
+    a.start(connect=False)
+    (tmp_path / "allowed").mkdir()
+    secret = tmp_path / "elsewhere.txt"
+    secret.write_text("private", encoding="utf-8")
+    a._maybe_upload(
+        ReplyTarget(channel="D1", thread_ts="1.0"),
+        {"data": {"file_path": str(secret)}},
+    )
+    assert web.uploads == []
+
+
+def test_a_path_escaping_an_upload_root_with_dotdot_is_refused(tmp_path):
+    """The check resolves the path first, so ../ cannot walk out of a root."""
+    web = FakeWeb()
+    root = tmp_path / "allowed"
+    root.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_text("private", encoding="utf-8")
+    a = SlackAdapter(
+        "xoxb-t",
+        "xapp-t",
+        allowed_users={ALLOWED},
+        web_client=web,
+        upload_roots=[str(root)],
+        channel_factory=lambda **kw: FakeChannel(**kw),
+    )
+    a.start(connect=False)
+    a._maybe_upload(
+        ReplyTarget(channel="D1", thread_ts="1.0"),
+        {"data": {"file_path": str(root / ".." / "outside.txt")}},
+    )
+    assert web.uploads == []
+
+
+def test_the_same_file_is_not_uploaded_twice_in_one_turn(tmp_path):
+    web = FakeWeb()
+    a = SlackAdapter(
+        "xoxb-t",
+        "xapp-t",
+        allowed_users={ALLOWED},
+        web_client=web,
+        upload_roots=[str(tmp_path)],
+        channel_factory=lambda **kw: FakeChannel(**kw),
+    )
+    a.start(connect=False)
+    written = tmp_path / "a.txt"
+    written.write_text("x", encoding="utf-8")
+    target = ReplyTarget(channel="D1", thread_ts="1.0")
+    for _ in range(3):
+        a._maybe_upload(target, {"data": {"file_path": str(written)}})
+    assert len(web.uploads) == 1
+
+
+def test_an_oversized_file_is_skipped(tmp_path, monkeypatch):
+    web = FakeWeb()
+    a = SlackAdapter(
+        "xoxb-t",
+        "xapp-t",
+        allowed_users={ALLOWED},
+        web_client=web,
+        upload_roots=[str(tmp_path)],
+        channel_factory=lambda **kw: FakeChannel(**kw),
+    )
+    a.start(connect=False)
+    written = tmp_path / "big.bin"
+    written.write_bytes(b"x" * 128)
+    monkeypatch.setattr(ad, "MAX_UPLOAD_BYTES", 16)
+    a._maybe_upload(
+        ReplyTarget(channel="D1", thread_ts="1.0"),
+        {"data": {"file_path": str(written)}},
+    )
+    assert web.uploads == []
+
+
+def test_a_tool_result_without_a_file_path_uploads_nothing(adapter):
+    a, web, channel = adapter
+    a._maybe_upload(
+        ReplyTarget(channel="D1", thread_ts="1.0"),
+        {"type": "tool_result", "data": {"status": "success"}},
+    )
+    assert web.uploads == []
+
+
+def test_a_missing_file_is_not_uploaded(tmp_path):
+    web = FakeWeb()
+    a = SlackAdapter(
+        "xoxb-t",
+        "xapp-t",
+        allowed_users={ALLOWED},
+        web_client=web,
+        upload_roots=[str(tmp_path)],
+        channel_factory=lambda **kw: FakeChannel(**kw),
+    )
+    a.start(connect=False)
+    a._maybe_upload(
+        ReplyTarget(channel="D1", thread_ts="1.0"),
+        {"data": {"file_path": str(tmp_path / "gone.txt")}},
+    )
+    assert web.uploads == []
+
+
+# ----------------------------------------------------------------------
+# Workspace pinning
+# ----------------------------------------------------------------------
+
+
+def test_verify_pins_the_workspace_from_auth_test():
+    web = FakeWeb(team_id="T_REAL")
+    a = SlackAdapter("xoxb-t", "xapp-t", allowed_users={ALLOWED}, web_client=web)
+    assert a.team_id is None
+    a.verify()
+    assert a.team_id == "T_REAL"
+
+
+def test_verify_refuses_a_token_slack_rejects():
+    class Rejecting(FakeWeb):
+        def auth_test(self):
+            return {"ok": False, "error": "invalid_auth"}
+
+    a = SlackAdapter(
+        "xoxb-bad", "xapp-t", allowed_users={ALLOWED}, web_client=Rejecting()
+    )
+    with pytest.raises(RuntimeError) as excinfo:
+        a.verify()
+    assert "invalid_auth" in str(excinfo.value)
+    assert "gaia slack setup" in str(excinfo.value), "name the remedy"
+
+
+def test_an_explicit_team_id_is_not_overwritten_by_verify():
+    web = FakeWeb(team_id="T_FROM_TOKEN")
+    a = SlackAdapter(
+        "xoxb-t",
+        "xapp-t",
+        allowed_users={ALLOWED},
+        team_id="T_PINNED",
+        web_client=web,
+    )
+    a.verify()
+    assert a.team_id == "T_PINNED"
+
+
+def test_using_the_adapter_before_start_names_the_fix():
+    """Under ``python -O`` an assert would vanish and this would surface as
+    'NoneType has no attribute submit' from inside a Slack event handler."""
+    a = SlackAdapter("xoxb-t", "xapp-t", allowed_users={ALLOWED}, web_client=FakeWeb())
+    with pytest.raises(RuntimeError) as excinfo:
+        a._agent()
+    assert "gaia slack start" in str(excinfo.value)

--- a/tests/unit/messaging/test_slack_cli.py
+++ b/tests/unit/messaging/test_slack_cli.py
@@ -1,0 +1,193 @@
+"""``gaia slack`` — argument handling, credentials, and the status report."""
+
+import json
+
+import pytest
+
+from gaia.messaging.slack import cli, credentials, onboarding
+
+# ----------------------------------------------------------------------
+# Allowlist parsing
+# ----------------------------------------------------------------------
+
+
+def test_ids_are_split_and_trimmed():
+    assert cli.parse_allowed_users(" U024BE7LH , U0G9QF9C6 ") == {
+        "U024BE7LH",
+        "U0G9QF9C6",
+    }
+
+
+def test_an_omitted_allowlist_is_empty_not_an_error():
+    """The adapter's own refusal explains why one is mandatory; argparse's
+    'the following arguments are required' does not."""
+    assert cli.parse_allowed_users(None) == set()
+    assert cli.parse_allowed_users("") == set()
+
+
+@pytest.mark.parametrize("wrong", ["@kalin", "kalin@example.com", "12345"])
+def test_a_handle_or_email_is_refused_with_the_real_instruction(wrong):
+    """Pasting a display name is the obvious mistake, and it would silently
+    deny the person who made it."""
+    with pytest.raises(ValueError) as excinfo:
+        cli.parse_allowed_users(wrong)
+    assert "Copy member ID" in str(excinfo.value)
+
+
+def test_one_bad_entry_fails_the_whole_list():
+    with pytest.raises(ValueError):
+        cli.parse_allowed_users("U024BE7LH,@kalin")
+
+
+# ----------------------------------------------------------------------
+# Credentials
+# ----------------------------------------------------------------------
+
+
+def test_the_environment_supplies_tokens_without_a_keyring(monkeypatch):
+    monkeypatch.setenv(credentials.BOT_TOKEN_ENV_VAR, "xoxb-env")
+    monkeypatch.setenv(credentials.APP_TOKEN_ENV_VAR, "xapp-env")
+    creds = credentials.load()
+    assert creds.bot_token == "xoxb-env"
+    assert creds.app_token == "xapp-env"
+
+
+def test_a_half_configured_environment_names_what_is_missing(monkeypatch):
+    monkeypatch.setenv(credentials.BOT_TOKEN_ENV_VAR, "xoxb-env")
+    monkeypatch.delenv(credentials.APP_TOKEN_ENV_VAR, raising=False)
+    monkeypatch.setenv("PYTHON_KEYRING_BACKEND", "null")
+    with pytest.raises(credentials.SlackCredentialsError) as excinfo:
+        credentials.load()
+    message = str(excinfo.value)
+    assert credentials.APP_TOKEN_ENV_VAR in message
+    assert "gaia slack setup" in message
+
+
+def test_load_optional_answers_none_rather_than_raising(monkeypatch):
+    monkeypatch.delenv(credentials.BOT_TOKEN_ENV_VAR, raising=False)
+    monkeypatch.delenv(credentials.APP_TOKEN_ENV_VAR, raising=False)
+    monkeypatch.setenv("PYTHON_KEYRING_BACKEND", "null")
+    assert credentials.load_optional() is None
+
+
+# ----------------------------------------------------------------------
+# start
+# ----------------------------------------------------------------------
+
+
+def test_start_without_credentials_exits_with_the_setup_remedy(monkeypatch, capsys):
+    monkeypatch.delenv(credentials.BOT_TOKEN_ENV_VAR, raising=False)
+    monkeypatch.delenv(credentials.APP_TOKEN_ENV_VAR, raising=False)
+    monkeypatch.setenv("PYTHON_KEYRING_BACKEND", "null")
+    lines = []
+    assert cli.run_start(allowed_users="U024BE7LH", emit=lines.append) == 2
+    assert any("gaia slack setup" in line for line in lines)
+
+
+def test_start_with_a_malformed_allowlist_fails_before_touching_the_keyring():
+    lines = []
+    assert cli.run_start(allowed_users="@kalin", emit=lines.append) == 2
+    assert any("member ID" in line for line in lines)
+
+
+def test_start_without_an_allowlist_is_refused_with_the_reason(monkeypatch):
+    """Credentials present, allowlist absent — the case the adapter guards."""
+    monkeypatch.setenv(credentials.BOT_TOKEN_ENV_VAR, "xoxb-env")
+    monkeypatch.setenv(credentials.APP_TOKEN_ENV_VAR, "xapp-env")
+    lines = []
+    assert cli.run_start(allowed_users=None, emit=lines.append) == 2
+    assert any("--allowed-users" in line for line in lines)
+
+
+# ----------------------------------------------------------------------
+# status
+# ----------------------------------------------------------------------
+
+
+def test_status_reports_an_unconfigured_machine(monkeypatch, tmp_path):
+    monkeypatch.setenv("GAIA_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setenv("PYTHON_KEYRING_BACKEND", "null")
+    monkeypatch.delenv(credentials.BOT_TOKEN_ENV_VAR, raising=False)
+    monkeypatch.delenv(credentials.APP_TOKEN_ENV_VAR, raising=False)
+    monkeypatch.setattr(onboarding, "detect_slack", lambda: False)
+    info = cli.status()
+    assert info["configured"] is False
+    assert info["slack_installed"] is False
+    assert info["should_offer_setup"] is False
+
+
+def test_status_offers_setup_when_slack_appears(monkeypatch, tmp_path):
+    monkeypatch.setenv("GAIA_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setenv("PYTHON_KEYRING_BACKEND", "null")
+    monkeypatch.delenv(credentials.BOT_TOKEN_ENV_VAR, raising=False)
+    monkeypatch.delenv(credentials.APP_TOKEN_ENV_VAR, raising=False)
+    monkeypatch.setattr(onboarding, "detect_slack", lambda: True)
+    assert cli.status()["should_offer_setup"] is True
+
+
+def test_status_json_is_machine_readable(monkeypatch, tmp_path):
+    monkeypatch.setenv("GAIA_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setenv("PYTHON_KEYRING_BACKEND", "null")
+    monkeypatch.setattr(onboarding, "detect_slack", lambda: False)
+    lines = []
+    assert cli.run_status(as_json=True, emit=lines.append) == 0
+    payload = json.loads("\n".join(lines))
+    assert set(payload) == {
+        "slack_installed",
+        "configured",
+        "onboarding_state",
+        "team_name",
+        "should_offer_setup",
+        "running",
+    }
+
+
+def test_stop_without_a_running_bridge_is_not_an_error(monkeypatch, tmp_path):
+    monkeypatch.setattr(cli, "PID_PATH", tmp_path / "slack.pid")
+    lines = []
+    assert cli.run_stop(emit=lines.append) == 0
+    assert any("No backgrounded" in line for line in lines)
+
+
+def test_stop_clears_a_stale_pid_file(monkeypatch, tmp_path):
+    """A pid that no longer exists must not leave the bridge un-startable."""
+    pid_file = tmp_path / "slack.pid"
+    # PID 1 is init; a kill from a normal user raises PermissionError, so use a
+    # pid that genuinely cannot exist instead.
+    pid_file.write_text("999999999", encoding="utf-8")
+    monkeypatch.setattr(cli, "PID_PATH", pid_file)
+    lines = []
+    assert cli.run_stop(emit=lines.append) == 0
+    assert not pid_file.exists()
+
+
+# ----------------------------------------------------------------------
+# setup
+# ----------------------------------------------------------------------
+
+
+def test_setup_refuses_swapped_tokens_before_any_network_call(monkeypatch):
+    answers = iter(["xoxb-wrong-field", "xapp-wrong-field"])
+    lines = []
+    code = cli.run_setup(
+        prompt=lambda _: next(answers), emit=lines.append, open_browser=False
+    )
+    assert code == 2
+    assert any("goes in the other field" in line for line in lines)
+
+
+def test_setup_prints_the_create_url_when_no_browser_is_available():
+    answers = iter(["xapp-a", "xoxb-b"])
+    lines = []
+    cli.run_setup(prompt=lambda _: next(answers), emit=lines.append, open_browser=False)
+    assert any("api.slack.com/apps" in line for line in lines)
+
+
+def test_setup_does_not_promise_automatic_configuration():
+    """Saying 'automatic' strands the user on a settings page thirty seconds
+    later. The copy has to say what they will actually do."""
+    answers = iter(["xapp-a", "xoxb-b"])
+    lines = []
+    cli.run_setup(prompt=lambda _: next(answers), emit=lines.append, open_browser=False)
+    joined = " ".join(lines).lower()
+    assert "cannot be fully automatic" in joined

--- a/tests/unit/messaging/test_slack_manifest.py
+++ b/tests/unit/messaging/test_slack_manifest.py
@@ -1,0 +1,135 @@
+"""The Slack app manifest and the tokens pasted back.
+
+The manifest is what the user is asked to approve, so its contents are a
+security surface, not configuration trivia: an extra scope in here is an extra
+thing GAIA can do in their workspace.
+"""
+
+import json
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from gaia.messaging.slack import manifest as m
+
+
+def _manifest_from_url(url):
+    return json.loads(parse_qs(urlparse(url).query)["manifest_json"][0])
+
+
+# ----------------------------------------------------------------------
+# Manifest contents
+# ----------------------------------------------------------------------
+
+
+def test_socket_mode_is_on():
+    """Without it the app needs a public URL, which a local agent cannot have."""
+    assert m.build_manifest()["settings"]["socket_mode_enabled"] is True
+
+
+def test_interactivity_is_on():
+    """Tool approvals are buttons; without interactivity every click is dropped
+    and every gated tool sits until it times out and denies."""
+    assert m.build_manifest()["settings"]["interactivity"]["is_enabled"] is True
+
+
+def test_only_direct_messages_are_subscribed():
+    """Channel events would make the bot reachable by everyone in a channel."""
+    assert m.build_manifest()["settings"]["event_subscriptions"]["bot_events"] == [
+        "message.im"
+    ]
+
+
+def test_scopes_are_exactly_the_documented_set():
+    """A scope added without a reason is a scope the user cannot evaluate."""
+    assert set(m.build_manifest()["oauth_config"]["scopes"]["bot"]) == set(m.BOT_SCOPES)
+
+
+@pytest.mark.parametrize(
+    "forbidden",
+    [
+        "channels:history",
+        "channels:read",
+        "groups:history",
+        "chat:write.public",
+        "admin",
+        "users:read.email",
+    ],
+)
+def test_no_channel_or_admin_scope_is_requested(forbidden):
+    assert forbidden not in m.build_manifest()["oauth_config"]["scopes"]["bot"]
+
+
+def test_app_name_flows_into_the_bot_user():
+    built = m.build_manifest("Acme Agent")
+    assert built["display_information"]["name"] == "Acme Agent"
+    assert built["features"]["bot_user"]["display_name"] == "Acme Agent"
+
+
+def test_bot_is_not_advertised_as_always_online():
+    """The bridge starts on demand; a green dot over a dead bridge is a lie."""
+    assert m.build_manifest()["features"]["bot_user"]["always_online"] is False
+
+
+# ----------------------------------------------------------------------
+# The create-app URL
+# ----------------------------------------------------------------------
+
+
+def test_create_url_carries_a_manifest_slack_can_parse():
+    """The URL is the whole one-click story — if it does not round-trip, the
+    user lands on an empty form and fills it in by hand."""
+    url = m.create_app_url()
+    assert url.startswith(m.CREATE_APP_ENDPOINT)
+    assert _manifest_from_url(url) == m.build_manifest()
+
+
+def test_create_url_asks_for_the_new_app_dialog():
+    assert parse_qs(urlparse(m.create_app_url()).query)["new_app"] == ["1"]
+
+
+def test_create_url_survives_a_name_with_url_metacharacters():
+    url = m.create_app_url("A&B agent?")
+    assert _manifest_from_url(url)["display_information"]["name"] == "A&B agent?"
+
+
+# ----------------------------------------------------------------------
+# Token shape
+# ----------------------------------------------------------------------
+
+
+def test_well_formed_tokens_pass():
+    m.validate_tokens("xoxb-real", "xapp-real")
+
+
+def test_tokens_are_accepted_with_surrounding_whitespace():
+    """Pasting from Slack's UI routinely brings a trailing newline."""
+    m.validate_tokens("  xoxb-real\n", "\txapp-real ")
+
+
+def test_swapped_tokens_name_the_swap():
+    """The single most common setup mistake. Saying 'invalid token' twice
+    leaves the user re-copying the same two strings."""
+    with pytest.raises(m.TokenFormatError) as excinfo:
+        m.validate_tokens("xapp-oops", "xoxb-oops")
+    assert "goes in the other field" in str(excinfo.value)
+
+
+def test_a_missing_bot_token_names_where_to_find_it():
+    with pytest.raises(m.TokenFormatError) as excinfo:
+        m.validate_tokens("", "xapp-real")
+    assert "Install to Workspace" in str(excinfo.value)
+
+
+def test_a_missing_app_token_names_the_scope_it_needs():
+    with pytest.raises(m.TokenFormatError) as excinfo:
+        m.validate_tokens("xoxb-real", "")
+    assert "connections:write" in str(excinfo.value)
+
+
+def test_setup_steps_are_not_promised_as_automatic():
+    """Claiming 'automatic' strands the user on a settings page. The steps must
+    read as steps."""
+    joined = " ".join(m.SETUP_STEPS).lower()
+    assert "paste" in joined
+    assert "keyring" in joined, "the user should know where the tokens land"

--- a/tests/unit/messaging/test_slack_onboarding.py
+++ b/tests/unit/messaging/test_slack_onboarding.py
@@ -1,0 +1,187 @@
+"""When the Slack setup offer appears, and what it remembers.
+
+The rule under test: offer once, then again only when something changed. A
+prompt on every launch trains the user to dismiss it; a prompt that never
+returns strands the user who installed Slack after saying no.
+"""
+
+import json
+
+import pytest
+
+from gaia.messaging.slack import onboarding as ob
+
+#: One record captured from a REAL ``scan_installed_apps()`` run on macOS.
+#: Verbatim on purpose: the scanner returns discovery *facts*, not rows with a
+#: ``name`` field, and an invented fixture shaped like the latter is exactly how
+#: a detector passes its tests while reporting that nobody has Slack.
+REAL_SLACK_RECORD = {
+    "content": "Installed app: Slack [Communication]",
+    "category": "fact",
+    "context": "unclassified",
+    "entity": "app:slack",
+    "sensitive": False,
+    "confidence": 0.4,
+    "source": "discovery",
+    "approved": None,
+}
+
+REAL_OTHER_RECORD = {
+    "content": "Installed app: Google Chrome [Browser]",
+    "category": "fact",
+    "entity": "app:google_chrome",
+    "source": "discovery",
+}
+
+
+# ----------------------------------------------------------------------
+# Detection
+# ----------------------------------------------------------------------
+
+
+def test_detects_slack_in_a_real_discovery_record():
+    assert ob.slack_is_installed([REAL_OTHER_RECORD, REAL_SLACK_RECORD]) is True
+
+
+def test_reports_absent_when_no_record_is_slack():
+    assert ob.slack_is_installed([REAL_OTHER_RECORD]) is False
+
+
+def test_empty_inventory_is_not_slack():
+    assert ob.slack_is_installed([]) is False
+
+
+def test_a_similarly_named_app_is_not_slack():
+    """'Slackware Tools' must not light up the offer."""
+    assert (
+        ob.slack_is_installed(
+            [
+                {
+                    "entity": "app:slackware_tools",
+                    "content": "Installed app: Slackware Tools [Other]",
+                }
+            ]
+        )
+        is False
+    )
+
+
+def test_falls_back_to_the_content_line_when_no_entity_slug():
+    assert (
+        ob.slack_is_installed([{"content": "Installed app: Slack [Communication]"}])
+        is True
+    )
+
+
+def test_content_fallback_still_rejects_a_prefix_match():
+    assert (
+        ob.slack_is_installed([{"content": "Installed app: Slackware [Other]"}])
+        is False
+    )
+
+
+# ----------------------------------------------------------------------
+# The offer rule
+# ----------------------------------------------------------------------
+
+
+def test_first_boot_with_slack_installed_offers_setup():
+    assert ob.should_offer(ob.OnboardingState(), detected=True) is True
+
+
+def test_first_boot_without_slack_stays_quiet():
+    assert ob.should_offer(ob.OnboardingState(), detected=False) is False
+
+
+def test_skipped_without_slack_then_installing_it_offers_again():
+    """The user answered a different question: they had no Slack at the time."""
+    state = ob.OnboardingState(state=ob.STATE_SKIPPED, detected_when_decided=False)
+    assert ob.should_offer(state, detected=True) is True
+
+
+def test_skipped_with_slack_installed_never_offers_again():
+    """They saw the offer with Slack present and said no. Honour it."""
+    state = ob.OnboardingState(state=ob.STATE_SKIPPED, detected_when_decided=True)
+    assert ob.should_offer(state, detected=True) is False
+
+
+def test_never_is_honoured_forever():
+    for detected_then in (True, False):
+        state = ob.OnboardingState(
+            state=ob.STATE_NEVER, detected_when_decided=detected_then
+        )
+        assert ob.should_offer(state, detected=True) is False
+
+
+def test_connected_does_not_re_offer():
+    state = ob.OnboardingState(state=ob.STATE_CONNECTED, detected_when_decided=True)
+    assert ob.should_offer(state, detected=True) is False
+
+
+# ----------------------------------------------------------------------
+# Persistence
+# ----------------------------------------------------------------------
+
+
+def test_missing_state_file_means_never_asked(tmp_path):
+    """A fresh install is not an error — it is the starting point."""
+    state = ob.load_state(tmp_path / "nope.json")
+    assert state.state == ob.STATE_UNSET
+
+
+def test_a_decision_round_trips(tmp_path):
+    path = tmp_path / "onboarding.json"
+    ob.record_decision(ob.STATE_SKIPPED, detected=False, team_name="acme", path=path)
+    reloaded = ob.load_state(path)
+    assert reloaded.state == ob.STATE_SKIPPED
+    assert reloaded.detected_when_decided is False
+    assert reloaded.team_name == "acme"
+    assert reloaded.updated_at > 0
+
+
+def test_saving_creates_the_parent_directory(tmp_path):
+    path = tmp_path / "slack" / "onboarding.json"
+    ob.save_state(ob.OnboardingState(state=ob.STATE_CONNECTED), path)
+    assert path.is_file()
+
+
+def test_corrupt_state_is_refused_rather_than_reset(tmp_path):
+    """Silently resetting would re-prompt a user who explicitly said never."""
+    path = tmp_path / "onboarding.json"
+    path.write_text("{not json", encoding="utf-8")
+    with pytest.raises(ob.OnboardingStateError) as excinfo:
+        ob.load_state(path)
+    assert "Delete the file" in str(excinfo.value), "an error must name the remedy"
+
+
+def test_a_non_object_state_file_is_refused(tmp_path):
+    path = tmp_path / "onboarding.json"
+    path.write_text('["not", "an", "object"]', encoding="utf-8")
+    with pytest.raises(ob.OnboardingStateError):
+        ob.load_state(path)
+
+
+def test_an_unknown_state_name_is_refused(tmp_path):
+    path = tmp_path / "onboarding.json"
+    path.write_text(json.dumps({"state": "sideways"}), encoding="utf-8")
+    with pytest.raises(ob.OnboardingStateError):
+        ob.load_state(path)
+
+
+def test_unknown_keys_in_the_file_are_ignored(tmp_path):
+    """Forward compatibility: a newer GAIA's extra key must not break an older one."""
+    path = tmp_path / "onboarding.json"
+    path.write_text(
+        json.dumps({"state": ob.STATE_NEVER, "future_field": 1}), encoding="utf-8"
+    )
+    assert ob.load_state(path).state == ob.STATE_NEVER
+
+
+def test_constructing_an_invalid_state_is_refused():
+    with pytest.raises(ValueError):
+        ob.OnboardingState(state="banana")
+
+
+def test_state_path_honours_a_relocated_gaia_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("GAIA_CONFIG_DIR", str(tmp_path))
+    assert ob._state_path() == tmp_path / "slack" / "onboarding.json"

--- a/tests/unit/messaging/test_slack_sdk_contract.py
+++ b/tests/unit/messaging/test_slack_sdk_contract.py
@@ -1,0 +1,100 @@
+"""Pin the adapter's Slack calls against the real ``slack_sdk``.
+
+``test_slack_adapter.py`` drives a ``FakeWeb`` that accepts any keyword it is
+handed, so every assertion there proves only "we called it" — never "the call
+would be accepted". That is the boundary-validity gap CLAUDE.md names, and on a
+third-party HTTP client it is exactly where a rename lands: ``files.upload`` was
+retired in favour of ``files_upload_v2`` with a different signature, and a fake
+would have kept reporting success right through the change.
+
+These tests introspect the installed SDK. They cannot prove Slack's *server*
+accepts a payload — only an end-to-end run against a real workspace does that —
+but they do prove the adapter is not calling a method that no longer exists or
+passing a keyword that was removed.
+"""
+
+import inspect
+
+import pytest
+
+slack_sdk = pytest.importorskip(
+    "slack_sdk", reason="slack-sdk is an optional extra: pip install 'amd-gaia[slack]'"
+)
+
+from slack_sdk import WebClient  # noqa: E402
+from slack_sdk.socket_mode import SocketModeClient  # noqa: E402
+from slack_sdk.socket_mode.response import SocketModeResponse  # noqa: E402
+
+
+def _params(method):
+    return set(inspect.signature(method).parameters)
+
+
+# ----------------------------------------------------------------------
+# WebClient
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "method", ["auth_test", "chat_postMessage", "chat_update", "files_upload_v2"]
+)
+def test_the_adapter_only_calls_methods_that_exist(method):
+    assert hasattr(
+        WebClient, method
+    ), f"WebClient has no {method}; the adapter calls it"
+
+
+def test_post_accepts_every_keyword_the_adapter_sends():
+    assert {"channel", "text", "blocks", "thread_ts"} <= _params(
+        WebClient.chat_postMessage
+    )
+
+
+def test_update_accepts_every_keyword_the_adapter_sends():
+    assert {"channel", "ts", "text", "blocks"} <= _params(WebClient.chat_update)
+
+
+def test_upload_accepts_every_keyword_the_adapter_sends():
+    """``files_upload_v2``, not the retired ``files.upload``. Its keywords
+    differ from the old call's, which is the whole reason this is pinned."""
+    assert {
+        "channel",
+        "file",
+        "filename",
+        "initial_comment",
+        "thread_ts",
+    } <= _params(WebClient.files_upload_v2)
+
+
+# ----------------------------------------------------------------------
+# Socket Mode
+# ----------------------------------------------------------------------
+
+
+def test_socket_client_takes_the_app_token_and_a_web_client():
+    assert {"app_token", "web_client"} <= _params(SocketModeClient.__init__)
+
+
+def test_socket_client_exposes_the_listener_list_the_adapter_appends_to():
+    client = SocketModeClient(app_token="xapp-not-a-real-token")
+    assert isinstance(client.socket_mode_request_listeners, list)
+
+
+def test_the_ack_carries_an_envelope_id():
+    """Slack retries anything unacked within three seconds, and a turn takes far
+    longer — a broken ack turns one question into three."""
+    assert "envelope_id" in _params(SocketModeResponse.__init__)
+
+
+# ----------------------------------------------------------------------
+# The adapter against a real WebClient
+# ----------------------------------------------------------------------
+
+
+def test_the_adapter_builds_a_real_web_client_from_the_bot_token():
+    from gaia.messaging.slack.adapter import SlackAdapter
+
+    adapter = SlackAdapter("xoxb-not-a-real-token", "xapp-x", allowed_users={"U1"})
+    client = adapter._build_web_client()
+    assert isinstance(client, WebClient)
+    assert client.token == "xoxb-not-a-real-token"

--- a/tests/unit/messaging/test_slack_tool_surface.py
+++ b/tests/unit/messaging/test_slack_tool_surface.py
@@ -1,0 +1,131 @@
+"""Pin the security posture a Slack message runs under.
+
+Slack differs from Telegram on the axis that matters. Telegram's adapter reaches
+a tool-less ``AgentSDK``, so no shell tool exists to be reached and
+``test_telegram_tool_surface.py`` pins exactly that. This bridge deliberately
+drives the full flagship agent — reading your files and running commands is the
+feature — so the safety argument is not "the tools are absent" but "the
+dangerous ones are gated, and nothing in this path can ungate them".
+
+These tests are that argument, written down. Each one fails if a change makes a
+dangerous tool reachable without a decision the user consciously made.
+"""
+
+import inspect
+
+from gaia.agents.base import agent as base_agent
+from gaia.messaging import bridge
+from gaia.messaging.slack import adapter as ad
+
+#: Tool names whose unattended execution from a remote message would be the bug.
+#: Read from the base agent rather than copied, so a tool added to the gate
+#: lands here automatically instead of silently shrinking what this file checks.
+GATED_TOOLS = frozenset(base_agent.TOOLS_REQUIRING_CONFIRMATION)
+
+
+def test_the_dangerous_tools_are_gated_by_the_base_agent():
+    """The whole posture rests on this set being non-empty and containing the
+    obvious offenders. If the base agent stops gating shell, every other test
+    in this file is testing nothing."""
+    assert {"run_shell_command", "write_file", "edit_file"} <= GATED_TOOLS
+
+
+def test_a_gated_tool_pauses_the_turn_rather_than_running():
+    """``needs_confirmation`` is the event that makes approval possible at all."""
+    assert bridge.NEEDS_CONFIRMATION == "needs_confirmation"
+    assert bridge.NEEDS_CONFIRMATION not in bridge.TERMINAL_EVENTS
+
+
+def test_the_bridge_has_no_bypass_control():
+    """``gaia_agent.stdio`` accepts a ``bypass`` verb that disarms the gate for
+    the whole session. A remote surface must not be able to send it: an
+    allowlisted user is trusted to approve one tool, not to switch the gate off
+    for every later one."""
+    source = inspect.getsource(bridge)
+    # The module documents the absence; what must not appear is a control
+    # message that actually carries the verb.
+    assert '"bypass"' not in source
+    assert "CONTROL_BYPASS" not in source
+
+
+def test_the_adapter_cannot_build_a_raw_control_message():
+    """The adapter's only channel to the agent is ``decide()``, which accepts
+    the three decisions and nothing else.
+
+    Checked structurally rather than by searching for the word: the module
+    docstring explains that bypass is unreachable, and a text search would
+    either trip over that sentence or be defeated by rewording it. What matters
+    is that no code here builds a control dict of its own — if it did, it could
+    put any verb in it, including the one that disarms the gate.
+    """
+    import ast
+
+    tree = ast.parse(inspect.getsource(ad))
+    referenced = {node.id for node in ast.walk(tree) if isinstance(node, ast.Name)} | {
+        node.attr for node in ast.walk(tree) if isinstance(node, ast.Attribute)
+    }
+    assert "CONTROL_KEY" not in referenced
+    assert "CONTROL_TOOL_DECISION" not in referenced
+    assert "CONTROL_BYPASS" not in referenced
+
+
+def test_the_adapter_reaches_the_agent_only_through_decide():
+    """Every write to the agent goes through the one method that validates."""
+    import ast
+
+    tree = ast.parse(inspect.getsource(ad))
+    channel_calls = {
+        node.func.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Attribute)
+        and node.func.value.attr == "_channel"
+    }
+    assert channel_calls <= {"decide", "start", "close", "submit"}, channel_calls
+
+
+def test_the_adapter_only_ever_sends_the_three_real_decisions():
+    """A fourth value would be downgraded to a deny by the agent, which looks
+    to the user like their approval was ignored."""
+    assert set(ad._ACTION_DECISIONS.values()) == bridge.VALID_DECISIONS
+
+
+def test_every_button_maps_to_a_decision_the_agent_accepts():
+    for action_id, decision in ad._ACTION_DECISIONS.items():
+        assert decision in bridge.VALID_DECISIONS, action_id
+
+
+def test_the_manifest_subscribes_to_no_channel_events():
+    """A channel subscription makes the agent addressable by everyone in the
+    channel, which the allowlist alone would then have to carry."""
+    from gaia.messaging.slack import manifest
+
+    events = manifest.build_manifest()["settings"]["event_subscriptions"]["bot_events"]
+    assert events == ["message.im"]
+    assert not any("channel" in event for event in events)
+
+
+def test_both_message_and_button_paths_check_the_allowlist():
+    """Slack routes events and interactions to different handlers. Guarding only
+    one is the trap Telegram's ``require_allowed`` exists for — a command update
+    never reaches the message handler."""
+    for handler in (ad.SlackAdapter._handle_event, ad.SlackAdapter._handle_interactive):
+        source = inspect.getsource(handler)
+        assert "_allowed(" in source, f"{handler.__name__} does not check the allowlist"
+        assert (
+            "_same_workspace(" in source
+        ), f"{handler.__name__} does not pin the workspace"
+
+
+def test_an_upload_root_outside_the_agents_reach_is_still_enforced(tmp_path):
+    """Approving a write is not approving a transfer off the machine."""
+    source = inspect.getsource(ad.SlackAdapter._maybe_upload)
+    assert "upload_roots" in source
+    assert "resolve()" in source, "the path must be resolved before it is compared"
+
+
+def test_the_refusal_message_never_names_who_is_allowed():
+    """A stranger who found the bot learns only that they are not allowed."""
+    assert "U0" not in ad.UNAUTHORIZED_REPLY
+    assert "allowlist" not in ad.UNAUTHORIZED_REPLY.lower()

--- a/tui/internal/gaiaslack/gaiaslack.go
+++ b/tui/internal/gaiaslack/gaiaslack.go
@@ -1,0 +1,175 @@
+// Package gaiaslack asks the `gaia` CLI about the Slack bridge and records the
+// user's answer to the setup offer.
+//
+// Everything here shells out rather than re-deriving anything in Go, for the
+// same reason gaiainit does: src/gaia/messaging/slack/ owns what "installed",
+// "configured" and "should we offer" mean, and a Go copy of those rules goes
+// stale the first time one of them changes. `gaia slack status --json` exists
+// precisely so this package can be a thin reader of it.
+//
+// Nothing is cached. Whether Slack is installed is read fresh on every call —
+// the whole point of the offer is to notice a Slack that was not there before.
+package gaiaslack
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// StatusTimeout bounds the read-only probe. It spawns a Python interpreter and
+// walks the installed-application inventory, so a couple of seconds is normal;
+// this only stops a wedged call from hanging the UI forever.
+const StatusTimeout = 30 * time.Second
+
+// ErrUnanswered wraps every failure to ASK the question, as opposed to a clean
+// answer of "not set up". Callers must not render it as "Slack is not
+// connected": against a gaia too old to know the subcommand, argparse exits 2,
+// and treating that as a clean negative would offer setup on a machine that
+// cannot run it.
+var ErrUnanswered = errors.New("Slack readiness could not be determined")
+
+// Binary resolves the `gaia` CLI on PATH. A package var, not a bare
+// exec.LookPath, so tests can substitute a stub — same injection point as
+// gaiainit.Binary.
+var Binary = func() (string, error) {
+	bin, err := exec.LookPath("gaia")
+	if err != nil {
+		return "", fmt.Errorf(
+			"the `gaia` CLI is not on PATH, so Slack setup cannot run. " +
+				"Install GAIA with `curl -fsSL https://amd-gaia.ai/install.sh | sh` " +
+				"(on Windows: `irm https://amd-gaia.ai/install.ps1 | iex`), or " +
+				"`pip install amd-gaia` into the Python environment on your PATH")
+	}
+	return bin, nil
+}
+
+// Status is `gaia slack status --json`, one field per question a screen asks.
+type Status struct {
+	// SlackInstalled is whether the Slack desktop app is on this machine.
+	SlackInstalled bool `json:"slack_installed"`
+	// Configured is whether tokens are stored and the bridge could start.
+	Configured bool `json:"configured"`
+	// OnboardingState is one of unset / connected / skipped / never.
+	OnboardingState string `json:"onboarding_state"`
+	// TeamName names the workspace the stored tokens belong to.
+	TeamName string `json:"team_name"`
+	// ShouldOfferSetup is the ONLY field a caller should gate the offer on. The
+	// rule behind it — offer once, then again only if Slack appears on a machine
+	// that lacked it — lives in Python and must not be re-implemented here.
+	ShouldOfferSetup bool `json:"should_offer_setup"`
+	// Running is whether a backgrounded bridge is alive.
+	Running bool `json:"running"`
+}
+
+// Summary is the one-line form for a status row.
+func (s Status) Summary() string {
+	switch {
+	case s.Running:
+		return "connected and running" + s.workspace()
+	case s.Configured:
+		return "connected" + s.workspace() + " — not running"
+	case s.SlackInstalled:
+		return "Slack is installed here, but GAIA is not connected to it"
+	default:
+		return "no Slack app found on this machine"
+	}
+}
+
+func (s Status) workspace() string {
+	if s.TeamName == "" {
+		return ""
+	}
+	return " to " + s.TeamName
+}
+
+// Query asks the CLI for the current Slack status.
+func Query(ctx context.Context) (Status, error) {
+	bin, err := Binary()
+	if err != nil {
+		return Status{}, fmt.Errorf("%w: %w", ErrUnanswered, err)
+	}
+	ctx, cancel := context.WithTimeout(ctx, StatusTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, bin, "slack", "status", "--json")
+	var out, errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if runErr := cmd.Run(); runErr != nil {
+		return Status{}, fmt.Errorf("%w (%w). GAIA said: %s",
+			ErrUnanswered, runErr, lastMeaningfulLine(errBuf.String()+out.String()))
+	}
+
+	// The CLI's logger writes to stderr, but a stray banner on stdout would
+	// still break a naive unmarshal — so decode from the first '{' rather than
+	// from byte zero.
+	raw := out.Bytes()
+	if i := bytes.IndexByte(raw, '{'); i > 0 {
+		raw = raw[i:]
+	}
+	var status Status
+	if err := json.Unmarshal(raw, &status); err != nil {
+		return Status{}, fmt.Errorf("%w: `gaia slack status --json` returned "+
+			"something that is not JSON (%w): %s",
+			ErrUnanswered, err, lastMeaningfulLine(out.String()))
+	}
+	return status, nil
+}
+
+// Decline records that the user does not want Slack set up. `never` is the
+// difference between "not now" — reconsidered once if Slack appears later — and
+// "stop asking", which is honoured forever.
+func Decline(ctx context.Context, never bool) error {
+	bin, err := Binary()
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(ctx, StatusTimeout)
+	defer cancel()
+
+	args := []string{"slack", "decline"}
+	if never {
+		args = append(args, "--never")
+	}
+	cmd := exec.CommandContext(ctx, bin, args...)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if runErr := cmd.Run(); runErr != nil {
+		return fmt.Errorf("could not record the Slack decision (%w). GAIA said: %s",
+			runErr, lastMeaningfulLine(out.String()))
+	}
+	return nil
+}
+
+// SetupCommand is the command that runs setup, for a caller that suspends the
+// TUI and hands the terminal over. Setup is interactive — it opens a browser
+// and reads two pasted tokens — so it cannot run as a captured child.
+func SetupCommand() (string, []string, error) {
+	bin, err := Binary()
+	if err != nil {
+		return "", nil, err
+	}
+	return bin, []string{"slack", "setup"}, nil
+}
+
+// TypedCommand is what a user should type to do this themselves.
+const TypedCommand = "gaia slack setup"
+
+// lastMeaningfulLine returns the last non-blank line, for quoting a failure.
+// The whole buffer would bury the reason under a traceback.
+func lastMeaningfulLine(s string) string {
+	lines := strings.Split(strings.TrimSpace(s), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if line := strings.TrimSpace(lines[i]); line != "" {
+			return line
+		}
+	}
+	return "(no output)"
+}

--- a/tui/internal/gaiaslack/gaiaslack_test.go
+++ b/tui/internal/gaiaslack/gaiaslack_test.go
@@ -1,0 +1,195 @@
+package gaiaslack
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// stubGaia installs a fake `gaia` binary that prints what the test wants and
+// exits with the given code. Substituting Binary rather than PATH keeps the
+// real CLI (and its multi-second Python start-up) out of these tests.
+func stubGaia(t *testing.T, stdout string, exitCode int) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("the shell stub is POSIX-only; the code under test is not")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gaia")
+	script := "#!/bin/sh\ncat <<'EOF'\n" + stdout + "\nEOF\nexit " +
+		string(rune('0'+exitCode)) + "\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("could not write the gaia stub: %v", err)
+	}
+	original := Binary
+	Binary = func() (string, error) { return path, nil }
+	t.Cleanup(func() { Binary = original })
+}
+
+func TestQueryReadsEveryField(t *testing.T) {
+	stubGaia(t, `{"slack_installed": true, "configured": true,
+	 "onboarding_state": "connected", "team_name": "Acme",
+	 "should_offer_setup": false, "running": true}`, 0)
+
+	status, err := Query(context.Background())
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if !status.SlackInstalled || !status.Configured || !status.Running {
+		t.Errorf("booleans did not survive the round trip: %+v", status)
+	}
+	if status.TeamName != "Acme" || status.OnboardingState != "connected" {
+		t.Errorf("strings did not survive the round trip: %+v", status)
+	}
+	if status.ShouldOfferSetup {
+		t.Error("ShouldOfferSetup must stay false")
+	}
+}
+
+func TestQueryToleratesABannerBeforeTheJSON(t *testing.T) {
+	// The CLI logs to stderr, but a dependency printing to stdout would
+	// otherwise turn a working probe into "not set up".
+	stubGaia(t, "Some library said something\n{\"slack_installed\": true}", 0)
+
+	status, err := Query(context.Background())
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if !status.SlackInstalled {
+		t.Error("the JSON after the banner was not parsed")
+	}
+}
+
+func TestAFailedProbeIsUnansweredNotANegative(t *testing.T) {
+	// An older gaia exits 2 for an unrecognized subcommand. Reading that as
+	// "Slack is not set up" would offer setup on a machine that cannot run it.
+	stubGaia(t, "usage: gaia [-h] ...\ngaia: error: argument command: invalid choice", 2)
+
+	_, err := Query(context.Background())
+	if err == nil {
+		t.Fatal("a non-zero exit must not be reported as a clean answer")
+	}
+	if !errors.Is(err, ErrUnanswered) {
+		t.Errorf("error must wrap ErrUnanswered, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "invalid choice") {
+		t.Errorf("the error must quote what GAIA said, got %v", err)
+	}
+}
+
+func TestUnparseableOutputIsUnanswered(t *testing.T) {
+	stubGaia(t, "not json at all", 0)
+
+	_, err := Query(context.Background())
+	if !errors.Is(err, ErrUnanswered) {
+		t.Errorf("garbage output must be unanswered, got %v", err)
+	}
+}
+
+func TestAMissingGaiaNamesTheInstallCommand(t *testing.T) {
+	original := Binary
+	Binary = func() (string, error) { return "", errors.New("not on PATH") }
+	t.Cleanup(func() { Binary = original })
+
+	_, err := Query(context.Background())
+	if !errors.Is(err, ErrUnanswered) {
+		t.Errorf("a missing CLI must be unanswered, got %v", err)
+	}
+}
+
+func TestDeclineForwardsNever(t *testing.T) {
+	dir := t.TempDir()
+	argsFile := filepath.Join(dir, "args")
+	path := filepath.Join(dir, "gaia")
+	script := "#!/bin/sh\necho \"$@\" > " + argsFile + "\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("stub: %v", err)
+	}
+	original := Binary
+	Binary = func() (string, error) { return path, nil }
+	t.Cleanup(func() { Binary = original })
+
+	if err := Decline(context.Background(), true); err != nil {
+		t.Fatalf("Decline: %v", err)
+	}
+	recorded, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("reading the recorded args: %v", err)
+	}
+	if !strings.Contains(string(recorded), "--never") {
+		t.Errorf("--never did not reach the CLI, got %q", recorded)
+	}
+}
+
+func TestDeclineOmitsNeverForAPlainSkip(t *testing.T) {
+	dir := t.TempDir()
+	argsFile := filepath.Join(dir, "args")
+	path := filepath.Join(dir, "gaia")
+	if err := os.WriteFile(path,
+		[]byte("#!/bin/sh\necho \"$@\" > "+argsFile+"\n"), 0o755); err != nil {
+		t.Fatalf("stub: %v", err)
+	}
+	original := Binary
+	Binary = func() (string, error) { return path, nil }
+	t.Cleanup(func() { Binary = original })
+
+	if err := Decline(context.Background(), false); err != nil {
+		t.Fatalf("Decline: %v", err)
+	}
+	recorded, _ := os.ReadFile(argsFile)
+	if strings.Contains(string(recorded), "--never") {
+		t.Errorf("a plain skip must not be permanent, got %q", recorded)
+	}
+}
+
+func TestSummaryDistinguishesEveryState(t *testing.T) {
+	cases := []struct {
+		name   string
+		status Status
+		want   string
+	}{
+		{"running", Status{Running: true, Configured: true, TeamName: "Acme"}, "running"},
+		{"configured but stopped", Status{Configured: true, TeamName: "Acme"}, "not running"},
+		{"installed only", Status{SlackInstalled: true}, "not connected"},
+		{"absent", Status{}, "no Slack app"},
+	}
+	seen := map[string]bool{}
+	for _, tc := range cases {
+		got := tc.status.Summary()
+		if !strings.Contains(got, tc.want) {
+			t.Errorf("%s: Summary() = %q, want it to mention %q", tc.name, got, tc.want)
+		}
+		if seen[got] {
+			t.Errorf("%s: Summary() %q collides with another state", tc.name, got)
+		}
+		seen[got] = true
+	}
+}
+
+func TestSummaryNamesTheWorkspaceWhenKnown(t *testing.T) {
+	got := Status{Configured: true, TeamName: "Acme"}.Summary()
+	if !strings.Contains(got, "Acme") {
+		t.Errorf("Summary() = %q, want the workspace named", got)
+	}
+}
+
+func TestSetupCommandAsksForSetup(t *testing.T) {
+	original := Binary
+	Binary = func() (string, error) { return "/usr/bin/gaia", nil }
+	t.Cleanup(func() { Binary = original })
+
+	bin, args, err := SetupCommand()
+	if err != nil {
+		t.Fatalf("SetupCommand: %v", err)
+	}
+	if bin != "/usr/bin/gaia" {
+		t.Errorf("bin = %q", bin)
+	}
+	if strings.Join(args, " ") != "slack setup" {
+		t.Errorf("args = %v", args)
+	}
+}

--- a/tui/internal/ui/chat/model.go
+++ b/tui/internal/ui/chat/model.go
@@ -19,6 +19,7 @@ import (
 	"github.com/amd/gaia/tui/internal/client"
 	"github.com/amd/gaia/tui/internal/event"
 	"github.com/amd/gaia/tui/internal/gaiainit"
+	"github.com/amd/gaia/tui/internal/gaiaslack"
 	"github.com/amd/gaia/tui/internal/ui/components"
 
 	"github.com/amd/gaia/tui/internal/ui/theme"
@@ -334,6 +335,11 @@ type ChatModel struct {
 	// auto-started because the first-boot check said not ready, or started on
 	// demand by /setup.
 	setupRunning bool
+	// slackOffered records that the one-time Slack offer has already been shown
+	// this session, so a second launch-time probe cannot repeat it. The durable
+	// answer lives in `gaia slack decline`; this only stops a duplicate inside
+	// one run.
+	slackOffered bool
 	// setupCancel tears down the in-flight `gaia init` subprocess. Nil unless
 	// setupRunning.
 	setupCancel context.CancelFunc
@@ -432,6 +438,14 @@ func (m ChatModel) Init() tea.Cmd {
 	cmds := []tea.Cmd{
 		m.spinner.Tick,
 		textarea.Blink,
+	}
+	if m.agentID == setupAgentID && m.initialQuery == "" {
+		// The one-time Slack offer. Gated on an empty initial query so a user
+		// who launched with a question gets their answer, not an ad; and run
+		// only for the flagship, which is the agent a Slack message drives.
+		// Whether it actually shows is `gaia slack status`'s decision, not
+		// ours -- this only asks.
+		cmds = append(cmds, querySlackCmd(true /* offer */))
 	}
 	if m.setupChecking {
 		// The flagship agent's first-boot gate (see applyFirstBootGate):
@@ -615,6 +629,15 @@ func (m ChatModel) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case setupCheckResultMsg:
 		return m.handleSetupCheckResult(msg)
+
+	case slackStatusMsg:
+		return m.handleSlackStatus(msg)
+
+	case slackDeclinedMsg:
+		return m.handleSlackDeclined(msg)
+
+	case slackSetupDoneMsg:
+		return m.handleSlackSetupDone(msg)
 
 	case setupStreamMsg:
 		if m.supersededSetup(msg.ch) {
@@ -1337,6 +1360,19 @@ func (m ChatModel) submit(query string) (tea.Model, tea.Cmd) {
 			return m.statusNote("Setup is already running. Esc cancels it."), nil
 		}
 		return m.startSetupRun(false /* firstBoot */)
+
+	case "/slack":
+		return m.startSlackCheck()
+
+	case "/slack setup":
+		return m.statusNote("Handing over to `"+gaiaslack.TypedCommand+"`…"),
+			runSlackSetupCmd()
+
+	case "/slack skip":
+		return m, declineSlackCmd(false)
+
+	case "/slack never":
+		return m, declineSlackCmd(true)
 	}
 
 	return m.sendQuery(query)

--- a/tui/internal/ui/chat/palette.go
+++ b/tui/internal/ui/chat/palette.go
@@ -35,6 +35,7 @@ var paletteCommands = []paletteCommand{
 	{"/memory", "View this agent's memory"},
 	{"/bypass", "Run every tool without asking first — shows a warning before it turns on"},
 	{"/setup", "Run first-time setup (gaia flagship agent only)"},
+	{"/slack", "Connect this agent to Slack, or show the connection's status"},
 	{"/model", "Switch the model this session runs on (gaia flagship agent only)"},
 }
 

--- a/tui/internal/ui/chat/palette_test.go
+++ b/tui/internal/ui/chat/palette_test.go
@@ -297,6 +297,13 @@ func TestPaletteListsEverySubmitCommand(t *testing.T) {
 			// one command the palette offers.
 			base = "/bypass"
 		}
+		if strings.HasPrefix(cmd, "/slack") {
+			// /slack setup|skip|never are the three answers to the setup
+			// offer, which names them itself. One palette row, same as
+			// /bypass -- listing them at the top level would put two rows
+			// nobody asked for above the command that explains them.
+			base = "/slack"
+		}
 		seen[base] = true
 		if !known[base] {
 			t.Errorf("submit now handles %q but paletteCommands (palette.go) does not offer %q — add it", cmd, base)

--- a/tui/internal/ui/chat/slack.go
+++ b/tui/internal/ui/chat/slack.go
@@ -1,0 +1,182 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package chat
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/amd/gaia/tui/internal/gaiaslack"
+)
+
+// `/slack` and the one-time offer that precedes it.
+//
+// The offer is the whole point: a user who has Slack installed should be told
+// GAIA can use it, exactly once, without having to go looking. Everything about
+// WHEN that is true lives in `gaia slack status --json` — this file renders the
+// answer and records the reply, and deliberately re-derives none of the rule.
+//
+// Setup itself is interactive: it opens a browser and reads two pasted tokens.
+// A captured child cannot do that, so the offer hands the terminal over with
+// tea.ExecProcess and takes it back when setup exits.
+
+// slackStatusMsg carries the result of the read-only probe.
+type slackStatusMsg struct {
+	status gaiaslack.Status
+	// err is set only when the question could not be ASKED. A machine with no
+	// Slack is a clean answer, not an error.
+	err error
+	// offer marks a probe run at launch, whose answer may open the offer, as
+	// opposed to one the user asked for with /slack.
+	offer bool
+}
+
+// slackDeclinedMsg is delivered once a skip/never has been recorded.
+type slackDeclinedMsg struct {
+	never bool
+	err   error
+}
+
+// slackSetupDoneMsg is delivered when the handed-over setup process exits.
+type slackSetupDoneMsg struct{ err error }
+
+// querySlackCmd asks the CLI about Slack without changing anything.
+func querySlackCmd(offer bool) tea.Cmd {
+	return func() tea.Msg {
+		status, err := gaiaslack.Query(context.Background())
+		return slackStatusMsg{status: status, err: err, offer: offer}
+	}
+}
+
+// declineSlackCmd records "not now" or "stop asking".
+func declineSlackCmd(never bool) tea.Cmd {
+	return func() tea.Msg {
+		err := gaiaslack.Decline(context.Background(), never)
+		return slackDeclinedMsg{never: never, err: err}
+	}
+}
+
+// runSlackSetupCmd suspends the TUI and runs `gaia slack setup` on the real
+// terminal. Setup prompts for two tokens, so it needs the keyboard: run as a
+// captured child it would block forever on a prompt nobody can answer — the
+// same trap gaiainit avoids by passing --yes.
+func runSlackSetupCmd() tea.Cmd {
+	bin, args, err := gaiaslack.SetupCommand()
+	if err != nil {
+		return func() tea.Msg { return slackSetupDoneMsg{err: err} }
+	}
+	return tea.ExecProcess(exec.Command(bin, args...), func(err error) tea.Msg {
+		return slackSetupDoneMsg{err: err}
+	})
+}
+
+// startSlackCheck runs the probe for the /slack command.
+func (m ChatModel) startSlackCheck() (tea.Model, tea.Cmd) {
+	return m.statusNote("Checking Slack…"), querySlackCmd(false)
+}
+
+// handleSlackStatus renders a probe result.
+func (m ChatModel) handleSlackStatus(msg slackStatusMsg) (tea.Model, tea.Cmd) {
+	if msg.err != nil {
+		if msg.offer {
+			// At launch this is background work the user never asked for.
+			// Interrupting them with its failure would be noise; /slack still
+			// reports it on demand.
+			return m, nil
+		}
+		return m.statusNote(slackUnavailableNote(msg.err)), nil
+	}
+	if msg.offer {
+		// Two guards, and they answer different questions. ShouldOfferSetup is
+		// the DURABLE one -- has this user already said no? slackOffered is the
+		// session one: a probe that somehow ran twice must not print the offer
+		// twice into the same transcript.
+		if !msg.status.ShouldOfferSetup || m.slackOffered {
+			return m, nil
+		}
+		m.slackOffered = true
+		return m.statusNote(slackOfferText()), nil
+	}
+	return m.statusNote(slackStatusText(msg.status)), nil
+}
+
+// handleSlackDeclined renders the recorded decision.
+func (m ChatModel) handleSlackDeclined(msg slackDeclinedMsg) (tea.Model, tea.Cmd) {
+	if msg.err != nil {
+		return m.statusNote(fmt.Sprintf(
+			"Could not record that: %v\nRun `gaia slack decline` yourself, or "+
+				"ignore the offer — it is not shown twice in one session.",
+			msg.err)), nil
+	}
+	if msg.never {
+		return m.statusNote(
+			"Won't ask about Slack again. Type /slack whenever you change your mind.",
+		), nil
+	}
+	return m.statusNote(
+		"Skipped. Type /slack whenever you want to connect it.",
+	), nil
+}
+
+// handleSlackSetupDone renders the outcome of the handed-over setup run.
+func (m ChatModel) handleSlackSetupDone(msg slackSetupDoneMsg) (tea.Model, tea.Cmd) {
+	if msg.err != nil {
+		return m.statusNote(fmt.Sprintf(
+			"Slack setup did not finish: %v\nRun `%s` in a terminal to retry.",
+			msg.err, gaiaslack.TypedCommand)), nil
+	}
+	// Re-probe rather than assume success: the user may have quit setup
+	// half-way, and claiming "connected" when no token was stored is worse than
+	// saying nothing.
+	return m.statusNote("Setup finished — checking…"), querySlackCmd(false)
+}
+
+// slackOfferText is the one-time offer.
+func slackOfferText() string {
+	return strings.Join([]string{
+		"Slack is installed on this machine — GAIA can answer there too.",
+		"",
+		"You'd message GAIA from Slack on any device and it would answer from",
+		"here, with access to your files. Setup takes about ninety seconds.",
+		"",
+		"  /slack setup   connect it now",
+		"  /slack skip    not now (offered again only if something changes)",
+		"  /slack never   stop asking",
+	}, "\n")
+}
+
+// slackStatusText is what /slack reports.
+func slackStatusText(s gaiaslack.Status) string {
+	lines := []string{"Slack: " + s.Summary()}
+	switch {
+	case s.Running:
+		lines = append(lines, "", "Send it a direct message.")
+	case s.Configured:
+		lines = append(lines, "",
+			"Start it with:",
+			"  gaia slack start --allowed-users <your member ID>")
+	default:
+		lines = append(lines, "",
+			"Connect it with:",
+			"  "+gaiaslack.TypedCommand,
+			"",
+			"Or type /slack setup to do it from here.")
+	}
+	return strings.Join(lines, "\n")
+}
+
+// slackUnavailableNote explains a probe that could not run.
+func slackUnavailableNote(err error) string {
+	if errors.Is(err, gaiaslack.ErrUnanswered) {
+		return fmt.Sprintf(
+			"Could not check Slack: %v\n\nThis says nothing about whether Slack "+
+				"is set up — only that the question could not be asked.", err)
+	}
+	return fmt.Sprintf("Could not check Slack: %v", err)
+}

--- a/tui/internal/ui/chat/slack_test.go
+++ b/tui/internal/ui/chat/slack_test.go
@@ -1,0 +1,250 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package chat
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/amd/gaia/tui/internal/gaiaslack"
+)
+
+func slackModel(t *testing.T) ChatModel {
+	t.Helper()
+	m := NewChatModel(&nullClient{}, "gaia", "", false)
+	m.width, m.height = 100, 30
+	return m
+}
+
+// lastStatus returns the text of the most recent status message.
+func lastStatus(t *testing.T, m ChatModel) string {
+	t.Helper()
+	for i := len(m.messages) - 1; i >= 0; i-- {
+		if m.messages[i].Role == RoleStatus {
+			return m.messages[i].Content
+		}
+	}
+	t.Fatal("no status message was added")
+	return ""
+}
+
+func hasStatus(m ChatModel) bool {
+	for _, msg := range m.messages {
+		if msg.Role == RoleStatus {
+			return true
+		}
+	}
+	return false
+}
+
+// ----------------------------------------------------------------------
+// The one-time offer
+// ----------------------------------------------------------------------
+
+func TestOfferAppearsWhenTheCLISaysSo(t *testing.T) {
+	m := slackModel(t)
+	updated, _ := m.handleSlackStatus(slackStatusMsg{
+		status: gaiaslack.Status{SlackInstalled: true, ShouldOfferSetup: true},
+		offer:  true,
+	})
+	text := lastStatus(t, updated.(ChatModel))
+	for _, want := range []string{"/slack setup", "/slack skip", "/slack never"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("the offer must show %q, got:\n%s", want, text)
+		}
+	}
+}
+
+func TestOfferStaysHiddenWhenTheCLISaysNotToShowIt(t *testing.T) {
+	// The rule — offer once, then only if something changed — lives in Python.
+	// The TUI must not second-guess it from SlackInstalled alone.
+	m := slackModel(t)
+	updated, _ := m.handleSlackStatus(slackStatusMsg{
+		status: gaiaslack.Status{SlackInstalled: true, ShouldOfferSetup: false},
+		offer:  true,
+	})
+	if hasStatus(updated.(ChatModel)) {
+		t.Errorf("nothing should have been shown, got:\n%s",
+			lastStatus(t, updated.(ChatModel)))
+	}
+}
+
+func TestOfferIsNotRepeatedInOneSession(t *testing.T) {
+	m := slackModel(t)
+	msg := slackStatusMsg{
+		status: gaiaslack.Status{SlackInstalled: true, ShouldOfferSetup: true},
+		offer:  true,
+	}
+	first, _ := m.handleSlackStatus(msg)
+	second, _ := first.(ChatModel).handleSlackStatus(msg)
+
+	count := 0
+	for _, message := range second.(ChatModel).messages {
+		if message.Role == RoleStatus && strings.Contains(message.Content, "/slack setup") {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("the offer appeared %d times, want 1", count)
+	}
+}
+
+func TestAFailedProbeAtLaunchStaysSilent(t *testing.T) {
+	// The user did not ask for this check; interrupting them with its failure
+	// would be noise. /slack still reports it on demand.
+	m := slackModel(t)
+	updated, _ := m.handleSlackStatus(slackStatusMsg{
+		err:   fmt.Errorf("%w: gaia is not on PATH", gaiaslack.ErrUnanswered),
+		offer: true,
+	})
+	if hasStatus(updated.(ChatModel)) {
+		t.Errorf("a background failure must not be shown, got:\n%s",
+			lastStatus(t, updated.(ChatModel)))
+	}
+}
+
+// ----------------------------------------------------------------------
+// /slack
+// ----------------------------------------------------------------------
+
+func TestSlackCommandReportsAFailureTheUserAskedFor(t *testing.T) {
+	m := slackModel(t)
+	updated, _ := m.handleSlackStatus(slackStatusMsg{
+		err:   fmt.Errorf("%w: gaia is not on PATH", gaiaslack.ErrUnanswered),
+		offer: false,
+	})
+	text := lastStatus(t, updated.(ChatModel))
+	if !strings.Contains(text, "not on PATH") {
+		t.Errorf("the real reason must be quoted, got:\n%s", text)
+	}
+	if !strings.Contains(text, "says nothing about whether Slack is set up") {
+		t.Errorf("an unanswered probe must not read as 'not connected', got:\n%s", text)
+	}
+}
+
+func TestStatusTextTellsAConnectedUserWhatToDoNext(t *testing.T) {
+	text := slackStatusText(gaiaslack.Status{Configured: true, TeamName: "Acme"})
+	if !strings.Contains(text, "gaia slack start") {
+		t.Errorf("a configured-but-stopped bridge must name the start command, got:\n%s", text)
+	}
+	if !strings.Contains(text, "--allowed-users") {
+		t.Errorf("the start command must carry the allowlist flag, got:\n%s", text)
+	}
+}
+
+func TestStatusTextTellsARunningUserToJustMessageIt(t *testing.T) {
+	text := slackStatusText(gaiaslack.Status{
+		Configured: true, Running: true, TeamName: "Acme",
+	})
+	if !strings.Contains(text, "direct message") {
+		t.Errorf("a running bridge must say how to use it, got:\n%s", text)
+	}
+}
+
+func TestStatusTextOffersSetupWhenNothingIsConfigured(t *testing.T) {
+	text := slackStatusText(gaiaslack.Status{SlackInstalled: true})
+	if !strings.Contains(text, gaiaslack.TypedCommand) {
+		t.Errorf("an unconfigured machine must name the setup command, got:\n%s", text)
+	}
+}
+
+// ----------------------------------------------------------------------
+// Recording the answer
+// ----------------------------------------------------------------------
+
+func TestSkipAndNeverReadDifferently(t *testing.T) {
+	m := slackModel(t)
+	skipped, _ := m.handleSlackDeclined(slackDeclinedMsg{never: false})
+	never, _ := m.handleSlackDeclined(slackDeclinedMsg{never: true})
+
+	skipText := lastStatus(t, skipped.(ChatModel))
+	neverText := lastStatus(t, never.(ChatModel))
+	if skipText == neverText {
+		t.Fatal("'not now' and 'stop asking' must not read identically")
+	}
+	if !strings.Contains(neverText, "again") {
+		t.Errorf("never must say it is permanent, got %q", neverText)
+	}
+	for _, text := range []string{skipText, neverText} {
+		if !strings.Contains(text, "/slack") {
+			t.Errorf("every decline must leave a way back, got %q", text)
+		}
+	}
+}
+
+func TestAFailedDeclineNamesTheManualCommand(t *testing.T) {
+	m := slackModel(t)
+	updated, _ := m.handleSlackDeclined(slackDeclinedMsg{
+		err: errors.New("keyring is locked"),
+	})
+	text := lastStatus(t, updated.(ChatModel))
+	if !strings.Contains(text, "keyring is locked") {
+		t.Errorf("the real reason must be quoted, got:\n%s", text)
+	}
+	if !strings.Contains(text, "gaia slack decline") {
+		t.Errorf("a failure must name what to run instead, got:\n%s", text)
+	}
+}
+
+// ----------------------------------------------------------------------
+// Setup hand-over
+// ----------------------------------------------------------------------
+
+func TestSetupSuccessReprobesRatherThanClaimingSuccess(t *testing.T) {
+	// The user can quit setup half-way. Saying "connected" when no token was
+	// stored is worse than saying nothing.
+	m := slackModel(t)
+	updated, cmd := m.handleSlackSetupDone(slackSetupDoneMsg{})
+	if cmd == nil {
+		t.Fatal("a finished setup must re-probe")
+	}
+	text := lastStatus(t, updated.(ChatModel))
+	if strings.Contains(strings.ToLower(text), "connected") {
+		t.Errorf("success must not be claimed before it is checked, got %q", text)
+	}
+}
+
+func TestAFailedSetupNamesTheRetryCommand(t *testing.T) {
+	m := slackModel(t)
+	updated, _ := m.handleSlackSetupDone(slackSetupDoneMsg{
+		err: errors.New("exit status 2"),
+	})
+	text := lastStatus(t, updated.(ChatModel))
+	if !strings.Contains(text, gaiaslack.TypedCommand) {
+		t.Errorf("a failure must name the retry command, got:\n%s", text)
+	}
+}
+
+// ----------------------------------------------------------------------
+// Command routing
+// ----------------------------------------------------------------------
+
+func TestEverySlackCommandIsHandledRatherThanSentToTheAgent(t *testing.T) {
+	// A slash command that falls through reaches the LLM as a question, and the
+	// model cheerfully answers it as prose — the failure /setup exists to avoid.
+	for _, command := range []string{"/slack", "/slack setup", "/slack skip", "/slack never"} {
+		m := slackModel(t)
+		updated, _ := m.submit(command)
+		after := updated.(ChatModel)
+		for _, message := range after.messages {
+			if message.Role == RoleUser {
+				t.Errorf("%q reached the agent as a question", command)
+			}
+		}
+	}
+}
+
+func TestSlackIsOfferedInTheCommandPalette(t *testing.T) {
+	for _, entry := range paletteCommands {
+		if entry.Name == "/slack" {
+			if entry.Desc == "" {
+				t.Error("/slack needs a description in the palette")
+			}
+			return
+		}
+	}
+	t.Error("/slack is missing from the command palette")
+}

--- a/tui/internal/ui/components/helpoverlay.go
+++ b/tui/internal/ui/components/helpoverlay.go
@@ -199,6 +199,7 @@ const chatHelpText = `  GAIA Chat
 
   Commands    /help /clear /bypass
               /setup /memory /model
+              /slack
   /           On an empty line, browse commands —
               hover/click or ↑/↓ to pick, Enter or
               click to run, Esc or click out to close

--- a/tui/internal/ui/components/helpoverlay_test.go
+++ b/tui/internal/ui/components/helpoverlay_test.go
@@ -183,11 +183,18 @@ func TestChatHelpNamesEveryChatBinding(t *testing.T) {
 		"/memory": "/memory",
 		"/setup":  "/setup",
 		"/bypass": "/bypass",
+		"/slack":  "/slack",
 	}
 	for _, cmd := range chatModelCommands(t) {
 		key := cmd
 		if strings.HasPrefix(cmd, "/bypass") {
 			key = "/bypass"
+		}
+		if strings.HasPrefix(cmd, "/slack") {
+			// /slack setup|skip|never are the three answers to the setup
+			// offer, which names them itself -- the help panel documents the
+			// one command, same as /bypass.
+			key = "/slack"
 		}
 		want, ok := commandText[key]
 		if !ok {


### PR DESCRIPTION
You can message the flagship GAIA agent from a Slack DM and it answers from your desktop — reading your files, streaming its reply, and sending back files it writes. The TUI offers to connect Slack the first time it sees the app installed, and the whole setup is one click plus two pasted tokens. Shell commands, file writes and code execution still pause for approval, now as Allow/Deny buttons in Slack.

The security argument rests on the agent's existing confirmation gate, and no Slack message or button can disarm it. The bridge refuses to start without an allowlist, answers direct messages only, is pinned to one workspace, and serves exactly one member — it drives one agent with one conversation, so a second member would share the first's history and approvals. Reads stay ungated; the guide says so plainly.

Also fixes `gaia telegram` on installed wheels, which failed to import because `gaia.messaging` was never packaged.

## Test plan

- [ ] `python -m pytest tests/unit/messaging -q` — includes `test_slack_event_contract.py`, which drives the adapter with events from the real handler and translator rather than hand-written ones
- [ ] `cd tui && go test ./...`
- [ ] `python util/lint.py --all`
- [ ] `gaia slack status` on a machine with Slack installed reports it and offers setup
- [ ] `gaia slack start --allowed-users U0A,U0B` refuses, explaining the shared conversation
- [ ] **Needs a real workspace:** `gaia slack setup`, DM the bot, watch the reply stream, approve a gated command, ask for a file back, and leave one prompt unanswered for ten minutes to see it denied