### PR TITLE
fix: apply reviewed maintenance repairs for #3375

### DIFF
--- a/src/gaia/eval/runner.py
+++ b/src/gaia/eval/runner.py
@@ -1097,7 +1097,10 @@ def run_scenario_subprocess(
                     "status": "ERRORED",
                     "overall_score": None,
                     "turns": [],
-                    "error": f"JSON parse error: {e}. stdout: {proc.stdout[:300]}",
+                    "error": (
+                        f"JSON parse error: {e}. stdout: {proc.stdout[:300]}"
+                        f"\nstderr: {proc.stderr[:300]}"
+                    ),
                     "elapsed_s": elapsed,
                     "cost_estimate": {"turns": 0, "estimated_usd": 0.0},
                 }
@@ -1110,6 +1113,7 @@ def run_scenario_subprocess(
             "status": "TIMEOUT",
             "overall_score": None,
             "turns": [],
+            "error": f"subprocess exceeded {timeout}s timeout",
             "elapsed_s": elapsed,
             "cost_estimate": {"turns": 0, "estimated_usd": 0.0},
         }

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1177,6 +1177,12 @@ class TestRunScenarioSubprocess:
         assert "on-stderr" in result["error"]
         assert "on-stdout" in result["error"]
 
+    def test_malformed_json_includes_stderr_diagnostic(self, mocker):
+        result = self._run(mocker, "{broken", stderr="Output stream interrupted")
+        assert result["status"] == "ERRORED"
+        assert "{broken" in result["error"]
+        assert "Output stream interrupted" in result["error"]
+
     def test_nonzero_exit_error_never_empty(self, mocker):
         """A silent exit must still say something — an empty string explains nothing."""
         result = self._run(mocker, "", returncode=3, stderr="")
@@ -2755,6 +2761,8 @@ class TestRunner:
         assert result["status"] == "TIMEOUT"
         assert result["overall_score"] is None
         assert result["scenario_id"] == "timeout_test"
+        assert "timeout" in result["error"]
+        assert "30s" in result["error"]
         assert "elapsed_s" in result
         assert isinstance(result["elapsed_s"], float)
 


### PR DESCRIPTION
Recovers #3689, which GitHub auto-closed the moment #3375 merged — its base was that feature branch, not `main`, so closing it silently dropped reviewed work.

The diff is byte-identical to the reviewed original; only the base moved to `main`. Verified the content is not already on `main` (the patch applies cleanly).

## Test plan

- [ ] CI green on this PR
- [ ] Confirm the change is the one reviewed on #3689