### PR TITLE
fix(agent): emit exactly one verification statement per answer

### DIFF
--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -44,6 +44,7 @@ from gaia.agents.base.verification import (
     NOT_EXECUTED,
     build_verification_scope,
     check_was_executed,
+    strip_verification_scope,
     verification_check_label,
 )
 
@@ -4847,14 +4848,25 @@ Do NOT wrap conversational replies in JSON.
         )
 
     def _with_verification_scope(self, answer: Optional[str]) -> Optional[str]:
-        """Append the scope statement to a non-empty answer (#3376).
+        """Give a non-empty answer exactly one scope statement (#3376, #3675).
+
+        Any statement the model wrote itself comes out first. The line rides in
+        the answer and the answer comes back as conversation history, so a model
+        can and does echo a previous turn's — and the user then read the same
+        verification paragraph twice, once from the model and once from here.
+        Only the one derived from this turn's tool log is authoritative.
 
         Empty stays empty — a blank answer is a signal downstream (cancelled
         turns skip persistence), and a scope line would make it non-blank.
         """
         if not answer or not answer.strip():
             return answer
-        return f"{answer.rstrip()}\n\n{self.verification_scope_statement()}"
+        body = strip_verification_scope(answer)
+        statement = self.verification_scope_statement()
+        if not body.strip():
+            # The whole "answer" was an echoed scope line; one is still one.
+            return statement
+        return f"{body.rstrip()}\n\n{statement}"
 
     def process_query(
         self,

--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -41,7 +41,9 @@ from gaia.agents.base.console import AgentConsole, SilentConsole
 from gaia.agents.base.errors import format_execution_trace
 from gaia.agents.base.tools import _TOOL_REGISTRY
 from gaia.agents.base.verification import (
+    NOT_EXECUTED,
     build_verification_scope,
+    check_was_executed,
     verification_check_label,
 )
 
@@ -3697,6 +3699,12 @@ Do NOT wrap conversational replies in JSON.
         """
         Execute a tool by name with the provided arguments.
 
+        Every exit that returns BEFORE the tool body runs carries
+        ``NOT_EXECUTED``. ``_execute_tool_timed`` records each return for the
+        verification footer, which otherwise reads a call rejected at dispatch
+        — unknown name, missing/unexpected/uncoercible argument, guardrail
+        refusal — as a check that ran and failed (#3677).
+
         Args:
             tool_name: Name of the tool to execute
             tool_args: Arguments to pass to the tool
@@ -3761,13 +3769,13 @@ Do NOT wrap conversational replies in JSON.
                     # here would point them at something that isn't there.
                     err = "Unknown tool name. Use only the tools you were given."
                 logger.error(err)
-                return {"status": "error", "error": err}
+                return {**NOT_EXECUTED, "status": "error", "error": err}
 
         # Validate first, confirm second: a call the guardrails already refuse
         # must never reach a prompt.
         refusal = self._policy_refusal(tool_name, tool_args)
         if refusal is not None:
-            return refusal
+            return {**refusal, **NOT_EXECUTED} if isinstance(refusal, dict) else refusal
 
         # Guardrail: require explicit user confirmation for high-risk tools.
         # Consoles that cannot reach a human deny rather than answer for them
@@ -3823,6 +3831,7 @@ Do NOT wrap conversational replies in JSON.
             # Tagged so callers can tell a malformed call (retryable — the model
             # can re-emit it) from a tool that ran and failed (#3581).
             return {
+                **NOT_EXECUTED,
                 "status": "error",
                 "error_type": "invalid_arguments",
                 "error": error_msg,
@@ -3857,6 +3866,7 @@ Do NOT wrap conversational replies in JSON.
                 )
                 logger.error(error_msg)
                 return {
+                    **NOT_EXECUTED,
                     "status": "error",
                     "error_type": "invalid_arguments",
                     "error": error_msg,
@@ -3869,6 +3879,7 @@ Do NOT wrap conversational replies in JSON.
         if coercion_error is not None:
             logger.error(coercion_error)
             return {
+                **NOT_EXECUTED,
                 "status": "error",
                 "error_type": "invalid_arguments",
                 "error": coercion_error,
@@ -4809,10 +4820,13 @@ Do NOT wrap conversational replies in JSON.
     def _note_verification_signal(
         self, tool_name: str, tool_args: Dict[str, Any], result: Any
     ) -> None:
-        """Record one executed tool call for this turn's verification scope.
+        """Record one dispatched tool call for this turn's verification scope.
 
         Called from the single execution seam so every loop path — legacy,
-        native tool-calling, and the forced-call branch — is covered.
+        native tool-calling, and the forced-call branch — is covered. That seam
+        also returns for calls that never ran (allowlist refusal, declined
+        confirmation), so ``ran`` says which this was: without it a refused
+        ``pytest`` was reported as a test that ran and failed (#3677).
         """
         log = getattr(self, "_turn_tool_executions", None)
         if log is None:
@@ -4822,6 +4836,7 @@ Do NOT wrap conversational replies in JSON.
                 "tool": tool_name,
                 "check_label": verification_check_label(tool_name, tool_args),
                 "failed": self._is_error_result(result),
+                "ran": check_was_executed(result),
             }
         )
 

--- a/src/gaia/agents/base/verification.py
+++ b/src/gaia/agents/base/verification.py
@@ -72,9 +72,30 @@ NOT_EXECUTED: Dict[str, Any] = {EXECUTED_KEY: False}
 #: there to declare it. The loop's own denial shape says it for them.
 _DENIED_STATUS = "denied"
 
-_SCOPE_LINE_RE = re.compile(
-    r"\n{1,2}" + re.escape(VERIFICATION_SCOPE_PREFIX) + r"[^\n]*\s*\Z"
+#: Leading blockquote markers, headings, list bullets and emphasis runs, so a
+#: model's ``> **Verification:** …`` or ``## Verification: …`` is recognised as
+#: the same line.
+_SCOPE_MARKUP_RE = re.compile(
+    r"^[ \t]*(?:>[ \t]*)*(?:\#{1,6}[ \t]+)?(?:(?:[-*+]|\d{1,3}[.)])[ \t]+)?[*_~`]*[ \t]*"
 )
+
+#: An opening or closing code fence — three or more backticks or tildes,
+#: indented or not. Lines between a matching pair are never touched.
+_FENCE_RE = re.compile(r"^[ \t]*(`{3,}|~{3,})")
+
+#: A line is a scope statement only when it carries the WHOLE generated shape:
+#: the prefix, then one of the three states, then the em dash that introduces
+#: the body. Matching the bare prefix deleted a user's own "Verification: run
+#: pytest before tagging" out of a checklist the model wrote.
+_SCOPE_BODY_RE = re.compile(
+    re.escape(VERIFICATION_SCOPE_PREFIX.strip())
+    + r"\s*[*_~`]*\s*(?:un|partially )?verified\s*[—–-]"
+)
+
+
+def _is_scope_line(line: str) -> bool:
+    """True when *line* is a generated verification statement, Markdown and all."""
+    return bool(_SCOPE_BODY_RE.match(_SCOPE_MARKUP_RE.sub("", line)))
 
 
 def verification_check_label(tool_name: str, tool_args: Any) -> Optional[str]:
@@ -199,8 +220,54 @@ def build_verification_scope(executions: List[Dict[str, Any]]) -> str:
     return statement
 
 
+def split_verification_scope(text: str) -> Tuple[str, str]:
+    """Split *text* into ``(body, scope_line)``, removing EVERY scope line.
+
+    The line rides in the answer, and the answer is re-sent as conversation
+    history — so a model that reads it can write one of its own, anywhere in
+    its reply, in whatever Markdown it likes. Taking only a trailing one left
+    the echo in place and the appended line beside it, and the user saw the
+    same verification paragraph twice (#3675).
+
+    ``scope_line`` is the LAST one found, stripped of its markup, or ``""``.
+
+    Only the statement lines go, plus the blank line each one was separated by.
+    Everything else is left byte-for-byte: this runs on every Agent-UI answer,
+    and an earlier version that normalised blank runs silently reflowed the
+    inside of every fenced code block it passed through.
+
+    Code blocks are skipped entirely. An answer that *quotes* a footer — a
+    transcript, an explanation of the feature, this repo's own source — has to
+    come back with the quote intact, or the deletion lands in the middle of a
+    fence and leaves an empty pair of backticks.
+    """
+    if not isinstance(text, str) or VERIFICATION_SCOPE_PREFIX.strip() not in text:
+        return (text if isinstance(text, str) else "", "")
+    kept: List[str] = []
+    found = ""
+    fence = ""
+    for line in text.splitlines():
+        marker = _FENCE_RE.match(line)
+        if marker:
+            token = marker.group(1)[:3]
+            if not fence:
+                fence = token
+            elif token == fence:
+                fence = ""
+            kept.append(line)
+            continue
+        if not fence and _is_scope_line(line):
+            bare = _SCOPE_MARKUP_RE.sub("", line).strip()
+            body = bare[len(VERIFICATION_SCOPE_PREFIX.strip()) :].strip(" *_~`")
+            found = VERIFICATION_SCOPE_PREFIX + body if body else ""
+            # The blank line that set this statement apart goes with it.
+            if kept and not kept[-1].strip():
+                kept.pop()
+            continue
+        kept.append(line)
+    return "\n".join(kept).rstrip(), found
+
+
 def strip_verification_scope(text: str) -> str:
-    """Remove a trailing verification-scope line added by the agent loop."""
-    if not isinstance(text, str) or VERIFICATION_SCOPE_PREFIX not in text:
-        return text
-    return _SCOPE_LINE_RE.sub("", text)
+    """Remove every verification-scope line, wherever it sits in *text*."""
+    return split_verification_scope(text)[0]

--- a/src/gaia/agents/base/verification.py
+++ b/src/gaia/agents/base/verification.py
@@ -61,6 +61,17 @@ _CHECK_COMMAND_RE = re.compile(
 # Argument keys that carry a shell command, in priority order.
 _COMMAND_KEYS: Tuple[str, ...] = ("command", "cmd", "script")
 
+#: Result key a tool sets to ``False`` to declare it refused the call before
+#: running it. Set at the refusal itself — see ``NOT_EXECUTED`` below.
+EXECUTED_KEY = "executed"
+
+#: Spread into a tool's pre-execution refusal: ``{**NOT_EXECUTED, "status": …}``.
+NOT_EXECUTED: Dict[str, Any] = {EXECUTED_KEY: False}
+
+#: A declined confirmation never reaches the tool body, so there is nothing
+#: there to declare it. The loop's own denial shape says it for them.
+_DENIED_STATUS = "denied"
+
 _SCOPE_LINE_RE = re.compile(
     r"\n{1,2}" + re.escape(VERIFICATION_SCOPE_PREFIX) + r"[^\n]*\s*\Z"
 )
@@ -84,6 +95,28 @@ def verification_check_label(tool_name: str, tool_args: Any) -> Optional[str]:
     return None
 
 
+def check_was_executed(result: Any) -> bool:
+    """False only when *result* says the call was stopped before it ran (#3677).
+
+    A command the allowlist refused and a command that ran and failed are both
+    ``{"status": "error"}``, so the footer called a rejected ``pytest`` a test
+    that "ran and did not pass" — and a *declined* one, which is
+    ``{"status": "denied"}``, a test that passed.
+
+    The refusal has to say so: a tool that stops a call before running it
+    spreads :data:`NOT_EXECUTED` into what it returns. Guessing from the shape
+    of the result instead gets it wrong in the more damaging direction — a real
+    failing test whose tool returned a bare error dict would be reported as
+    never having run, which is the same false claim with the sign flipped.
+    """
+    if not isinstance(result, dict):
+        return True
+    declared = result.get(EXECUTED_KEY)
+    if declared is not None:
+        return bool(declared)
+    return str(result.get("status", "")).lower() != _DENIED_STATUS
+
+
 def _names(executions: List[Dict[str, Any]], limit: int = 3) -> str:
     """Deduped, order-preserving, count-capped label list."""
     labels: List[str] = []
@@ -105,16 +138,39 @@ def build_verification_scope(executions: List[Dict[str, Any]]) -> str:
     passed), ``partially verified`` (checks ran, not all passed), and
     ``unverified`` (no check ran at all).
 
+    A check the agent *requested* and never got to run — refused by the shell
+    allowlist, declined by the user — is none of those three. It is named as
+    not having run, and never counted as one that did (#3677).
+
     Each execution is ``{"tool": str, "check_label": str | None,
-    "failed": bool}`` — see ``Agent._note_verification_signal``.
+    "failed": bool, "ran": bool}`` — see ``Agent._note_verification_signal``.
+    ``ran`` defaults to True for a record written before the field existed.
     """
     executions = list(executions or [])
-    checks = [e for e in executions if e.get("check_label")]
+    ran = [e for e in executions if e.get("ran", True)]
+    checks = [e for e in ran if e.get("check_label")]
+    # A refusal the agent recovered from is not an unrun check. Retrying a
+    # refused command in an allowed form is the ordinary path, and listing the
+    # first attempt alongside the one that succeeded read as
+    # "pytest ran and passed. pytest did not run."
+    reached = {e.get("check_label") for e in checks}
+    blocked = [
+        e
+        for e in executions
+        if e.get("check_label")
+        and not e.get("ran", True)
+        and e["check_label"] not in reached
+    ]
     if not checks:
-        total = len(executions)
-        if total == 0:
+        if blocked:
+            body = (
+                f"unverified — {_names(blocked)} did not run (refused before "
+                "execution), so nothing was checked."
+            )
+        elif not ran:
             body = "unverified — no tools ran, so nothing was checked."
         else:
+            total = len(ran)
             plural = "" if total == 1 else "s"
             body = (
                 f"unverified — {total} tool call{plural} ran, none of them a "
@@ -123,17 +179,19 @@ def build_verification_scope(executions: List[Dict[str, Any]]) -> str:
     else:
         passed = [e for e in checks if not e.get("failed")]
         failed = [e for e in checks if e.get("failed")]
+        # A check left unrun keeps the claim below "verified", whatever the
+        # ones that did run reported.
+        unrun = f" {_names(blocked)} did not run." if blocked else ""
         if not failed:
-            body = f"verified — {_names(passed)} ran and passed."
+            state = "partially verified" if blocked else "verified"
+            body = f"{state} — {_names(passed)} ran and passed.{unrun}"
         elif not passed:
-            body = (
-                f"partially verified — {_names(failed)} ran and did not pass; "
-                "nothing else was checked."
-            )
+            tail = unrun or " Nothing else was checked."
+            body = f"partially verified — {_names(failed)} ran and did not pass.{tail}"
         else:
             body = (
                 f"partially verified — {_names(passed)} passed, "
-                f"{_names(failed)} did not."
+                f"{_names(failed)} did not.{unrun}"
             )
     statement = VERIFICATION_SCOPE_PREFIX + body
     if len(statement) > VERIFICATION_SCOPE_MAX_CHARS:

--- a/src/gaia/agents/base/verification.py
+++ b/src/gaia/agents/base/verification.py
@@ -240,13 +240,20 @@ def split_verification_scope(text: str) -> Tuple[str, str]:
     transcript, an explanation of the feature, this repo's own source — has to
     come back with the quote intact, or the deletion lands in the middle of a
     fence and leaves an empty pair of backticks.
+
+    A statement sharing a line with prose is left alone on purpose: the models
+    emit it on its own line, and matching mid-line risks eating real prose.
     """
     if not isinstance(text, str) or VERIFICATION_SCOPE_PREFIX.strip() not in text:
         return (text if isinstance(text, str) else "", "")
     kept: List[str] = []
     found = ""
     fence = ""
-    for line in text.splitlines():
+    removed = False
+    # split("\n"), not splitlines(): the email agent compares a stripped answer
+    # against the original for identity, and splitlines() also breaks on \x0b,
+    # \x0c and U+2028 and would rewrite CRLF as LF.
+    for line in text.split("\n"):
         marker = _FENCE_RE.match(line)
         if marker:
             token = marker.group(1)[:3]
@@ -263,8 +270,11 @@ def split_verification_scope(text: str) -> Tuple[str, str]:
             # The blank line that set this statement apart goes with it.
             if kept and not kept[-1].strip():
                 kept.pop()
+            removed = True
             continue
         kept.append(line)
+    if not removed:
+        return text, found
     return "\n".join(kept).rstrip(), found
 
 

--- a/src/gaia/agents/tools/shell_tools.py
+++ b/src/gaia/agents/tools/shell_tools.py
@@ -16,6 +16,8 @@ from collections import deque
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from gaia.agents.base.verification import NOT_EXECUTED
+
 logger = logging.getLogger(__name__)
 
 # Security: WHITELIST approach - only allow explicitly safe commands
@@ -315,6 +317,18 @@ class ShellToolsMixin:
         self.max_commands_per_10_seconds = 3
 
     def _validate_shell_command(self, command: str) -> tuple:
+        """Every refusal ``command`` earns on its text alone, plus its segments.
+
+        Each refusal is stamped ``executed: False`` — nothing here has launched
+        anything, and downstream cannot tell a refused command from a failed one
+        by the shape of the error alone (#3677).
+        """
+        error, segments = self._shell_command_refusal(command)
+        if error is not None:
+            error = {**error, **NOT_EXECUTED}
+        return error, segments
+
+    def _shell_command_refusal(self, command: str) -> tuple:
         """Every refusal ``command`` earns on its text alone, plus its segments.
 
         Pure and side-effect free, so it can run twice: once as a pre-flight
@@ -818,6 +832,7 @@ class ShellToolsMixin:
                 allowed, reason, wait_time = self._check_rate_limit()
                 if not allowed:
                     return {
+                        **NOT_EXECUTED,
                         "status": "error",
                         "error": f"{reason}. Please wait {wait_time:.1f} seconds.",
                         "has_errors": True,
@@ -830,6 +845,7 @@ class ShellToolsMixin:
                 if working_directory:
                     if not os.path.exists(working_directory):
                         return {
+                            **NOT_EXECUTED,
                             "status": "error",
                             "error": f"Working directory not found: {working_directory}",
                             "has_errors": True,
@@ -837,6 +853,7 @@ class ShellToolsMixin:
 
                     if not os.path.isdir(working_directory):
                         return {
+                            **NOT_EXECUTED,
                             "status": "error",
                             "error": f"Path is not a directory: {working_directory}",
                             "has_errors": True,
@@ -846,6 +863,7 @@ class ShellToolsMixin:
                     if hasattr(self, "path_validator"):
                         if not self.path_validator.is_path_allowed(working_directory):
                             return {
+                                **NOT_EXECUTED,
                                 "status": "error",
                                 "error": f"Access denied: {working_directory} is not in allowed paths",
                                 "has_errors": True,
@@ -853,6 +871,7 @@ class ShellToolsMixin:
                     elif hasattr(self, "_is_path_allowed"):
                         if not self._is_path_allowed(working_directory):
                             return {
+                                **NOT_EXECUTED,
                                 "status": "error",
                                 "error": f"Access denied: {working_directory} is not in allowed paths",
                                 "has_errors": True,
@@ -920,6 +939,7 @@ class ShellToolsMixin:
                                     resolved_path
                                 ):
                                     return {
+                                        **NOT_EXECUTED,
                                         "status": "error",
                                         "error": f"Access denied: Argument '{arg}' resolves to forbidden path '{resolved_path}'",
                                         "has_errors": True,
@@ -1126,6 +1146,16 @@ class ShellToolsMixin:
                     "output_truncated": truncated,
                 }
 
+            except FileNotFoundError as exc:
+                # The executable is not there, so nothing started. Said out loud
+                # or the footer reports a missing pytest as a failing one.
+                logger.error(f"Command executable not found: {exc}")
+                return {
+                    **NOT_EXECUTED,
+                    "status": "error",
+                    "error": str(exc),
+                    "has_errors": True,
+                }
             except Exception as exc:
                 logger.error(f"Error executing shell command: {exc}")
                 return {"status": "error", "error": str(exc), "has_errors": True}

--- a/src/gaia/ui/sse_handler.py
+++ b/src/gaia/ui/sse_handler.py
@@ -25,7 +25,7 @@ from gaia.agents.base.console import OutputHandler
 from gaia.agents.base.tool_grants import grant_scope
 from gaia.agents.base.tools import get_tool_display_label, get_tool_metadata
 from gaia.agents.base.turn_metrics import turn_log_path
-from gaia.agents.base.verification import strip_verification_scope
+from gaia.agents.base.verification import split_verification_scope
 from gaia.ui.event_narration import DEBUG_CHANNEL, format_count
 
 logger = logging.getLogger(__name__)
@@ -612,14 +612,10 @@ class SSEOutputHandler(OutputHandler):
         ttft_seconds: Optional[float] = None,
     ):
         if answer:
-            scope_line = ""
             # Set aside the verification-scope line before the cleaners run: an
             # answer they strip to nothing (a card-echo) must stay empty, not
             # arrive as a message consisting only of the scope line (#3376).
-            cleaned_of_scope = strip_verification_scope(answer)
-            if cleaned_of_scope != answer:
-                scope_line = answer[len(cleaned_of_scope) :].strip()
-                answer = cleaned_of_scope
+            answer, scope_line = split_verification_scope(answer)
             answer = _THINK_TAG_SUB_RE.sub("", answer)
             # Extract answer text from {"thought":..., "answer":...} JSON before
             # the regex cleaners run.  _THOUGHT_JSON_SUB_RE would otherwise strip

--- a/tests/unit/agents/test_verification_scope.py
+++ b/tests/unit/agents/test_verification_scope.py
@@ -32,9 +32,11 @@ import pytest
 from gaia.agents.base.agent import Agent
 from gaia.agents.base.tools import tool
 from gaia.agents.base.verification import (
+    NOT_EXECUTED,
     VERIFICATION_SCOPE_MAX_CHARS,
     VERIFICATION_SCOPE_PREFIX,
     build_verification_scope,
+    check_was_executed,
     strip_verification_scope,
     verification_check_label,
 )
@@ -62,6 +64,12 @@ class _DummyAgent(Agent):
         def sandbox_shell_for_verification_scope_test(command: str) -> dict:
             """Run a command in a sandbox."""
             del command
+            return agent.shell_result
+
+        @tool
+        def sandbox_check_with_a_timeout(command: str, timeout: int = 60) -> dict:
+            """Run a command in a sandbox with a timeout."""
+            del command, timeout
             return agent.shell_result
 
     def _create_console(self):
@@ -485,3 +493,400 @@ def test_sse_card_echo_stays_empty_rather_than_scope_line_only():
     """An answer the cleaners strip to nothing must not become a scope line."""
     raw = f'{{"thought": "done", "answer": ""}}\n\n{build_verification_scope([])}'
     assert _sse_answer(raw) == ""
+
+
+# ---------------------------------------------------------------------------
+# A check that never ran is not a check that failed (#3677)
+# ---------------------------------------------------------------------------
+
+# Every shape ``run_shell_command`` can return, and whether the call ran. A
+# refusal and a failing run are both ``status: error``; only the refusal says
+# so, because only the refusal knows.
+EXECUTION_EVIDENCE_CASES = [
+    (
+        "allowlist_refusal",
+        {
+            **NOT_EXECUTED,
+            "status": "error",
+            "error": "Command 'python3.14' is not available to this agent.",
+            "has_errors": True,
+        },
+        False,
+    ),
+    (
+        "declined_confirmation",
+        {"status": "denied", "error": "The user declined to run this command."},
+        False,
+    ),
+    (
+        "missing_executable",
+        {
+            **NOT_EXECUTED,
+            "status": "error",
+            "error": "[Errno 2] No such file or directory: 'pytest'",
+            "has_errors": True,
+        },
+        False,
+    ),
+    (
+        "policy_refusal_before_the_prompt",
+        {
+            **NOT_EXECUTED,
+            "status": "error",
+            "error": "Shell operators are not allowed for security reasons.",
+            "has_errors": True,
+        },
+        False,
+    ),
+    (
+        "ran_and_failed",
+        {
+            "status": "success",
+            "return_code": 1,
+            "stdout": "1 failed",
+            "stderr": "",
+            "has_errors": True,
+        },
+        True,
+    ),
+    (
+        "ran_and_passed",
+        {"status": "success", "return_code": 0, "stdout": "5 passed", "stderr": ""},
+        True,
+    ),
+    (
+        "timed_out_mid_run",
+        {
+            "status": "error",
+            "error": "Command timed out after 180 seconds",
+            "has_errors": True,
+            "timed_out": True,
+            "duration_seconds": 180.0,
+        },
+        True,
+    ),
+    # The direction the evidence-sniffing first draft got wrong: a tool that
+    # really did run a check and reports only a message must NOT read as
+    # refused. Silence is not a refusal.
+    (
+        "bare_error_from_a_check_that_ran",
+        {"status": "error", "error": "pytest exited 1", "has_errors": True},
+        True,
+    ),
+    ("bare_error_with_no_status", {"error": "something went wrong"}, True),
+    ("plain_string_result", "5 passed", True),
+]
+
+
+def _blocked(label="pytest", name="run_shell_command"):
+    return {"tool": name, "check_label": label, "failed": True, "ran": False}
+
+
+def test_a_refused_check_is_unverified_not_partially_verified():
+    statement = build_verification_scope([_blocked()])
+    assert statement.startswith(f"{VERIFICATION_SCOPE_PREFIX}unverified")
+    assert "did not run" in statement
+    assert "did not pass" not in statement
+
+
+def test_a_refused_check_names_what_was_requested():
+    statement = build_verification_scope([_blocked("pytest")])
+    assert "pytest" in statement
+    assert "refused before execution" in statement
+
+
+def test_a_declined_check_is_not_reported_as_passing():
+    """``status: denied`` is not an error result, so it read as a pass."""
+    declined = {
+        "tool": "run_shell_command",
+        "check_label": "pytest",
+        "failed": False,
+        "ran": False,
+    }
+    statement = build_verification_scope([declined])
+    assert "ran and passed" not in statement
+    assert statement.startswith(f"{VERIFICATION_SCOPE_PREFIX}unverified")
+
+
+def test_a_refused_check_alongside_a_passing_one_is_only_partial():
+    statement = build_verification_scope(
+        [{"tool": "t", "check_label": "ruff", "failed": False}, _blocked("pytest")]
+    )
+    assert statement.startswith(f"{VERIFICATION_SCOPE_PREFIX}partially verified")
+    assert "ruff ran and passed" in statement
+    assert "pytest did not run" in statement
+
+
+def test_a_refused_check_does_not_inflate_the_ran_tool_count():
+    statement = build_verification_scope(
+        [
+            {"tool": "read_file", "check_label": None, "failed": False},
+            _blocked("pytest"),
+        ]
+    )
+    assert "2 tool calls ran" not in statement
+
+
+def test_non_check_tools_that_never_ran_are_not_counted_as_having_run():
+    statement = build_verification_scope(
+        [{"tool": "read_file", "check_label": None, "failed": True, "ran": False}]
+    )
+    assert "no tools ran" in statement
+
+
+def test_a_tool_that_ran_and_errored_still_counts_as_a_tool_call_that_ran():
+    """An error is not a refusal — read_file on a missing path did run."""
+    statement = build_verification_scope(
+        [
+            {
+                "tool": "read_file",
+                "check_label": None,
+                "failed": True,
+                "ran": check_was_executed(
+                    {"status": "error", "error": "File not found"}
+                ),
+            }
+        ]
+    )
+    assert "1 tool call ran" in statement
+
+
+def test_the_footer_is_still_bounded_with_blocked_checks():
+    executions = [_blocked(f"checker-{i:03d}-with-a-long-name") for i in range(200)]
+    assert len(build_verification_scope(executions)) <= VERIFICATION_SCOPE_MAX_CHARS
+
+
+# --- through the real agent loop -------------------------------------------
+
+
+REJECTION_RESULT = {
+    **NOT_EXECUTED,
+    "status": "error",
+    "error": (
+        "Command 'python3.14' is not available to this agent. It is granted "
+        "only to a skill that declares 'shell:execute:python3.14'."
+    ),
+    "has_errors": True,
+}
+
+
+def test_loop_reports_a_rejected_pytest_as_never_having_run(agent):
+    agent.shell_result = REJECTION_RESULT
+    _stub_chat(
+        agent,
+        _tool_call("python3.14 -m pytest tests/"),
+        _answer("The command was rejected, so no tests ran."),
+    )
+
+    line = _scope_line(agent.process_query("run the tests")["result"])
+
+    assert line.startswith(f"{VERIFICATION_SCOPE_PREFIX}unverified")
+    assert "did not run" in line
+    assert "did not pass" not in line
+
+
+def test_loop_reports_a_declined_pytest_as_never_having_run(agent):
+    agent.shell_result = {"status": "denied", "error": "The user said no."}
+    _stub_chat(
+        agent,
+        _tool_call("pytest tests/"),
+        _answer("You declined, so nothing was checked."),
+    )
+
+    line = _scope_line(agent.process_query("run the tests")["result"])
+
+    assert line.startswith(f"{VERIFICATION_SCOPE_PREFIX}unverified")
+    assert "ran and passed" not in line
+
+
+def test_loop_still_reports_a_real_failing_test_as_having_run(agent):
+    agent.shell_result = {
+        "status": "success",
+        "return_code": 1,
+        "stdout": "1 failed",
+        "stderr": "",
+        "has_errors": True,
+    }
+    _stub_chat(agent, _tool_call("pytest tests/"), _answer("One test failed."))
+
+    line = _scope_line(agent.process_query("run the tests")["result"])
+
+    assert "partially verified" in line
+    assert "did not pass" in line
+
+
+def test_loop_still_reports_a_passing_test_as_verified(agent):
+    agent.shell_result = {
+        "status": "success",
+        "return_code": 0,
+        "stdout": "5 passed",
+        "stderr": "",
+    }
+    _stub_chat(agent, _tool_call("pytest tests/"), _answer("All green."))
+
+    line = _scope_line(agent.process_query("run the tests")["result"])
+
+    assert line.startswith(f"{VERIFICATION_SCOPE_PREFIX}verified")
+
+
+# --- the real shell tool declares its own refusals --------------------------
+#
+# ``check_was_executed`` believes what a tool says. These pin that the tool
+# actually says it — a refusal that forgets the stamp reads as a check that ran.
+
+
+@pytest.fixture
+def shell_tool():
+    """The real ``run_shell_command``, on a bare mixin."""
+    import importlib
+
+    from gaia.agents.base.tools import _TOOL_REGISTRY
+
+    module = importlib.import_module("gaia.agents.tools.shell_tools")
+    mixin = module.ShellToolsMixin()
+    saved = dict(_TOOL_REGISTRY)
+    try:
+        mixin.register_shell_tools()
+        entry = _TOOL_REGISTRY.get("run_shell_command")
+        assert entry is not None, "run_shell_command was not registered"
+        yield entry["function"]
+    finally:
+        _TOOL_REGISTRY.clear()
+        _TOOL_REGISTRY.update(saved)
+
+
+REFUSED_COMMANDS = [
+    ("not_on_the_allowlist", "/usr/local/bin/python3.14 -m pytest tests/"),
+    ("shell_operators", "pytest tests/ && echo done"),
+    ("unknown_binary", "definitely-not-a-real-binary --version"),
+]
+
+
+@pytest.mark.parametrize(
+    "command",
+    [c for _, c in REFUSED_COMMANDS],
+    ids=[i for i, _ in REFUSED_COMMANDS],
+)
+def test_a_refused_command_says_it_did_not_run(shell_tool, command):
+    result = shell_tool(command)
+    assert result["status"] == "error", result
+    assert check_was_executed(result) is False, result
+
+
+def test_a_refused_pytest_leaves_the_turn_unverified(shell_tool):
+    """The whole chain: real refusal -> real classifier -> footer."""
+    result = shell_tool("/usr/local/bin/python3.14 -m pytest tests/")
+    statement = build_verification_scope(
+        [
+            {
+                "tool": "run_shell_command",
+                "check_label": verification_check_label(
+                    "run_shell_command",
+                    {"command": "/usr/local/bin/python3.14 -m pytest tests/"},
+                ),
+                "failed": True,
+                "ran": check_was_executed(result),
+            }
+        ]
+    )
+    assert statement.startswith(f"{VERIFICATION_SCOPE_PREFIX}unverified")
+    assert "did not pass" not in statement
+
+
+def test_a_command_that_really_runs_says_it_ran(shell_tool):
+    result = shell_tool("echo hello")
+    assert result["status"] == "success", result
+    assert check_was_executed(result) is True
+
+
+# --- every dispatch-time rejection declares itself too (#3677 review) --------
+#
+# ``_execute_tool`` has five exits that return before the tool body: unknown
+# name, guardrail refusal, missing argument, unexpected argument, uncoercible
+# argument. All five reach ``_note_verification_signal``, so all five have to
+# say nothing ran — a model that calls the shell tool for pytest with one
+# hallucinated kwarg is rejected at dispatch, and the footer used to call that
+# a test that ran and failed.
+
+DISPATCH_REJECTIONS = [
+    ("unknown_tool_name", "no_such_tool_at_all", {"command": "pytest tests/"}),
+    (
+        "missing_required_argument",
+        _SANDBOX_SHELL,
+        {},
+    ),
+    (
+        "unexpected_argument",
+        _SANDBOX_SHELL,
+        {"command": "pytest tests/", "timeout_sec": 30},
+    ),
+    (
+        "uncoercible_argument",
+        "sandbox_check_with_a_timeout",
+        {"command": "pytest tests/", "timeout": "not-a-number"},
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "tool_name,tool_args",
+    [(name, args) for _, name, args in DISPATCH_REJECTIONS],
+    ids=[case[0] for case in DISPATCH_REJECTIONS],
+)
+def test_a_call_rejected_at_dispatch_says_it_did_not_run(agent, tool_name, tool_args):
+    result = agent._execute_tool(tool_name, tool_args)
+    assert result["status"] == "error", result
+    assert check_was_executed(result) is False, result
+
+
+def test_a_hallucinated_kwarg_on_a_pytest_call_leaves_the_turn_unverified(agent):
+    """The exact shape the review reproduced."""
+    args = {"command": "pytest tests/", "timeout_sec": 30}
+    result = agent._execute_tool(_SANDBOX_SHELL, args)
+    statement = build_verification_scope(
+        [
+            {
+                "tool": _SANDBOX_SHELL,
+                "check_label": verification_check_label(_SANDBOX_SHELL, args),
+                "failed": True,
+                "ran": check_was_executed(result),
+            }
+        ]
+    )
+    assert statement.startswith(f"{VERIFICATION_SCOPE_PREFIX}unverified")
+    assert "ran and did not pass" not in statement
+
+
+# --- a refusal the agent recovered from is not an unrun check ---------------
+
+
+def test_a_refused_check_that_later_ran_is_not_also_reported_as_unrun():
+    statement = build_verification_scope(
+        [
+            _blocked("pytest"),
+            {"tool": "run_shell_command", "check_label": "pytest", "failed": False},
+        ]
+    )
+    assert statement == f"{VERIFICATION_SCOPE_PREFIX}verified — pytest ran and passed."
+
+
+def test_a_different_check_left_unrun_is_still_reported():
+    statement = build_verification_scope(
+        [
+            _blocked("ruff"),
+            {"tool": "run_shell_command", "check_label": "pytest", "failed": False},
+        ]
+    )
+    assert statement.startswith(f"{VERIFICATION_SCOPE_PREFIX}partially verified")
+    assert "ruff did not run" in statement
+
+
+def test_a_refused_check_that_later_ran_and_failed_is_reported_as_failing():
+    statement = build_verification_scope(
+        [
+            _blocked("pytest"),
+            {"tool": "run_shell_command", "check_label": "pytest", "failed": True},
+        ]
+    )
+    assert "ran and did not pass" in statement
+    assert "did not run" not in statement

--- a/tests/unit/agents/test_verification_scope.py
+++ b/tests/unit/agents/test_verification_scope.py
@@ -1073,3 +1073,16 @@ def test_an_unterminated_fence_is_left_alone_rather_than_edited_inside():
     """Ambiguous markup: keep the answer whole instead of guessing."""
     text = "Broken:\n\n```\n" + ECHOED
     assert strip_verification_scope(text) == text
+
+
+def test_an_answer_without_a_statement_comes_back_byte_for_byte():
+    """The email agent compares the stripped answer against the original."""
+    text = "Line one.\r\nLine two.\r\n\r\nStill line two.\n"
+
+    assert strip_verification_scope(text) == text
+
+
+def test_an_exotic_separator_is_not_treated_as_a_line_break():
+    text = "before\x0cafter"
+
+    assert strip_verification_scope(text) == text

--- a/tests/unit/agents/test_verification_scope.py
+++ b/tests/unit/agents/test_verification_scope.py
@@ -37,6 +37,7 @@ from gaia.agents.base.verification import (
     VERIFICATION_SCOPE_PREFIX,
     build_verification_scope,
     check_was_executed,
+    split_verification_scope,
     strip_verification_scope,
     verification_check_label,
 )
@@ -890,3 +891,185 @@ def test_a_refused_check_that_later_ran_and_failed_is_reported_as_failing():
     )
     assert "ran and did not pass" in statement
     assert "did not run" not in statement
+
+
+# ---------------------------------------------------------------------------
+# Exactly one statement per answer, whatever the model wrote (#3675)
+# ---------------------------------------------------------------------------
+
+ECHOED = (
+    "Verification: unverified — 5 tool calls ran, none of them a test, lint, or build."
+)
+
+MODEL_ECHOES = [
+    ("plain_trailing", f"All five calls succeeded.\n\n{ECHOED}"),
+    ("no_blank_line", f"All five calls succeeded.\n{ECHOED}"),
+    ("trailing_whitespace", f"All five calls succeeded.\n\n{ECHOED}   \n\n"),
+    (
+        "bold_markdown",
+        "All five calls succeeded.\n\n**Verification:** unverified — 5 tool calls ran.",
+    ),
+    (
+        "italic_markdown",
+        "All five calls succeeded.\n\n_Verification: unverified — 5 tool calls ran._",
+    ),
+    (
+        "blockquoted",
+        "All five calls succeeded.\n\n> Verification: unverified — 5 tool calls ran.",
+    ),
+    (
+        "bulleted",
+        "All five calls succeeded.\n\n- **Verification:** unverified — 5 tool calls ran.",
+    ),
+    ("mid_answer", f"First part.\n\n{ECHOED}\n\nSecond part."),
+    ("twice_over", f"Body.\n\n{ECHOED}\n\n{ECHOED}"),
+    (
+        "heading",
+        "All five calls succeeded.\n\n## Verification: unverified — 5 tool calls ran.",
+    ),
+    (
+        "ordered_list",
+        "All five calls succeeded.\n\n1. Verification: unverified — 5 tool calls ran.",
+    ),
+    (
+        "em_dash_variants",
+        "All five calls succeeded.\n\nVerification: unverified - 5 tool calls ran.",
+    ),
+]
+
+
+def _scope_lines(text):
+    return [
+        line
+        for line in text.splitlines()
+        if line.lstrip(" >-*_`").startswith("Verification:")
+    ]
+
+
+@pytest.mark.parametrize(
+    "answer", [case[1] for case in MODEL_ECHOES], ids=[case[0] for case in MODEL_ECHOES]
+)
+def test_an_echoed_statement_is_replaced_not_duplicated(agent, answer):
+    emitted = agent._with_verification_scope(answer)
+    assert len(_scope_lines(emitted)) == 1, emitted
+
+
+def test_the_surviving_statement_is_the_one_derived_from_this_turn(agent):
+    agent._turn_tool_executions = [
+        {"tool": "run_shell_command", "check_label": "pytest", "failed": False}
+    ]
+    emitted = agent._with_verification_scope(f"Body.\n\n{ECHOED}")
+    assert _scope_lines(emitted) == [agent.verification_scope_statement()]
+    assert "5 tool calls ran" not in emitted
+
+
+def test_the_answer_text_around_an_echo_is_preserved(agent):
+    emitted = agent._with_verification_scope(f"First part.\n\n{ECHOED}\n\nSecond part.")
+    assert "First part." in emitted
+    assert "Second part." in emitted
+
+
+def test_an_answer_that_is_only_an_echo_keeps_exactly_one_statement(agent):
+    emitted = agent._with_verification_scope(ECHOED)
+    assert emitted == agent.verification_scope_statement()
+
+
+def test_an_answer_with_no_echo_is_unchanged_but_for_the_appended_line(agent):
+    emitted = agent._with_verification_scope("Just an answer.")
+    assert emitted.startswith("Just an answer.")
+    assert len(_scope_lines(emitted)) == 1
+
+
+def test_the_loop_emits_one_statement_when_the_model_echoes_one(agent):
+    """End-to-end: the echo comes back through conversation history."""
+    agent.shell_result = {"status": "success", "return_code": 0, "stdout": "ok"}
+    _stub_chat(
+        agent,
+        _tool_call("ls -la"),
+        _answer(f"Listed the directory.\n\n{ECHOED}"),
+    )
+
+    result = agent.process_query("list the directory")["result"]
+
+    assert len(_scope_lines(result)) == 1, result
+    assert "5 tool calls ran" not in result
+
+
+def test_split_returns_the_body_and_the_last_statement():
+    body, line = split_verification_scope(f"Body.\n\n{ECHOED}")
+    assert body == "Body."
+    assert line == ECHOED
+
+
+def test_split_tolerates_a_non_string():
+    assert split_verification_scope(None) == ("", "")
+
+
+# --- what the splitter must NOT touch ---------------------------------------
+#
+# It runs on every Agent-UI answer, so anything it rewrites, it rewrites for
+# every answer. Only the generated statement goes.
+
+KEEP_VERBATIM = [
+    (
+        "blank_lines_inside_a_code_block",
+        "Here you go:\n\n```python\ndef a():\n    pass\n\n\ndef b():\n    pass\n```",
+    ),
+    (
+        "a_users_own_verification_step",
+        "Here is the plan:\n\n1. Build\n\nVerification: run pytest before tagging.\n\nDone.",
+    ),
+    ("the_word_in_prose", "verification: none was performed on this branch."),
+    ("a_colon_line_that_is_not_a_statement", "Verification: TBD"),
+    ("paragraph_spacing", "Line A.\n\n\nLine B."),
+    (
+        "a_footer_quoted_inside_a_code_fence",
+        "Here is what it looks like:\n\n```\n"
+        "Verification: unverified - no tools ran, so nothing was checked.\n```",
+    ),
+    (
+        "a_footer_inside_a_tilde_fence",
+        "Example:\n\n~~~text\nVerification: verified - pytest ran and passed.\n~~~",
+    ),
+    (
+        "a_footer_inside_an_indented_fence",
+        "Steps:\n\n  ```\n  Verification: verified - pytest ran and passed.\n  ```",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "text", [t for _, t in KEEP_VERBATIM], ids=[i for i, _ in KEEP_VERBATIM]
+)
+def test_text_that_is_not_a_generated_statement_is_untouched(text):
+    assert strip_verification_scope(text) == text
+
+
+@pytest.mark.parametrize(
+    "text", [t for _, t in KEEP_VERBATIM], ids=[i for i, _ in KEEP_VERBATIM]
+)
+def test_the_body_survives_byte_for_byte_when_a_statement_is_removed(text):
+    """Removing the line must not reflow what is left (the email agent compares
+    the stripped answer against its own grounded text for exact identity)."""
+    emitted = f"{text}\n\n{ECHOED}"
+    assert strip_verification_scope(emitted) == text
+
+
+def test_only_the_statements_blank_separator_is_removed():
+    assert strip_verification_scope(f"Body.\n\n{ECHOED}") == "Body."
+    assert strip_verification_scope(f"Body.\n{ECHOED}") == "Body."
+
+
+def test_a_quoted_footer_survives_while_the_real_one_is_replaced(agent):
+    """An answer explaining the feature must keep its example intact."""
+    answer = "Here is what the footer looks like:\n\n```\n" f"{ECHOED}\n```\n\n{ECHOED}"
+    emitted = agent._with_verification_scope(answer)
+    assert "```\n" + ECHOED + "\n```" in emitted
+    assert len(_scope_lines(emitted)) == 2  # the quoted one, and exactly one real
+    assert emitted.rstrip().endswith(agent.verification_scope_statement())
+
+
+def test_an_unterminated_fence_is_left_alone_rather_than_edited_inside():
+    """Ambiguous markup: keep the answer whole instead of guessing."""
+    text = "Broken:\n\n```\n" + ECHOED
+    assert strip_verification_scope(text) == text


### PR DESCRIPTION
A successful answer could carry the same verification paragraph twice — once on screen, once more in the conversation history every later turn re-reads. Observed in #3675 on a five-tool memory sequence where all five calls succeeded.

> **Stacked on #3703** — both change `verification.py`, so this branch contains that commit too. Merge #3703 first and this diff collapses to its own commit. Review the second commit only.

Fixes #3675

## Test plan

- [x] `pytest tests/unit/agents/test_verification_scope.py` (108 passed) — the echo matrix (plain, no blank line, bold, italic, blockquote, bullet, heading, ordered list, hyphen dash, mid-answer, twice over) and, separately, everything the stripper must leave alone.
- [x] `pytest tests/unit/agents tests/unit/test_sse_narration.py tests/unit/test_turn_metrics_wire.py` (882 passed)
- [x] Live TUI on Fireworks-via-Lemonade: asked the model to end its reply with a verification line. It wrote `ok\nVerification: unverified - 5 tool calls ran…`; the emitted answer carried one line, the authoritative one. On `main` that input produces two.

<details>
<summary>🔍 Technical details</summary>

The line rides in the answer and the answer is re-sent as conversation history, so the model reads it and writes one of its own — usually an exact copy, which is why #3675 saw two identical paragraphs. `_with_verification_scope` appended regardless.

`split_verification_scope` now removes every model-authored statement before the authoritative one is appended, and returns `(body, last_line)` — replacing the Agent-UI handler's `answer[len(cleaned):]` slice, which assumed the stripper only ever removed a trailing line.

What it matches is deliberately narrow, after review caught the first draft deleting too much:

- A line counts only if it carries the whole generated shape — prefix, then `verified` / `partially verified` / `unverified`, then the dash. A user's own `Verification: run pytest before tagging` inside a plan the model wrote survives, and so does `verification: none` in prose.
- **Code blocks are skipped entirely.** An answer that quotes a footer — a transcript, an explanation of the feature, this repo's own source — keeps its example instead of having the line deleted out of the middle of a fence. Backticks and tildes, indented or not; an unterminated fence means the rest of the answer is left alone rather than guessed at.
- Only the statement's own blank separator goes with it. An earlier draft normalised blank runs across the whole document, which — because this runs on *every* Agent-UI answer — silently reflowed the inside of every fenced code block, and broke the email agent's byte-identity check against its grounded answer.
</details>