### PR TITLE
fix: apply reviewed maintenance repairs for #3617

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -31,10 +31,10 @@ A fully configured dev container for GAIA with Python 3.12, Claude Code, and AMD
 ## Running GAIA
 
 ```bash
-# The image does not ship Lemonade. Either install it in the container
-# with `gaia init`, or point LEMONADE_BASE_URL at a server on the host
-# (see "Lemonade Server not starting" below — that is the NPU path).
-gaia init
+# Start Lemonade on the host, then connect from this container.
+# The image does not ship Lemonade or a systemd service manager.
+# See "Lemonade Server not starting" below for host access and NPU setup.
+export LEMONADE_BASE_URL=http://host.docker.internal:13305/api/v1
 
 # Test LLM connectivity
 gaia llm "Hello"

--- a/.github/workflows/test_vscode.yml
+++ b/.github/workflows/test_vscode.yml
@@ -10,7 +10,6 @@ on:
       - 'src/vscode/**'
       - '.github/workflows/test_vscode.yml'
   pull_request:
-    branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/vscode/**'

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -50,7 +50,7 @@ How the server starts depends on the install, and there is no cross-platform
 `serve` command — Lemonade removed the `lemonade-server` CLI in 10.7. Windows
 starts `LemonadeServer.exe` from the tray icon or the Start menu; Linux runs the
 `lemond` systemd unit; macOS installs a LaunchDaemon. On Windows you can also
-start one from the repo:
+start one from the repo (this restarts the server and frees its port first):
 
 ```powershell
 .\installer\scripts\start-lemonade.ps1 -Port 13305 -NoModel

