### PR TITLE
fix(tools): keep a finished edit reported as finished when the diff won't render

### DIFF
--- a/src/gaia/agents/base/console.py
+++ b/src/gaia/agents/base/console.py
@@ -391,6 +391,18 @@ class OutputHandler(ABC):
         """Display performance statistics. Optional - default no-op."""
         ...
 
+    def print_diff(  # pylint: disable=unused-argument
+        self, diff: str, filename: str
+    ) -> None:
+        """Show a unified diff for a file the agent changed. Optional no-op.
+
+        Declared here so no handler can be missing it: the write tools call it
+        AFTER the bytes are on disk, and an AttributeError there reported a
+        completed edit as a failure (#3676). The diff also rides in the tool
+        result, so a handler that renders nothing loses no information.
+        """
+        ...
+
     def print_header(self, text: str):  # pylint: disable=unused-argument
         """Print header. Optional - default no-op."""
         ...

--- a/src/gaia/agents/tools/file_io_tools.py
+++ b/src/gaia/agents/tools/file_io_tools.py
@@ -37,7 +37,7 @@ def _show_after_write(console: Any, show: Callable[[Any], None]) -> Optional[str
     try:
         show(console)
         return None
-    except Exception as e:  # noqa: BLE001 - the write already succeeded
+    except Exception as e:
         logger.warning("Could not display the change (the write succeeded): %s", e)
         return f"the file was written; displaying the change failed: {e}"
 

--- a/src/gaia/agents/tools/file_io_tools.py
+++ b/src/gaia/agents/tools/file_io_tools.py
@@ -11,7 +11,7 @@ inherited by agents that need file manipulation capabilities.
 import ast
 import difflib
 import os
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 from gaia.agents.base.tools import tool
 from gaia.agents.tools.file_edit import (
@@ -19,6 +19,27 @@ from gaia.agents.tools.file_edit import (
     record_read,
     record_write,
 )
+from gaia.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def _show_after_write(console: Any, show: Callable[[Any], None]) -> Optional[str]:
+    """Run a post-write display step and report, never raise (#3676).
+
+    The bytes are on disk before any of these run, so a failure here is a
+    display failure, not a failed edit. Letting it reach the tool's ``except``
+    turned a completed write into ``{"status": "error"}``, and the model then
+    told the user the file was untouched.
+    """
+    if console is None:
+        return None
+    try:
+        show(console)
+        return None
+    except Exception as e:  # noqa: BLE001 - the write already succeeded
+        logger.warning("Could not display the change (the write succeeded): %s", e)
+        return f"the file was written; displaying the change failed: {e}"
 
 
 class FunctionLookupError(Exception):
@@ -854,16 +875,20 @@ class FileIOToolsMixin:
                 record_write(str(path), content)
 
                 console = getattr(self, "console", None)
-                if console:
-                    if content.strip():
-                        console.print_prompt(
-                            content,
-                            title=f"✏️ write_file → {path}",
-                        )
-                    else:
-                        console.print_info(
+                if content.strip():
+                    display_error = _show_after_write(
+                        console,
+                        lambda c: c.print_prompt(
+                            content, title=f"✏️ write_file → {path}"
+                        ),
+                    )
+                else:
+                    display_error = _show_after_write(
+                        console,
+                        lambda c: c.print_info(
                             f"write_file: {path} was created but no content was written."
-                        )
+                        ),
+                    )
 
                 # Audit successful write
                 if path_validator is not None:
@@ -882,6 +907,8 @@ class FileIOToolsMixin:
                 }
                 if path_validator is not None and backup_path:
                     result["backup_path"] = backup_path
+                if display_error:
+                    result["display_error"] = display_error
                 return result
             except Exception as e:
                 path_validator = getattr(self, "path_validator", None)
@@ -1001,11 +1028,18 @@ class FileIOToolsMixin:
                 record_write(str(path), updated_content)
 
                 console = getattr(self, "console", None)
-                if console:
-                    if diff.strip():
-                        console.print_diff(diff, os.path.basename(str(path)))
-                    else:
-                        console.print_info(f"edit_file: No changes were made to {path}")
+                if diff.strip():
+                    display_error = _show_after_write(
+                        console,
+                        lambda c: c.print_diff(diff, os.path.basename(str(path))),
+                    )
+                else:
+                    display_error = _show_after_write(
+                        console,
+                        lambda c: c.print_info(
+                            f"edit_file: No changes were made to {path}"
+                        ),
+                    )
 
                 # Audit successful edit
                 if path_validator is not None:
@@ -1030,6 +1064,8 @@ class FileIOToolsMixin:
                 }
                 if backup_path:
                     result["backup_path"] = backup_path
