### PR TITLE
ci(vscode): drop the base-branch filter that now fails the lint gate

### DIFF
--- a/.github/workflows/test_vscode.yml
+++ b/.github/workflows/test_vscode.yml
@@ -10,7 +10,6 @@ on:
       - 'src/vscode/**'
       - '.github/workflows/test_vscode.yml'
   pull_request:
-    branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/vscode/**'


### PR DESCRIPTION
Every PR is currently failing `Run Code Quality Checks` on `main`.

#3372 added a lint gate that rejects `on.pull_request.branches` — it filters on the PR's *base* branch, so it silently skips CI on stacked PRs. `test_vscode.yml` already had that filter, so the gate started failing on `main` the moment #3372 merged. This removes it.

The workflow is still scoped to VS Code changes by the `paths:` list it already had, and the `push` trigger's `branches: [ main ]` is untouched — a push filter names the branch being pushed to, not a PR base, and the gate correctly allows it.

## Test plan

- [x] `python util/check_workflow_triggers.py` → `[OK] 73 workflow pull_request triggers validated.`
- [ ] `Run Code Quality Checks` green on this PR