### PR TITLE
fix: apply reviewed maintenance repairs for #3615

### DIFF
--- a/.github/workflows/test_embeddings.yml
+++ b/.github/workflows/test_embeddings.yml
@@ -13,6 +13,8 @@ on:
       - 'src/gaia/rag/**'
       - 'src/gaia/llm/**'
       - 'tests/test_lemonade_embeddings.py'
+      - 'tests/integration/test_lemonade_health_schema.py'
+      - 'tests/conftest.py'
       - 'setup.py'
       - '.github/workflows/test_embeddings.yml'
   pull_request:
@@ -24,6 +26,8 @@ on:
       - 'src/gaia/rag/**'
       - 'src/gaia/llm/**'
       - 'tests/test_lemonade_embeddings.py'
+      - 'tests/integration/test_lemonade_health_schema.py'
+      - 'tests/conftest.py'
       - 'setup.py'
       - '.github/workflows/test_embeddings.yml'
   merge_group:
@@ -102,6 +106,10 @@ jobs:
             # Use --tb=long for full traceback, -rA for all test output summary
             pytest tests/test_lemonade_embeddings.py -v -s --tb=long -rA --log-cli-level=DEBUG
             if ($LASTEXITCODE -ne 0) { throw "Tests failed with exit code $LASTEXITCODE" }
+
+            Write-Host "`n=== Checking live Lemonade health schema ==="
+            pytest tests/integration/test_lemonade_health_schema.py -v --tb=long -rA
+            if ($LASTEXITCODE -ne 0) { throw "Health schema tests failed with exit code $LASTEXITCODE" }
         } finally {
             if ($env:LEMONADE_PROCESS_ID) {
                 Write-Host "`n=== Stopping Lemonade Server (PID $env:LEMONADE_PROCESS_ID) ==="

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,7 +176,7 @@ def lemonade_available():
     Check if Lemonade server is available and healthy.
 
     This is a session-scoped fixture that checks once at the start of the
-    test session whether Lemonade server is running on localhost:13305.
+    test session whether the configured Lemonade server is responding.
 
     Returns:
         bool: True if Lemonade server is available and responding to health checks
@@ -184,16 +184,22 @@ def lemonade_available():
     # Authenticated servers 401 an unauthenticated probe, which reads as "not
     # running" and silently skips every integration test that asks for one.
     from gaia.llm.lemonade_client import (
+        _get_lemonade_config,
         lemonade_auth_headers,
         resolve_lemonade_api_key,
     )
 
     try:
         response = requests.get(
-            "http://localhost:13305/api/v1/health",
+            f"{_get_lemonade_config()[2].rstrip('/')}/health",
             timeout=5,
             headers=lemonade_auth_headers(resolve_lemonade_api_key()),
         )
+        if response.status_code in (401, 403):
+            pytest.fail(
+                "Lemonade is reachable but rejected authentication. Configure "
+                "LEMONADE_API_KEY for the server selected by LEMONADE_BASE_URL."
+            )
         return response.status_code == 200
     except (requests.RequestException, requests.ConnectionError):
         return False

--- a/tests/integration/test_lemonade_health_schema.py
+++ b/tests/integration/test_lemonade_health_schema.py
@@ -19,12 +19,12 @@ The pre-existing live test
 (``tests/test_lemonade_client.py::test_integration_health_check_914_format``)
 cannot catch that: every assertion in it sits inside an ``if field in response``
 guard, so a rename prints a warning and passes. This file asserts unconditionally,
-and *skips loudly* rather than passing vacuously when there is nothing to inspect.
+and explicitly loads a model before inspecting the loaded-entry schema.
 """
 
 import pytest
 
-from gaia.llm.lemonade_client import LemonadeClient
+from gaia.llm.lemonade_client import DEFAULT_MODEL_NAME, LemonadeClient
 
 pytestmark = pytest.mark.integration
 
@@ -51,15 +51,17 @@ def test_all_models_loaded_is_present_and_a_list(health):
     assert isinstance(health["all_models_loaded"], list), health["all_models_loaded"]
 
 
-def test_loaded_model_entry_carries_the_fields_callers_read(health):
+def test_loaded_model_entry_carries_the_fields_callers_read(require_lemonade):
     """A loaded entry must expose model identity and its context size.
 
     ``_ensure_model_loaded`` matches on ``id`` *or* ``model_name``, so either is
     acceptable -- but at least one must be there.
     """
+    client = LemonadeClient()
+    client.load_model(DEFAULT_MODEL_NAME)
+    health = client.health_check()
     models = health["all_models_loaded"]
-    if not models:
-        pytest.skip("no model resident -- load one to exercise the entry schema")
+    assert models, "Lemonade reported no loaded model after a successful load"
 
     entry = models[0]
     assert "id" in entry or "model_name" in entry, (

--- a/tests/unit/test_lemonade_availability_probe.py
+++ b/tests/unit/test_lemonade_availability_probe.py
@@ -1,0 +1,44 @@
+# Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+"""The integration probe must use the same server and auth as real clients."""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+
+def _probe():
+    path = Path(__file__).parents[1] / "conftest.py"
+    spec = importlib.util.spec_from_file_location("availability_conftest", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.lemonade_available.__wrapped__()
+
+
+def test_probe_uses_configured_url_and_auth(monkeypatch):
+    monkeypatch.setenv("LEMONADE_BASE_URL", "http://127.0.0.1:19999/")
+    monkeypatch.setenv("LEMONADE_API_KEY", "fixture-key")
+    get = Mock(return_value=Mock(status_code=200))
+    monkeypatch.setattr(requests, "get", get)
+
+    assert _probe() is True
+    get.assert_called_once_with(
+        "http://127.0.0.1:19999/api/v1/health",
+        timeout=5,
+        headers={"Authorization": "Bearer fixture-key"},
+    )
+
+
+@pytest.mark.parametrize("status", [401, 403])
+def test_rejected_auth_is_not_misreported_as_offline(monkeypatch, status):
+    monkeypatch.setattr(requests, "get", Mock(return_value=Mock(status_code=status)))
+    with pytest.raises(pytest.fail.Exception, match="rejected authentication"):
+        _probe()
+
+
+def test_unreachable_server_is_unavailable(monkeypatch):
+    monkeypatch.setattr(requests, "get", Mock(side_effect=requests.ConnectionError))
+    assert _probe() is False


### PR DESCRIPTION
Recovers #3680, which GitHub auto-closed the moment #3615 merged — its base was that feature branch, not `main`, so closing it silently dropped reviewed work.

The diff is byte-identical to the reviewed original; only the base moved to `main`. Verified the content is not already on `main` (the patch applies cleanly).

## Test plan

- [ ] CI green on this PR
- [ ] Confirm the change is the one reviewed on #3680