+                if display_error:
+                    result["display_error"] = display_error
                 return result
             except Exception as e:
                 path_validator = getattr(self, "path_validator", None)

--- a/tests/unit/agents/test_write_display_contract.py
+++ b/tests/unit/agents/test_write_display_contract.py
@@ -1,0 +1,223 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""A completed write must be reported as completed, whatever the display does.
+
+``edit_file`` and ``write_file`` put the bytes on disk and *then* ask the
+console to show what changed. When that display step raised — the Agent-UI /
+TUI handler had no ``print_diff`` at all — the exception fell into the tool's
+catch-all and the call returned ``{"status": "error"}`` for a file that had
+already been changed. The agent then told the user the file was untouched
+(#3676).
+
+Every test here runs the real tool against a real file on disk and asserts the
+two things that must agree: what the file contains, and what the tool said.
+
+No LLM or external service required.
+"""
+
+import importlib
+
+import pytest
+
+from gaia.agents.base.console import OutputHandler
+from gaia.agents.base.tools import _TOOL_REGISTRY
+from gaia.agents.tools.file_edit import FileStateTracker
+
+
+@pytest.fixture(autouse=True)
+def clean_tracker():
+    """The tracker is process-wide; no test may inherit another's ledger."""
+    FileStateTracker.instance().clear()
+    yield
+    FileStateTracker.instance().clear()
+
+
+@pytest.fixture
+def file_tools():
+    """``(tool_name) -> callable`` for the file-I/O mixin, console attachable."""
+    module = importlib.import_module("gaia.agents.tools.file_io_tools")
+    mixin = module.FileIOToolsMixin()
+
+    saved = dict(_TOOL_REGISTRY)
+    try:
+        mixin.register_file_io_tools()
+
+        def get(name):
+            entry = _TOOL_REGISTRY.get(name)
+            assert entry is not None, f"{name} was not registered"
+            return entry["function"]
+
+        get.mixin = mixin
+        yield get
+    finally:
+        _TOOL_REGISTRY.clear()
+        _TOOL_REGISTRY.update(saved)
+
+
+def _ui_handler():
+    """The Agent-UI / TUI handler — the one #3676 was reported against."""
+    from gaia.ui.sse_handler import SSEOutputHandler
+
+    return SSEOutputHandler()
+
+
+def _api_handler():
+    from gaia.api.sse_handler import SSEOutputHandler
+
+    return SSEOutputHandler()
+
+
+class RaisingConsole(OutputHandler):
+    """A handler whose rendering is broken in every direction."""
+
+    def print_processing_start(self, query, max_steps, model_id=None): ...
+
+    def print_step_header(self, step_num, step_limit): ...
+
+    def print_state_info(self, state_message): ...
+
+    def print_thought(self, thought): ...
+
+    def print_goal(self, goal): ...
+
+    def print_plan(self, plan, current_step=None): ...
+
+    def print_tool_usage(self, tool_name): ...
+
+    def print_tool_complete(self): ...
+
+    def pretty_print_json(self, data, title=None): ...
+
+    def print_error(self, error_message, recoverable=False): ...
+
+    def print_warning(self, warning_message): ...
+
+    def start_progress(self, message): ...
+
+    def stop_progress(self): ...
+
+    def print_final_answer(self, answer, total_tokens=None, ttft_seconds=None): ...
+
+    def print_repeated_tool_warning(self): ...
+
+    def print_completion(self, steps_taken, steps_limit): ...
+
+    def print_step_paused(self, description): ...
+
+    def print_command_executing(self, command): ...
+
+    def print_agent_selected(self, agent_name, language, project_type): ...
+
+    def print_info(self, message):
+        raise RuntimeError("display is broken")
+
+    def print_diff(self, diff, filename):
+        raise RuntimeError("display is broken")
+
+    def print_prompt(self, prompt, title="Prompt"):
+        raise RuntimeError("display is broken")
+
+
+CONSOLES = [
+    ("ui_sse", _ui_handler),
+    ("api_sse", _api_handler),
+    ("raising", RaisingConsole),
+]
+CONSOLE_IDS = [name for name, _ in CONSOLES]
+
+
+@pytest.fixture(params=[factory for _, factory in CONSOLES], ids=CONSOLE_IDS)
+def console(request):
+    return request.param()
+
+
+# ============================================================================
+# 1. THE CONTRACT ITSELF
+# ============================================================================
+
+
+class TestHandlerContract:
+    """No handler the write tools can be given may be missing a display hook."""
+
+    @pytest.mark.parametrize("factory", [f for _, f in CONSOLES], ids=CONSOLE_IDS)
+    @pytest.mark.parametrize("method", ["print_diff", "print_info", "print_prompt"])
+    def test_handler_has_the_method_the_write_tools_call(self, factory, method):
+        assert callable(getattr(factory(), method, None))
+
+    def test_base_handler_declares_print_diff(self):
+        """Declared on the ABC so a future handler inherits it for free."""
+        assert callable(getattr(OutputHandler, "print_diff", None))
+
+
+# ============================================================================
+# 2. edit_file — DISK AND RESULT MUST AGREE
+# ============================================================================
+
+
+class TestEditFileReportsTheWrite:
+    def test_edit_succeeds_with_a_real_handler_attached(
+        self, file_tools, console, tmp_path
+    ):
+        path = tmp_path / "note.txt"
+        path.write_text("alpha\n", encoding="utf-8")
+        file_tools.mixin.console = console
+
+        result = file_tools("edit_file")(str(path), "alpha", "beta")
+
+        assert path.read_text(encoding="utf-8") == "beta\n"
+        assert result["status"] == "success", result
+
+    def test_a_broken_display_is_reported_without_denying_the_write(
+        self, file_tools, tmp_path
+    ):
+        path = tmp_path / "note.txt"
+        path.write_text("alpha\n", encoding="utf-8")
+        file_tools.mixin.console = RaisingConsole()
+
+        result = file_tools("edit_file")(str(path), "alpha", "beta")
+
+        assert path.read_text(encoding="utf-8") == "beta\n"
+        assert result["status"] == "success"
+        # The failure is surfaced, not swallowed — and says the write happened.
+        assert "display is broken" in result["display_error"]
+        assert "written" in result["display_error"]
+
+    def test_a_clean_edit_carries_no_display_error(self, file_tools, tmp_path):
+        path = tmp_path / "note.txt"
+        path.write_text("alpha\n", encoding="utf-8")
+        file_tools.mixin.console = _ui_handler()
+
+        result = file_tools("edit_file")(str(path), "alpha", "beta")
+
+        assert "display_error" not in result
+
+
+# ============================================================================
+# 3. write_file — SAME RULE
+# ============================================================================
+
+
+class TestWriteFileReportsTheWrite:
+    def test_write_succeeds_with_a_real_handler_attached(
+        self, file_tools, console, tmp_path
+    ):
+        path = tmp_path / "new.txt"
+        file_tools.mixin.console = console
+
+        result = file_tools("write_file")(str(path), "hello\n")
+
+        assert path.read_text(encoding="utf-8") == "hello\n"
+        assert result["status"] == "success", result
+
+    def test_a_broken_display_is_reported_without_denying_the_write(
+        self, file_tools, tmp_path
+    ):
+        path = tmp_path / "new.txt"
+        file_tools.mixin.console = RaisingConsole()
+
+        result = file_tools("write_file")(str(path), "hello\n")
+
+        assert path.read_text(encoding="utf-8") == "hello\n"
+        assert result["status"] == "success"
+        assert "display is broken" in result["display_error"]


### PR DESCRIPTION
Approve an `edit_file` in the TUI and the change lands on disk — then the tool reports failure and the agent tells you the file is untouched. Reproduced twice in #3676 against a live Fireworks session; the agent's memory had even learned it as a fact ("the tool crashed internally before modifying any file"), which is false and steers it away from editing at all. Now an approved edit reports what actually happened, and a display that cannot draw a diff no longer un-does a write.

Fixes #3676

## Test plan

- [x] `pytest tests/unit/agents/test_write_display_contract.py` — new; runs `edit_file` and `write_file` against a real file with the real Agent-UI, API-server, and a deliberately broken handler attached, asserting the on-disk bytes and the returned status agree. 7 of its cases fail on `main`.
- [x] `pytest tests/unit/agents tests/unit/test_file_write_guardrails.py` (192 passed)
- [x] `python util/lint.py --pylint` — clean (the first push failed CI here; the no-op's `unused-argument` disable was on the wrong line).
- [x] Live TUI on Fireworks-via-Lemonade, transcript below.

<details>
<summary>🔍 Live TUI evidence (asked for in review)</summary>

Probe file created containing `alpha`, one `edit_file` requested, approved with `y` in the TUI:

```
▶ You: Call edit_file exactly once on .../.gaia/drive-checks/edit-probe.txt
replacing alpha with beta. Then tell me exactly what the tool returned.

  [!] confirmation for 'edit_file' resolved: approved — running it

  • old_size: 6 bytes → new_size: 5 bytes
  • diff:  alpha  replaced with  beta
  • backup_path:  .../edit-probe.20260911_181843.bak.txt

  ...this path is inside the allowed-paths list and the edit went through
  cleanly — one call, no retry.

  46.4s · ttft 45.8s · 3 steps · 2 tools
```

The tool result in the agent log:

```
{"status": "success", "file_path": ".../edit-probe.txt", "old_size": 6, "new_size": 5, ...}
```

And on disk:

```
$ cat .gaia/drive-checks/edit-probe.txt
beta
```

On `main` the same run returns `'SSEOutputHandler' object has no attribute 'print_diff'` and the agent reports the file unchanged.
</details>

<details>
<summary>🔍 Technical details</summary>

`gaia.ui.sse_handler.SSEOutputHandler` — the handler behind the TUI and Agent UI — had no `print_diff`, and `file_io_tools.edit_file` calls `console.print_diff` *after* `path.write_text`. The `AttributeError` fell into the tool's catch-all and became `{"status": "error"}`.

- `print_diff` is declared on the `OutputHandler` ABC as an optional no-op, next to `print_prompt` / `print_response`, so no present or future handler can be missing it. The diff still rides in the tool result, so a handler that draws nothing loses no information.
- `_show_after_write` wraps every post-write display call: a failure is logged with context and surfaced as `display_error` on the successful result, rather than discarding a completed mutation.
- `write_file` had the same shape (`print_prompt` after the write) and gets the same treatment.

### Review follow-ups

- **The diff now renders as nothing** — filed as #3710. The webui already registers a `DiffCard` under the `diff` key; nothing feeds it. That issue carries the pointer so the no-op does not become permanent.
- **`getattr(self, "console", None)` hoisted** once per tool instead of once per branch, as suggested.
</details>