--- a/cpp/src/lemonade_client.cpp
+++ b/cpp/src/lemonade_client.cpp
@@ -321,7 +321,7 @@ std::string LemonadeClient::chatCompletions(const json& requestBody, int timeout
                         std::to_string(nPrompt) + " tokens but server n_ctx=" +
                         std::to_string(nCtx) + ".\n" +
                         "  Restart Lemonade with a larger context:\n" +
-                        "    set LEMONADE_CTX_SIZE=32768 before starting the server\n" +
+                        "    set LEMONADE_CTX_SIZE=32768 in the environment before starting the server\n" +
                         "  or via the helper script:\n" +
                         "    .\\installer\\scripts\\start-lemonade.ps1 -CtxSize 32768";
                 } else if (!msg.empty()) {
@@ -400,7 +400,7 @@ std::string LemonadeClient::chatCompletionsStreaming(const json& requestBody,
                             std::to_string(nPrompt) + " tokens but server n_ctx=" +
                             std::to_string(nCtx) + ".\n" +
                             "  Restart Lemonade with a larger context:\n" +
-                            "    set LEMONADE_CTX_SIZE=32768 before starting the server\n" +
+                            "    set LEMONADE_CTX_SIZE=32768 in the environment before starting the server\n" +
                             "  or via the helper script:\n" +
                             "    .\\installer\\scripts\\start-lemonade.ps1 -CtxSize 32768";
                     } else if (!msg.empty()) {

--- a/installer/scripts/start-lemonade.ps1
+++ b/installer/scripts/start-lemonade.ps1
@@ -19,7 +19,7 @@
     Server port (default: 13305, Lemonade's default since v10.1)
 
 .PARAMETER CtxSize
-    Context size (default: 8192)
+    Context size (default: 32768)
 
 .PARAMETER InitWaitTime
     Seconds to wait after loading model (default: 10)

--- a/src/gaia/apps/webui/src/components/ConnectionBanner.tsx
+++ b/src/gaia/apps/webui/src/components/ConnectionBanner.tsx
@@ -372,13 +372,10 @@ export function ConnectionBanner({ onRetry }: { onRetry?: () => void }) {
                         >
                             Lemonade
                         </a>
-                        , set ctx&#8209;size to {MIN_CONTEXT_SIZE.toLocaleString()}, or
-                        restart with:{' '}
-                        <code>
-                            {systemStatus?.start_command
-                                ? systemStatus.start_command
-                                : `LEMONADE_CTX_SIZE=${MIN_CONTEXT_SIZE} (see Settings)`}
-                        </code>
+                        , set ctx&#8209;size to {MIN_CONTEXT_SIZE.toLocaleString()} and reload the model.{' '}
+                        {systemStatus?.start_command
+                            ? <>Restart command: <code>{systemStatus.start_command}</code></>
+                            : systemStatus?.start_instruction}
                     </span>
                 </div>
                 {onRetry && (

--- a/src/gaia/apps/webui/src/components/__tests__/ConnectionBanner.test.tsx
+++ b/src/gaia/apps/webui/src/components/__tests__/ConnectionBanner.test.tsx
@@ -1,0 +1,38 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { ConnectionBanner } from '../ConnectionBanner';
+import { useChatStore } from '../../stores/chatStore';
+import type { SystemStatus } from '../../types';
+
+beforeEach(() => {
+    useChatStore.setState({ backendConnected: true, currentSessionId: null, messages: [] });
+});
+
+describe('context-size remediation comes from the backend', () => {
+    it.each([
+        '/usr/bin/lemonade-server serve --ctx-size 32768',
+        'LEMONADE_CTX_SIZE=32768 /usr/bin/lemond',
+    ])('prints %s verbatim without appending flags', (command) => {
+        useChatStore.setState({ systemStatus: {
+            lemonade_running: true, model_loaded: 'Gemma-4-E4B-it-GGUF', model_downloaded: true, expected_model_loaded: true,
+            context_size_sufficient: false, model_context_size: 8192, start_command: command,
+        } as SystemStatus });
+        const { container } = render(<ConnectionBanner />);
+        expect(container.querySelector('code')?.textContent).toBe(command);
+    });
+
+    it('prints model-reload instructions when there is no restart command', () => {
+        const instruction = 'Set the context size to 32768 and reload the model.';
+        useChatStore.setState({ systemStatus: {
+            lemonade_running: true, model_loaded: 'Gemma-4-E4B-it-GGUF', model_downloaded: true, expected_model_loaded: true,
+            context_size_sufficient: false, model_context_size: 8192,
+            start_command: null, start_instruction: instruction,
+        } as SystemStatus });
+        const { container } = render(<ConnectionBanner />);
+        expect(screen.getByText(instruction, { exact: false })).toBeInTheDocument();
+        expect(container.querySelector('code')).toBeNull();
+    });
+});

--- a/src/gaia/llm/lemonade_launcher.py
+++ b/src/gaia/llm/lemonade_launcher.py
@@ -327,7 +327,8 @@ def describe_start_hint(ctx_size: Optional[int] = None) -> StartHint:
     The single source of user-facing "here's how to start it" advice. It
     never names a command that does not exist on the host: on platforms
     started from a GUI (Windows tray, macOS app) it returns prose with
-    ``command=None`` rather than guessing a shell command, and the legacy
+    ``command=None`` rather than guessing a shell command. Service-managed
+    context changes also return manual configuration steps. The legacy
     ``lemonade-server serve`` CLI is only ever named when a legacy install
     was actually resolved.
     """
@@ -346,6 +347,15 @@ def describe_start_hint(ctx_size: Optional[int] = None) -> StartHint:
                 )
             )
         spec = build_start_command(tooling, ctx_size)
+        if spec.argv[0] == "systemctl" and ctx_size is not None:
+            return StartHint(
+                instruction=(
+                    "If Lemonade is stopped, run `systemctl --user start lemond`. "
+                    f"In Lemonade's model settings, set the context size to {ctx_size} "
+                    "and reload the model. Starting an already running service "
+                    "does not change its context size."
+                )
+            )
         command = _render_command(spec.argv, spec.env)
         if system == "Darwin":
             # The app is the normal macOS path; the daemon is the CLI way.

--- a/src/gaia/ui/models.py
+++ b/src/gaia/ui/models.py
@@ -63,8 +63,8 @@ class SystemStatus(BaseModel):
     # this machine has a modern daemon, a legacy CLI, or a tray app, and a
     # second copy of the answer is how `lemonade-server serve` survived in the
     # banner long after it stopped existing. ``start_command`` is None on hosts
-    # started from a GUI — there is no shell command to give, and inventing one
-    # is the bug.
+    # requiring GUI/manual configuration, including service context changes.
+    # In those cases start_instruction carries the necessary steps.
     start_instruction: Optional[str] = None
     start_command: Optional[str] = None
     # Extended Lemonade info (settings modal)

--- a/tests/unit/test_lemonade_launcher.py
+++ b/tests/unit/test_lemonade_launcher.py
@@ -535,7 +535,10 @@ def test_start_hint_modern_linux_names_systemctl_not_lemonade_server(mocker):
 
     hint = describe_start_hint(ctx_size=32768)
 
-    assert hint.command == "LEMONADE_CTX_SIZE=32768 systemctl --user start lemond"
+    assert hint.command is None
+    assert "systemctl --user start lemond" in hint.instruction
+    assert "32768" in hint.instruction
+    assert "reload the model" in hint.instruction
     assert "lemonade-server" not in hint.instruction
     # systemctl returns immediately — callers must not append " &".
     assert hint.foreground is False
@@ -729,6 +732,7 @@ def test_start_hint_instruction_embeds_the_command_verbatim(mocker):
         return_value=LemonadeTooling(
             found=True,
             kind="modern",
+            source="env",
             client_path="/usr/bin/lemonade",
             server_launcher="/usr/bin/lemond",
         ),

--- a/tests/unit/test_ui_gpu_detection.py
+++ b/tests/unit/test_ui_gpu_detection.py
@@ -160,6 +160,49 @@ def test_gpu_display_info_non_numeric_vram_is_undetected_not_zero(caplog):
 # ── /api/system/status ───────────────────────────────────────────────────
 
 
+@pytest.mark.parametrize(
+    "kind,source", [("legacy", "probe"), ("modern", "env"), ("modern", "probe")]
+)
+@pytest.mark.allow_network
+def test_system_status_renders_the_complete_context_remedy(
+    kind, source, stub_lemonade, monkeypatch
+):
+    from gaia.llm.lemonade_launcher import LemonadeTooling
+
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr(
+        "gaia.llm.lemonade_launcher.resolve_lemonade",
+        lambda: LemonadeTooling(
+            found=True,
+            kind=kind,
+            source=source,
+            client_path="/usr/bin/lemonade",
+            server_launcher=(
+                "/usr/bin/lemonade-server" if kind == "legacy" else "/usr/bin/lemond"
+            ),
+        ),
+    )
+    stub_lemonade(
+        {
+            "/health": {"model_loaded": "Gemma-4-E4B-it-GGUF"},
+            "/models": {"data": []},
+            "/system-info": {"devices": {}},
+        }
+    )
+    body = TestClient(create_app(db_path=":memory:")).get("/api/system/status").json()
+
+    if kind == "legacy":
+        assert (
+            body["start_command"] == "/usr/bin/lemonade-server serve --ctx-size 32768"
+        )
+    elif source == "env":
+        assert body["start_command"] == "LEMONADE_CTX_SIZE=32768 /usr/bin/lemond"
+    else:
+        assert body["start_command"] is None
+        assert "32768" in body["start_instruction"]
+        assert "reload the model" in body["start_instruction"]
+
+
 @pytest.mark.parametrize("fixture,expected_name,expected_vram", REAL_PAYLOADS)
 @pytest.mark.allow_network
 def test_system_status_reports_gpu(


### PR DESCRIPTION
Recovers #3679, which GitHub auto-closed the moment #3617 merged — its base was that feature branch, not `main`, so closing it silently dropped reviewed work.

The diff is byte-identical to the reviewed original; only the base moved to `main`. Verified the content is not already on `main` (the patch applies cleanly).

## Test plan

- [ ] CI green on this PR
- [ ] Confirm the change is the one reviewed on #3679