### PR TITLE
fix(tools): search the user's project, not the directory the sidecar was spawned in

### DIFF
--- a/docs/spec/file-search-mixin.mdx
+++ b/docs/spec/file-search-mixin.mdx
@@ -18,17 +18,26 @@ title: "FileSearchToolsMixin"
 FileSearchToolsMixin provides agent-agnostic file search and management operations shared across multiple agents (Chat, Code). Features intelligent multi-phase search, type-based file analysis, and grep-like content searching.
 
 **Key Features:**
-- 3-phase intelligent file search (CWD → common locations → deep scan)
+- 3-phase intelligent file search (workspace → common locations → deep scan)
 - Type-aware file reading (Python AST, Markdown structure, binary detection)
 - Grep-like content search across file systems
 - Directory search with depth control
 - Generic file writing with directory creation
 
 **Search Strategy:**
-- Phase 0: Deep search current working directory (unlimited depth)
-- Phase 1: Search common locations (Documents, Downloads, Desktop) with depth limit
-- Phase 2: Deep drive/root search if still not found
+- A named `directory` is the WHOLE scope: searched to unlimited depth, and never
+  widened — not by Phase 1, not by `deep_search` (#3576)
+- Phase 0: the agent's **workspace** — `PathValidator.allowed_paths`, most
+  specific first. The most specific root is searched to unlimited depth; the
+  others, which accumulate as the user approves paths, are depth-capped
+- Phase 1: common locations (Documents, Downloads, Desktop) with a depth limit
+- Phase 2: deep drive/root search, only when `deep_search=True` and no
+  `directory` was named
 - Early termination on first match for speed
+
+The search root is the declared sandbox, **not** `Path.cwd()`. A sidecar is
+spawned by the daemon in its own package directory, so the working directory
+says how the process was launched, not where the user's work is.
 
 ---
 
@@ -56,20 +65,26 @@ class FileSearchToolsMixin:
     @tool
     def search_file(
         file_pattern: str,
+        directory: str = None,
         deep_search: bool = False,
         file_types: str = None
     ) -> Dict[str, Any]:
         """
         Search for files with two-phase strategy.
 
-        Quick search (default): CWD + common locations (Documents, Downloads, Desktop)
+        Quick search (default): workspace roots + common locations
+        Scoped search (directory=...): that directory only
         Deep search (deep_search=True): All drives (Windows) or root (Unix)
 
         Always do quick search first. Only use deep_search=True after quick search
-        found nothing and user confirms they want a deeper search.
+        found nothing and user confirms they want a deeper search. A named
+        directory is never widened, deep_search or not.
 
         Args:
             file_pattern: Pattern to search (e.g., 'oil', '*.pdf')
+            directory: Restrict the search to this folder. Pass it whenever the
+                user names one. A relative path resolves against the deepest
+                workspace root containing it.
             deep_search: Search all drives thoroughly (default: False)
             file_types: Filter by extensions (e.g., 'pdf,docx')
 
@@ -333,26 +348,40 @@ class FileSearchToolsMixin:
 ### 3-Phase Search
 
 ```python
-# Phase 0: Current directory (deep)
-cwd = Path.cwd()
-self.console.start_progress(f"Searching {cwd.name}...")
-search_location(cwd, max_depth=999)
-if matching_files:
-    return {"search_context": "current_directory", ...}
+# A named directory is the whole scope — resolved against the workspace,
+# sandbox-checked, and never widened below.
+if directory:
+    search_location(scope, max_depth=DEEP_ROOT_DEPTH)
+    roots = [scope]
+else:
+    # Phase 0: the workspace — PathValidator.allowed_paths, most specific
+    # first. Only the most specific root is walked exhaustively; the rest
+    # accumulate as the user approves paths and are depth-capped.
+    roots = search_roots(self)          # gaia.agents.tools.search_scope
+    for root in roots:
+        search_location(root, max_depth=root_depth(root, roots))
 
-# Phase 1: Common locations
-for location in [home/"Documents", home/"Downloads", home/"Desktop"]:
-    search_location(location, max_depth=5)
+    # Phase 1: Common locations
+    for location in [home/"Documents", home/"Downloads", home/"Desktop"]:
+        search_location(location, max_depth=5)
+
 if matching_files:
     return {"search_context": "common_locations", ...}
 
-# Phase 2: Deep drive search
+# Phase 2: Deep drive search — never when a directory was named
+if not deep_search or directory:
+    return {"status": "success", "files": [], "searched_paths": [...], ...}
 if platform.system() == "Windows":
     for drive in ["C:/", "D:/", ...]:
         search_location(drive, max_depth=999)
 else:
     search_location(Path("/"), max_depth=999)
 ```
+
+A zero result reports where it looked: `searched_paths`, a `search_context` of
+`"workspace"` or `"directory"`, and a `suggestion` telling the model that zero
+means zero under those paths, not zero on the machine. A named directory that
+does not exist is `status: "error"`, not an empty success.
 
 ### Python File Analysis
 

--- a/docs/spec/file-system-agent.mdx
+++ b/docs/spec/file-system-agent.mdx
@@ -331,7 +331,7 @@ def find_files(
     - content: search inside file contents (grep-like)
     - metadata: filter by size, date, type
 
-    Scope 'smart' searches: CWD first, then home common locations,
+    Scope 'smart' searches: the agent's workspace first, then home common locations,
     then indexed directories. Use 'everywhere' for full drive search (slow).
     """
 ```
@@ -344,7 +344,7 @@ def find_files(
 5. Apply metadata filters (size, date, type) on results
 
 **"Smart" scope logic:**
-1. Current working directory (deepest)
+1. The agent's workspace — `PathValidator.allowed_paths`, most specific first (deepest)
 2. Home directory common locations
 3. All indexed directories
 4. Full drive search (only if `scope="everywhere"` explicitly)

--- a/src/gaia/agents/tools/file_tools.py
+++ b/src/gaia/agents/tools/file_tools.py
@@ -24,6 +24,11 @@ from gaia.agents.tools.file_edit import (
     record_read,
     record_write,
 )
+from gaia.agents.tools.search_scope import (
+    DEEP_ROOT_DEPTH,
+    root_depth,
+    search_roots,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +72,10 @@ class FileSearchToolsMixin:
             self, "_path_validator", None
         )
 
+    def _search_roots(self) -> List[Path]:
+        """Where a filesystem search should look — see ``search_scope`` (#3576)."""
+        return search_roots(self)
+
     def _read_access_error(self, path: str):
         """Enforce the ``--allowed-paths`` sandbox on read operations.
 
@@ -100,15 +109,24 @@ class FileSearchToolsMixin:
             atomic=True,
         )
         def search_file(
-            file_pattern: str, deep_search: bool = False, file_types: str = None
+            file_pattern: str,
+            directory: str = None,
+            deep_search: bool = False,
+            file_types: str = None,
         ) -> Dict[str, Any]:
             """
-            Search for files with intelligent prioritization.
+            Find files by name or pattern.
 
-            Strategy:
-            1. Quick search: CWD + common document locations (fast)
-            2. Deep search: entire drive(s) (only when deep_search=True)
-            3. Filter by document file types for speed
+            Args:
+                file_pattern: name, substring, glob ("*.go") or regex to match.
+                directory: WHERE to look. Pass it whenever the user names a
+                    folder ("in tui/internal", "under docs") — without it the
+                    search covers the whole workspace and common document
+                    folders, which is slower and can match the wrong file.
+                deep_search: search entire drives. Slow; only after a normal
+                    search found nothing.
+                file_types: comma-separated extensions to restrict to, e.g.
+                    "go,md". Defaults to common document and source types.
             """
             try:
                 # Document file extensions to search
@@ -272,55 +290,117 @@ class FileSearchToolsMixin:
 
                     search_recursive(location, 0)
 
-                # Phase 0+1: Search CWD AND common locations together
-                # (always search both before returning, so Documents/Downloads
-                # files aren't missed just because CWD had some matches)
-                cwd = Path.cwd()
                 home = Path.home()
 
-                # Show progress to user
-                if hasattr(self, "console") and hasattr(self.console, "start_progress"):
-                    self.console.start_progress(
-                        f"🔍 Searching current directory ({cwd.name}) for '{file_pattern}'..."
-                    )
+                # An explicit directory is the whole scope: the user named a
+                # place, so searching anywhere else can only return the wrong
+                # file. It is sandbox-checked and must exist — a search that
+                # silently skipped it would report an honest-looking zero.
+                if directory:
+                    # Resolve BEFORE the sandbox check: "tui/internal" means a
+                    # folder in the user's workspace, not one under whatever
+                    # directory this process happens to have been spawned in.
+                    scope = Path(directory).expanduser()
+                    workspace = self._search_roots()
+                    if not scope.is_absolute():
+                        matched = next(
+                            (r for r in workspace if (r / scope).is_dir()), None
+                        )
+                        if matched is None:
+                            # No root holds it. Say that, rather than resolving
+                            # against this process's cwd and reporting "access
+                            # denied" for an absolute path the user never typed
+                            # — a typo'd folder should read as a typo. Safe to
+                            # be specific: no absolute path was supplied, so
+                            # this is not an existence oracle.
+                            listed = ", ".join(str(r) for r in workspace)
+                            return {
+                                "status": "error",
+                                "error": (
+                                    f"Directory not found: '{directory}' is not "
+                                    f"under any workspace root ({listed}). "
+                                    "Nothing was searched — this is not an "
+                                    "empty result."
+                                ),
+                                "searched_paths": [],
+                                "workspace_roots": [str(r) for r in workspace],
+                            }
+                        scope = matched / scope
+                    scope = scope.resolve()
+                    # Sandbox before the existence probe, so an out-of-sandbox
+                    # path cannot be used as a directory-existence oracle
+                    # (same order as read_file / search_file_content).
+                    denied = self._read_access_error(str(scope))
+                    if denied:
+                        return denied
+                    if not scope.is_dir():
+                        return {
+                            "status": "error",
+                            "error": (
+                                f"Directory not found: '{directory}'. Nothing was "
+                                "searched — this is not an empty result."
+                            ),
+                            "searched_paths": [],
+                        }
+                    if hasattr(self, "console") and hasattr(
+                        self.console, "start_progress"
+                    ):
+                        self.console.start_progress(
+                            f"🔍 Searching {scope} for '{file_pattern}'..."
+                        )
+                    search_location(scope, max_depth=DEEP_ROOT_DEPTH)
+                    roots = [scope]
+                else:
+                    # Phase 0+1: the agent's allowed paths AND common document
+                    # locations (always both, so a Documents file isn't missed
+                    # just because a workspace root had some matches).
+                    roots = self._search_roots()
+                    if hasattr(self, "console") and hasattr(
+                        self.console, "start_progress"
+                    ):
+                        self.console.start_progress(
+                            f"🔍 Searching the workspace for '{file_pattern}'..."
+                        )
+                    logger.debug("Phase 0: searching %s", [str(r) for r in roots])
+                    for root in roots:
+                        # Only the project gets an exhaustive walk. The rest of
+                        # the sandbox is approvals that accumulated over time,
+                        # and a zero-result search would traverse all of them.
+                        search_location(root, max_depth=root_depth(root, roots))
 
-                logger.debug(
-                    f"Phase 0: Deep search of current directory for '{file_pattern}'..."
-                )
-                logger.debug(f"Current directory: {cwd}")
+                    # Always also search common locations (Documents, Downloads, etc.)
+                    if hasattr(self, "console") and hasattr(
+                        self.console, "start_progress"
+                    ):
+                        self.console.start_progress(
+                            "🔍 Searching common folders (Documents, Downloads, Desktop)..."
+                        )
 
-                # Search current directory thoroughly (unlimited depth)
-                search_location(cwd, max_depth=999)
+                    logger.debug("Phase 1: Searching common document locations...")
 
-                # Always also search common locations (Documents, Downloads, etc.)
-                if hasattr(self, "console") and hasattr(self.console, "start_progress"):
-                    self.console.start_progress(
-                        "🔍 Searching common folders (Documents, Downloads, Desktop)..."
-                    )
+                    common_locations = [
+                        home / "Documents",
+                        home / "Downloads",
+                        home / "Desktop",
+                        home / "OneDrive",
+                        home / "Google Drive",
+                        home / "Dropbox",
+                    ]
 
-                logger.debug("Phase 1: Searching common document locations...")
-
-                common_locations = [
-                    home / "Documents",
-                    home / "Downloads",
-                    home / "Desktop",
-                    home / "OneDrive",
-                    home / "Google Drive",
-                    home / "Dropbox",
-                ]
-
-                for location in common_locations:
-                    if len(matching_files) >= 20:
-                        break
-                    # Skip if already searched as part of CWD
-                    try:
-                        if location.resolve() == cwd.resolve() or str(
-                            location.resolve()
-                        ).startswith(str(cwd.resolve())):
-                            continue
-                    except (OSError, ValueError):
-                        pass
-                    search_location(location, max_depth=5)
+                    for location in common_locations:
+                        if len(matching_files) >= 20:
+                            break
+                        # Skip anything already covered by a searched root
+                        try:
+                            resolved = location.resolve()
+                            if any(
+                                resolved == root or str(resolved).startswith(str(root))
+                                for root in roots
+                            ):
+                                continue
+                        except (OSError, ValueError):
+                            pass
+                        search_location(location, max_depth=5)
 
                 # Deduplicate results (CWD and common locations may overlap)
                 unique_files = []
@@ -350,18 +430,32 @@ class FileSearchToolsMixin:
                         "display_message": f"✓ Found {len(limited_files)} file(s)",
                     }
 
-                # Quick search found nothing
-                if not deep_search:
-                    # Return with hint that deep search is available
+                # Quick search found nothing. A named directory is the WHOLE
+                # scope: a drive-wide sweep would answer about somewhere else,
+                # which is the same wrong answer in a softer form — and the
+                # deep_search docstring tells the model to reach for it after
+                # exactly this result.
+                if not deep_search or directory:
+                    # Name the places that were searched. A bare zero reads as
+                    # "there are none", and the model relays it that way (#3576).
+                    where = ", ".join(str(r) for r in roots) or "nowhere"
                     return {
                         "status": "success",
                         "files": [],
                         "count": 0,
                         "total_locations_searched": len(searched_locations),
-                        "search_context": "common_locations",
-                        "display_message": f"No files found matching '{file_pattern}' in common locations",
-                        "deep_search_available": True,
-                        "suggestion": "I can do a deep search across all drives if you'd like (this may take a minute).",
+                        "searched_paths": [str(p) for p in searched_locations],
+                        "search_context": "directory" if directory else "workspace",
+                        "display_message": (
+                            f"No files matching '{file_pattern}' under {where}"
+                        ),
+                        "deep_search_available": not directory,
+                        "suggestion": (
+                            "Zero here means zero UNDER THE PATHS LISTED IN "
+                            "searched_paths, not zero on the machine. Say where you "
+                            "looked. If the user named a folder, pass it as "
+                            "`directory`."
+                        ),
                     }
 
                 # Phase 2: Deep drive search (only when explicitly requested)
@@ -405,26 +499,13 @@ class FileSearchToolsMixin:
                         "user_instruction": "If multiple files found, display numbered list and ask user to select one.",
                     }
                 else:
-                    # Build helpful message about what was searched
-                    search_summary = []
-                    if str(cwd) in searched_locations:
-                        search_summary.append(f"current directory ({cwd.name})")
-                    if len(searched_locations) > 1:
-                        search_summary.append(
-                            f"{len(searched_locations)} total locations"
-                        )
-
-                    searched_str = (
-                        ", ".join(search_summary)
-                        if search_summary
-                        else f"{len(searched_locations)} locations"
-                    )
-
+                    searched_str = f"{len(searched_locations)} locations"
                     return {
                         "status": "success",
                         "files": [],
                         "count": 0,
                         "total_locations_searched": len(searched_locations),
+                        "searched_paths": [str(p) for p in searched_locations],
                         "search_summary": searched_str,
                         "display_message": f"❌ No files found matching '{file_pattern}'",
                         "searched": f"Searched {searched_str}",

--- a/src/gaia/agents/tools/filesystem_tools.py
+++ b/src/gaia/agents/tools/filesystem_tools.py
@@ -16,6 +16,9 @@ import mimetypes
 import os
 import sys
 from pathlib import Path
+from typing import Any
+
+from gaia.agents.tools.search_scope import search_roots
 
 logger = logging.getLogger(__name__)
 
@@ -55,13 +58,20 @@ _UNBOUNDED_SCOPES = frozenset({"smart", "everywhere"})
 _INDEX_SCOPE_OVERFETCH = 10
 
 
-def _scope_roots(scope: str) -> list:
-    """Directories an index hit must sit under; empty when the scope is open."""
+def _scope_roots(scope: str, host: Any = None) -> list:
+    """Directories an index hit must sit under; empty when the scope is open.
+
+    ``host`` supplies the workspace for ``cwd``. Resolving that scope to
+    ``Path.cwd()`` filtered index hits against the directory the sidecar was
+    spawned in, which is not where the user's work is — the same mistake the
+    walk path makes without it, and the two must agree or a hit the walk found
+    gets filtered out again (#3576).
+    """
     if scope in _UNBOUNDED_SCOPES:
         return []
     if scope == "cwd":
-        raw = Path.cwd()
-    elif scope == "home":
+        return [Path(root).expanduser().resolve() for root in search_roots(host)]
+    if scope == "home":
         raw = Path.home()
     else:
         raw = Path(scope)
@@ -103,6 +113,10 @@ class FileSystemToolsMixin:
             if not allowed:
                 raise ValueError(f"Access denied: {reason}")
         return resolved
+
+    def workspace_roots(self) -> list:
+        """The agent's allowed paths — see ``search_scope`` (#3576)."""
+        return [str(root) for root in search_roots(self)]
 
     def _get_default_excludes(self) -> set:
         """Get platform-specific default directory exclusion patterns."""
@@ -711,7 +725,7 @@ class FileSystemToolsMixin:
                 ):
                     # The index spans every indexed directory, so the caller's
                     # scope has to be applied to its rows too.
-                    scope_roots = _scope_roots(scope)
+                    scope_roots = _scope_roots(scope, self)
                     try:
                         index_results = mixin._fs_index.query_files(
                             name=query if effective_type != "metadata" else None,
@@ -1183,10 +1197,10 @@ class FileSystemToolsMixin:
         def _get_search_roots(scope: str) -> list:
             """Get search root directories based on scope."""
             home = str(Path.home())
-            cwd = str(Path.cwd())
+            workspace = self.workspace_roots()
 
             if scope == "cwd":
-                return [cwd]
+                return workspace
             elif scope == "home":
                 return [home]
             elif scope == "everywhere":
@@ -1200,7 +1214,7 @@ class FileSystemToolsMixin:
                     ]
                 return ["/"]
             elif scope == "smart":
-                roots = [cwd]
+                roots = list(workspace)
                 common = [
                     "Documents",
                     "Downloads",
@@ -1211,7 +1225,7 @@ class FileSystemToolsMixin:
                 ]
                 for folder in common:
                     p = Path(home) / folder
-                    if p.exists() and str(p) != cwd:
+                    if p.exists() and str(p) not in roots:
                         roots.append(str(p))
                 return roots
             else:

--- a/src/gaia/agents/tools/search_scope.py
+++ b/src/gaia/agents/tools/search_scope.py
@@ -1,0 +1,70 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""Where a filesystem search should look, and how deep (#3576).
+
+Both file-search mixins rooted their searches at ``Path.cwd()``. A sidecar is
+spawned by the daemon in its own package directory, so that is a fact about how
+the process was launched, not about where the user's work is — the agent
+answered "zero .go files" for a repo holding 203.
+
+The answer is the agent's declared sandbox. That set is not only the project,
+though: ``PathValidator`` merges every path the user has ever approved out of
+``~/.gaia/cache/allowed_paths.json``, so it grows with use. Walking all of it to
+unlimited depth on every miss is what :data:`SHALLOW_ROOT_DEPTH` exists to
+prevent.
+
+One module rather than a method on each mixin, so the two cannot drift.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, List
+
+#: Depth the primary root is walked to — effectively unlimited. The project the
+#: user is working in is the one place worth an exhaustive walk.
+DEEP_ROOT_DEPTH = 999
+
+#: Depth for every other root. An approved ``~/Documents`` is a legitimate
+#: search location and a bad thing to traverse exhaustively on every search
+#: that finds nothing; the old code capped the same folders at 5 for the same
+#: reason.
+SHALLOW_ROOT_DEPTH = 5
+
+
+def path_validator_of(host: Any) -> Any:
+    """The host's PathValidator under either of the two attribute names."""
+    return getattr(host, "path_validator", None) or getattr(
+        host, "_path_validator", None
+    )
+
+
+def search_roots(host: Any) -> List[Path]:
+    """Allowed paths, **most specific first**, then a working-directory fallback.
+
+    Most specific first is load-bearing: it decides which root a relative
+    directory like ``tui/internal`` is resolved against, and the deepest match
+    is the one the user meant. Sorting by string put ``/a`` before ``/a/b``.
+
+    The fallback is only for library use with no sandbox declared at all.
+    """
+    validator = path_validator_of(host)
+    roots = [
+        Path(root)
+        for root in (getattr(validator, "allowed_paths", None) or [])
+        if Path(root).exists()
+    ]
+    if not roots:
+        return [Path.cwd().resolve()]
+    return sorted(roots, key=lambda p: (-len(p.parts), str(p)))
+
+
+def root_depth(root: Path, roots: List[Path]) -> int:
+    """How deep to walk *root* given the whole set.
+
+    The first (most specific) root is the project; the rest are approvals that
+    accumulated, and are capped.
+    """
+    if roots and Path(root) == Path(roots[0]):
+        return DEEP_ROOT_DEPTH
+    return SHALLOW_ROOT_DEPTH

--- a/tests/unit/test_file_search_scope.py
+++ b/tests/unit/test_file_search_scope.py
@@ -1,0 +1,416 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""File search must look where the user's work is, and say where it looked.
+
+Ask the flagship how many Go files are under `tui/internal` and it answered
+"Zero." There are 203. Two things compounded (#3576):
+
+* the search was rooted at ``Path.cwd()``, which for a daemon-spawned sidecar is
+  its own package directory — the user's project was not in the search set;
+* nothing downstream could tell that apart from a genuine zero, because the
+  result was ``status: "success"`` with no record of where it looked.
+
+These tests build a fake project, point the agent's sandbox at it, and assert
+the search reaches it — from a working directory that is somewhere else
+entirely, which is the condition the bug needed.
+
+No LLM or external service required.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from gaia.agents.base.tools import _TOOL_REGISTRY
+from gaia.agents.tools.file_tools import FileSearchToolsMixin
+from gaia.agents.tools.filesystem_tools import FileSystemToolsMixin
+
+
+class _Sandbox:
+    """Stand-in for PathValidator: the paths the operator declared.
+
+    Implements the read gate the tools actually call — ``validate_read`` as
+    well as ``is_path_allowed`` — so this double cannot pass while the real
+    validator's interface moves underneath it.
+    """
+
+    def __init__(self, *paths):
+        self.allowed_paths = {Path(p).resolve() for p in paths}
+
+    def is_path_allowed(self, path, prompt_user=True):
+        resolved = Path(path).resolve()
+        return any(
+            resolved == root or root in resolved.parents for root in self.allowed_paths
+        )
+
+    def validate_read(self, path, prompt_user=True):
+        if not self.is_path_allowed(path, prompt_user=prompt_user):
+            return False, f"Access denied: '{path}' is not in allowed paths"
+        return True, ""
+
+
+@pytest.fixture
+def project(tmp_path):
+    """A project with Go files, and a separate directory to run the agent from.
+
+    ``elsewhere`` stands in for the sidecar's own package directory — the cwd
+    the daemon actually spawns it in.
+    """
+    root = tmp_path / "myproject"
+    (root / "tui" / "internal").mkdir(parents=True)
+    for name in ("model.go", "view.go", "controller.go"):
+        (root / "tui" / "internal" / name).write_text("package internal\n")
+    (root / "README.md").write_text("# project\n")
+
+    elsewhere = tmp_path / "sidecar-package-dir"
+    elsewhere.mkdir()
+
+    prev = Path.cwd()
+    os.chdir(elsewhere)
+    try:
+        yield root, elsewhere
+    finally:
+        os.chdir(prev)
+
+
+# ============================================================================
+# 1. file_tools.search_file
+# ============================================================================
+
+
+@pytest.fixture
+def search_file(project):
+    root, _ = project
+    mixin = FileSearchToolsMixin()
+    mixin.path_validator = _Sandbox(root)
+
+    saved = dict(_TOOL_REGISTRY)
+    try:
+        mixin.register_file_search_tools()
+        entry = _TOOL_REGISTRY.get("search_file")
+        assert entry is not None, "search_file was not registered"
+        fn = entry["function"]
+        fn.mixin = mixin
+        yield fn
+    finally:
+        _TOOL_REGISTRY.clear()
+        _TOOL_REGISTRY.update(saved)
+
+
+class TestSearchFileLooksAtTheWorkspace:
+    def test_it_finds_project_files_from_an_unrelated_cwd(self, search_file, project):
+        """The condition the bug needed: cwd is not the project."""
+        result = search_file("*.go")
+        assert result["status"] == "success", result
+        assert result["count"] == 3, result
+
+    def test_a_named_directory_scopes_the_search(self, search_file, project):
+        root, _ = project
+        result = search_file("*.go", directory=str(root / "tui" / "internal"))
+        assert result["count"] == 3
+        # Parts, not a substring: "tui/internal" is not how Windows spells it.
+        assert all(Path(f).parts[-3:-1] == ("tui", "internal") for f in result["files"])
+
+    def test_a_relative_directory_resolves_against_the_workspace(
+        self, search_file, project
+    ):
+        """The user says "in tui/internal"; they do not mean the process cwd."""
+        result = search_file("*.go", directory="tui/internal")
+        assert result["count"] == 3
+
+    def test_a_directory_that_does_not_exist_is_an_error_not_an_empty_result(
+        self, search_file, project
+    ):
+        root, _ = project
+        result = search_file("*.go", directory=str(root / "no" / "such" / "folder"))
+        assert result["status"] == "error"
+        assert "not an empty result" in result["error"]
+
+    def test_a_typod_relative_directory_reads_as_a_typo(self, search_file):
+        """It matches no workspace root — say that, and list the roots.
+
+        Resolving it against the process cwd and reporting "access denied"
+        named an absolute path the user never typed. Being specific is safe
+        here: no absolute path was supplied, so this is not an existence
+        oracle.
+        """
+        result = search_file("*.go", directory="no/such/folder")
+
+        assert result["status"] == "error"
+        assert "not under any workspace root" in result["error"]
+        assert "not an empty result" in result["error"]
+        assert result["workspace_roots"]
+
+    def test_a_typod_relative_directory_does_not_name_a_path_the_user_never_typed(
+        self, search_file
+    ):
+        result = search_file("*.go", directory="no/such/folder")
+        assert "sidecar-package-dir" not in result["error"]
+
+    def test_a_directory_outside_the_sandbox_is_refused(self, search_file, tmp_path):
+        outside = tmp_path / "not-my-project"
+        outside.mkdir()
+        result = search_file("*.go", directory=str(outside))
+        assert result["status"] == "error"
+        assert "not in allowed paths" in result["error"]
+
+    def test_a_genuine_zero_says_where_it_looked(self, search_file, project):
+        root, _ = project
+        result = search_file("*.rs", directory=str(root))
+        assert result["count"] == 0
+        assert result["searched_paths"], result
+        assert str(root) in result["display_message"]
+
+    def test_a_genuine_zero_tells_the_model_not_to_generalise_it(
+        self, search_file, project
+    ):
+        root, _ = project
+        result = search_file("*.rs", directory=str(root))
+        assert "not zero on the machine" in result["suggestion"]
+
+
+# ============================================================================
+# 2. filesystem_tools.find_files — the flagship's search tool
+# ============================================================================
+
+
+def _filesystem_agent(root):
+    class MockAgent(FileSystemToolsMixin):
+        def __init__(self):
+            self._web_client = None
+            self._path_validator = _Sandbox(root)
+            self._fs_index = None
+            self._tools = {}
+            self._bookmarks = {}
+
+    registered = {}
+
+    def mock_tool(atomic=True):
+        def decorator(func):
+            registered[func.__name__] = func
+            return func
+
+        return decorator
+
+    with patch("gaia.agents.base.tools.tool", mock_tool):
+        agent = MockAgent()
+        agent.register_filesystem_tools()
+    return agent, registered
+
+
+class TestFindFilesLooksAtTheWorkspace:
+    def test_smart_scope_reaches_the_project_not_the_cwd(self, project):
+        root, elsewhere = project
+        agent, tools = _filesystem_agent(root)
+
+        out = tools["find_files"]("*.go")
+
+        assert "model.go" in out, out
+        assert str(elsewhere) not in out
+
+    def test_cwd_scope_means_the_workspace_not_the_process_directory(self, project):
+        root, _ = project
+        agent, tools = _filesystem_agent(root)
+
+        assert "model.go" in tools["find_files"]("*.go", scope="cwd")
+
+    def test_workspace_roots_prefers_the_sandbox_over_the_process_cwd(self, project):
+        root, elsewhere = project
+        agent, _ = _filesystem_agent(root)
+
+        roots = agent.workspace_roots()
+
+        assert roots == [str(root.resolve())]
+        assert str(elsewhere.resolve()) not in roots
+
+    def test_workspace_roots_falls_back_to_cwd_without_a_sandbox(self, project):
+        _, elsewhere = project
+
+        class Bare(FileSystemToolsMixin):
+            pass
+
+        # resolve(): on macOS tmp_path is /var/... while cwd reports /private/var.
+        assert Bare().workspace_roots() == [str(elsewhere.resolve())]
+
+
+# ============================================================================
+# 3. A named directory stays the whole scope — deep search included
+# ============================================================================
+
+
+class TestDeepSearchCannotEscapeANamedDirectory:
+    """The model's natural next move after a scoped miss is `deep_search=True`.
+
+    That used to fall through to a drive-wide sweep, so "no .rs files in
+    tui/internal" could come back with a match from somewhere else entirely —
+    the same wrong answer this fix exists to remove, one step softer.
+    """
+
+    def test_a_scoped_miss_does_not_sweep_the_drive(self, search_file, project):
+        root, _ = project
+        (root / "elsewhere.rs").write_text("fn main() {}\n")
+
+        result = search_file(
+            "*.rs", directory=str(root / "tui" / "internal"), deep_search=True
+        )
+
+        assert result["count"] == 0, result
+        assert not result["files"]
+
+    def test_a_scoped_miss_does_not_offer_deep_search_either(
+        self, search_file, project
+    ):
+        root, _ = project
+        result = search_file("*.rs", directory=str(root), deep_search=False)
+        assert result["deep_search_available"] is False
+
+    def test_an_unscoped_miss_still_offers_deep_search(self, search_file):
+        result = search_file("*.rs")
+        assert result["deep_search_available"] is True
+
+
+# ============================================================================
+# 4. Roots: most specific first, and only the project walked exhaustively
+# ============================================================================
+
+
+class TestRootOrderAndDepth:
+    def test_roots_are_ordered_most_specific_first(self, tmp_path):
+        from gaia.agents.tools.search_scope import search_roots
+
+        shallow = tmp_path / "a"
+        deep = tmp_path / "a" / "b" / "c"
+        deep.mkdir(parents=True)
+
+        class Host:
+            path_validator = _Sandbox(shallow, deep)
+
+        assert search_roots(Host()) == [deep.resolve(), shallow.resolve()]
+
+    def test_a_relative_directory_resolves_against_the_deepest_match(
+        self, tmp_path, monkeypatch
+    ):
+        """Both roots contain `pkg/`; the user meant the one they are in."""
+        outer = tmp_path / "outer"
+        inner = tmp_path / "outer" / "inner"
+        (outer / "pkg").mkdir(parents=True)
+        (inner / "pkg").mkdir(parents=True)
+        (outer / "pkg" / "outer.go").write_text("package pkg\n")
+        (inner / "pkg" / "inner.go").write_text("package pkg\n")
+
+        mixin = FileSearchToolsMixin()
+        mixin.path_validator = _Sandbox(outer, inner)
+        saved = dict(_TOOL_REGISTRY)
+        try:
+            mixin.register_file_search_tools()
+            fn = _TOOL_REGISTRY["search_file"]["function"]
+            result = fn("*.go", directory="pkg")
+        finally:
+            _TOOL_REGISTRY.clear()
+            _TOOL_REGISTRY.update(saved)
+
+        assert [Path(f).name for f in result["files"]] == ["inner.go"]
+
+    def test_only_the_primary_root_is_walked_exhaustively(self, tmp_path):
+        """An accumulated approval must not be traversed in full on every miss."""
+        from gaia.agents.tools.search_scope import (
+            DEEP_ROOT_DEPTH,
+            SHALLOW_ROOT_DEPTH,
+            root_depth,
+        )
+
+        project = tmp_path / "project" / "nested"
+        documents = tmp_path / "Documents"
+        project.mkdir(parents=True)
+        documents.mkdir()
+        roots = [project.resolve(), documents.resolve()]
+
+        assert root_depth(roots[0], roots) == DEEP_ROOT_DEPTH
+        assert root_depth(roots[1], roots) == SHALLOW_ROOT_DEPTH
+
+    def test_a_named_directory_is_always_walked_exhaustively(
+        self, search_file, project
+    ):
+        """Scope came from the user, so depth is not a guess."""
+        root, _ = project
+        deep = root / "tui" / "internal" / "a" / "b" / "c" / "d" / "e" / "f"
+        deep.mkdir(parents=True)
+        (deep / "buried.go").write_text("package f\n")
+
+        result = search_file("buried", directory=str(root / "tui"))
+
+        assert [Path(f).name for f in result["files"]] == ["buried.go"]
+
+
+# ============================================================================
+# 5. The index path must agree with the walk path
+# ============================================================================
+
+
+class TestTheIndexScopeUsesTheSameRoots:
+    """#3671 added an index-hit scope filter that resolved `cwd` to Path.cwd().
+
+    Left that way, a hit the walk correctly found under the workspace would be
+    filtered back out because it is not under the directory the sidecar was
+    spawned in — the two halves of one search disagreeing.
+    """
+
+    def test_cwd_scope_resolves_to_the_workspace_not_the_process_directory(
+        self, project
+    ):
+        from gaia.agents.tools.filesystem_tools import _scope_roots
+
+        root, elsewhere = project
+        agent, _ = _filesystem_agent(root)
+
+        roots = _scope_roots("cwd", agent)
+
+        assert roots == [root.resolve()]
+        assert elsewhere.resolve() not in roots
+
+    def test_a_workspace_file_passes_the_index_scope_filter(self, project):
+        from gaia.agents.tools.filesystem_tools import (
+            _path_in_roots,
+            _scope_roots,
+        )
+
+        root, _ = project
+        agent, _ = _filesystem_agent(root)
+
+        hit = str(root / "tui" / "internal" / "model.go")
+        assert _path_in_roots(hit, _scope_roots("cwd", agent)) is True
+
+    def test_an_outside_file_still_fails_it(self, project):
+        from gaia.agents.tools.filesystem_tools import (
+            _path_in_roots,
+            _scope_roots,
+        )
+
+        root, elsewhere = project
+        agent, _ = _filesystem_agent(root)
+
+        outside = str(elsewhere / "stray.go")
+        assert _path_in_roots(outside, _scope_roots("cwd", agent)) is False
+
+    def test_unbounded_scopes_are_still_unbounded(self, project):
+        from gaia.agents.tools.filesystem_tools import _scope_roots
+
+        root, _ = project
+        agent, _ = _filesystem_agent(root)
+
+        assert _scope_roots("smart", agent) == []
+        assert _scope_roots("everywhere", agent) == []
+
+    def test_an_explicit_path_scope_is_unchanged(self, project):
+        from gaia.agents.tools.filesystem_tools import _scope_roots
+
+        root, _ = project
+        agent, _ = _filesystem_agent(root)
+        named = root / "tui"
+
+        assert _scope_roots(str(named), agent) == [named.resolve()]


### PR DESCRIPTION
Ask the agent how many Go files are under `tui/internal` and it answers **"Zero."** There are 203. No error, no hedge, delivered as fact about the user's own codebase — and every "find / list / count files" question about a real project has the same answer waiting.

Fixes #3576

## Test plan

- [x] `pytest tests/unit/test_file_search_scope.py` (25 passed) — builds a project, points the agent's sandbox at it, and searches **from a working directory that is somewhere else**, which is the condition the bug needs. The original 12 all fail on `main`.
- [x] `pytest tests/unit/test_file_tools.py tests/unit/test_filesystem_tools_mixin.py tests/unit/test_filesystem_index.py` (266 passed)
- [x] `black`, `flake8`, `isort`, `python util/lint.py --pylint`, `python util/check_workflow_triggers.py`
- [x] Live TUI on Fireworks-via-Lemonade — the issue's exact question, transcript below.

<details>
<summary>🔍 Live TUI evidence</summary>

```
▶ You: How many Go files are in the tui/internal directory?

  211 Go files in  /Users/kalin/Work/gaia/tui/internal/ .

  There's also a worktree copy at  .claude/worktrees/gaia-bug-fixes-1f770b/tui/internal/
  with 221 files (the bug-fixes branch has added some).

  10.3s · ttft 4.8s · 3 steps · 3 tools
```

Independently:

```
$ find /Users/kalin/Work/gaia/tui/internal -name "*.go" | wc -l
     211
$ find .../gaia-bug-fixes-1f770b/tui/internal -name "*.go" | wc -l
     221
```

Both exact — and it distinguishes the two checkouts rather than merging them. On `main` this same question answers "Zero."
</details>

<details>
<summary>🔍 Technical details</summary>

Both search tools rooted at `Path.cwd()`. For a daemon-spawned sidecar that is its own package directory (`hub/agents/gaia/python`), so the user's project was never in the search set. `.go` is already in the default extension list — the search was well-formed, ran successfully, and looked in the wrong place.

- **Roots come from the sandbox.** `gaia/agents/tools/search_scope.py` is the one helper both mixins call: `PathValidator.allowed_paths`, **most specific first**, falling back to the working directory only when no validator is attached at all.
- **Ordering is load-bearing.** Sorted by `(-len(parts), str)`, because that order decides which root a relative `directory` resolves against — the deepest match is the one the user meant.
- **Only the project is walked exhaustively.** `PathValidator._load_persisted_paths` merges every path the user has ever approved, so the sandbox grows with use. The most specific root gets depth 999; the rest get the cap of 5 the home folders always had, or a well-used machine gets slower the longer it is used.
- **`search_file` gains `directory`**, and it is the WHOLE scope — `deep_search` cannot widen it, because the `deep_search` docstring points the model there right after a scoped miss.
- **A zero says where it looked.** `searched_paths`, the roots named in `display_message`, and a `suggestion` telling the model that zero here means zero under those paths. A named directory that does not exist is `status: "error"`; a relative one matching no root says so and lists the roots, rather than reporting access denied for a path the user never typed.

**Interaction with #3671**, which merged while this was open: it added an index-hit scope filter whose `cwd` resolved to `Path.cwd()`. Left alone, a hit the walk correctly found under the workspace would be filtered back out — the two halves of one search disagreeing. `_scope_roots` now takes the host and uses the same roots, with five tests pinning the agreement.

The two spec pages that described the old rooting and signature are updated. The broader "returning nothing should not always be `success`" question (#3575) is untouched.