### PR TITLE
fix(tools): describe the edit and write tools by what agents actually edit

### DIFF
--- a/src/gaia/agents/tools/file_io_tools.py
+++ b/src/gaia/agents/tools/file_io_tools.py
@@ -802,11 +802,18 @@ class FileIOToolsMixin:
             create_dirs: bool = True,
             project_dir: Optional[str] = None,
         ) -> Dict[str, Any]:
-            """Write content to any file (TypeScript, JavaScript, JSON, etc.) without syntax validation.
+            """Create a text file, or replace one wholesale, without validation.
 
-            Use this tool for non-Python files like .tsx, .ts, .js, .json, etc.
-            Includes security guardrails: path validation, blocked directory enforcement,
-            sensitive file protection, size limits, backup creation, and audit logging.
+            Any text file: documentation (.md, .mdx), source (.py, .go, .ts,
+            .js), configuration (.yml, .json, .toml), plain text.
+
+            Prefer edit_file when changing PART of a file that already exists —
+            this replaces the whole thing. Use write_python_file instead only
+            when you want the write REFUSED if the content is not valid Python.
+
+            Includes security guardrails: path validation, blocked directory
+            enforcement, sensitive file protection, size limits, backup
+            creation, and audit logging.
 
             Args:
                 file_path: Path where to write the file
@@ -896,11 +903,19 @@ class FileIOToolsMixin:
             new_content: str,
             project_dir: Optional[str] = None,
         ) -> Dict[str, Any]:
-            """Edit any file by replacing old content with new content (no syntax validation).
+            """Change part of a text file in place, without rewriting the rest.
 
-            Use this tool for non-Python files like .tsx, .ts, .js, .json, etc.
-            Includes security guardrails: path validation, blocked directory enforcement,
-            sensitive file protection, backup creation, and audit logging.
+            The default way to edit anything: documentation (.md, .mdx, .rst),
+            source (.py, .go, .ts, .js, .rs, .cpp), configuration (.yml, .json,
+            .toml), plain text. Prefer it over rewriting a file with write_file,
+            and over shelling out to sed or a here-doc.
+
+            Use edit_python_file instead only when you want the edit REFUSED if
+            it would break Python syntax.
+
+            Includes security guardrails: path validation, blocked directory
+            enforcement, sensitive file protection, backup creation, and audit
+            logging.
 
             old_content must match exactly one location. Zero or several matches
             are errors that carry the file's current content, so a retry does not

--- a/tests/unit/test_file_editing_prompt.py
+++ b/tests/unit/test_file_editing_prompt.py
@@ -56,3 +56,63 @@ class TestAutoDiscovery:
         from gaia.agents.tools.file_io_tools import FileIOToolsMixin as M
 
         assert hasattr(M, "get_file_editing_system_prompt")
+
+
+class TestTheToolDescribesWhatItIsActuallyFor:
+    """``edit_file``'s description named ~2% of what agents really edit.
+
+    It read "use this tool for non-Python files like .tsx, .ts, .js, .json" —
+    9 of 461 edited files in the session corpus were among those, and the two
+    biggest groups, Markdown (207) and Python (124), were unnamed and
+    explicitly excluded respectively. A model holding a `.md` or `.go` file had
+    a reasonable basis to decide the tool was not for its situation (#3601).
+    """
+
+    @staticmethod
+    def _description(tool_name: str = "edit_file") -> str:
+        from gaia.agents.base.tools import _TOOL_REGISTRY
+
+        saved = dict(_TOOL_REGISTRY)
+        try:
+            _Bare().register_file_io_tools()
+            entry = _TOOL_REGISTRY[tool_name]
+            return (entry.get("description") or entry["function"].__doc__ or "").lower()
+        finally:
+            _TOOL_REGISTRY.clear()
+            _TOOL_REGISTRY.update(saved)
+
+    def test_it_names_the_file_types_agents_actually_edit(self):
+        text = self._description()
+        # The corpus's four biggest groups, none of which it used to mention.
+        for extension in (".md", ".py", ".yml", ".go"):
+            assert extension in text, f"{extension} unmentioned: {text}"
+
+    def test_it_does_not_exclude_python(self):
+        assert "non-python" not in self._description()
+
+    def test_it_says_which_tool_to_use_instead_when_it_defers(self):
+        """Naming only what NOT to use leaves a model with nowhere to go."""
+        text = self._description()
+        assert "edit_python_file" in text
+
+    def test_it_steers_away_from_rewriting_and_shelling_out(self):
+        text = self._description()
+        assert "write_file" in text
+        assert "sed" in text
+
+    def test_write_file_does_not_carry_the_wording_this_removed(self):
+        """The sibling edit_file now points the model at (#3601 review).
+
+        "Prefer it over rewriting a file with write_file" routes the model to a
+        tool that used to repeat the same 2%-of-edits claim.
+        """
+        text = self._description("write_file")
+        assert "non-python" not in text
+        for extension in (".md", ".py", ".yml", ".go"):
+            assert extension in text, f"{extension} unmentioned: {text}"
+
+    def test_write_file_says_when_to_use_edit_file_instead(self):
+        assert "edit_file" in self._description("write_file")
+
+    def test_write_file_says_which_tool_validates_python(self):
+        assert "write_python_file" in self._description("write_file")


### PR DESCRIPTION
`edit_file` told the model *"use this tool for non-Python files like `.tsx`, `.ts`, `.js`, `.json`"*. Across ~300 real sessions, **9 of 461 edited files were among those — 2%**. The two biggest groups went unmentioned and excluded respectively: Markdown (207 files) and Python (124). A model holding a `.md` or a `.go` file and reading that description had a reasonable basis to decide the tool was not for its situation, and reached for the shell instead.

Wording only — no behaviour change.

Fixes #3601

## Test plan

- [x] `pytest tests/unit/test_file_editing_prompt.py` — new cases pin the description against the corpus's real file types, that it no longer excludes Python, that it names the tool to use instead when it defers, and that it steers away from `write_file` and `sed`. They pin the *claims*, not the phrasing, so the wording stays tunable.
- [x] `pytest tests/unit/agents/test_file_edit_semantics.py tests/unit/test_file_write_guardrails.py tests/unit/test_tool_loader_token_budget.py` (207 passed) — the last one matters: `edit_file` is inside the always-on CORE tool floor, and the new text fits.
- [ ] `gaia eval agent --category tool_selection` — **not run.** A tool docstring is an eval-required surface per CLAUDE.md, and this change exists precisely to move tool *selection*, so it is the one that most deserves a before/after. It needs `ANTHROPIC_API_KEY` for the judge and a quiet Lemonade slot; neither was available here. Flagging rather than claiming it.

<details>
<summary>🔍 Technical details</summary>

The corpus breakdown from #3601 — edits by file type, and whether the old description named them:

| type | edits | advertised |
|---|--:|---|
| `.md` | 207 | no |
| `.py` | 124 | explicitly excluded |
| `.yml` | 46 | no |
| `.mdx` | 33 | no |
| `.go` | 27 | no |
| `.ts` | 7 | **yes** |

New text states the positive case (documentation, source, configuration, plain text), names the dominant extensions, and makes the Python split actionable: *"Use `edit_python_file` instead only when you want the edit REFUSED if it would break Python syntax."*

The issue also notes `run_shell_command` sits at position 11 of 67 while `edit_file` sits at 33, and that ordering is not free for a small local model. That is a separate change to tool ordering and is not touched here.

Three prompt-golden rows (12–14) fail in my environment on plain `main` as well — they turn on optional dependencies, not on this change.
</details>