### PR TITLE
fix(llm,vlm): keep the configured Lemonade URL instead of rebuilding it

### DIFF
--- a/.claude/skills/lemonade-client-patterns/SKILL.md
+++ b/.claude/skills/lemonade-client-patterns/SKILL.md
@@ -24,7 +24,14 @@ grep -n "requests\.post\|requests\.get\|OpenAI(" src/gaia/llm/lemonade_client.py
 ```
 
 ### Factory must mirror `__init__`
-`create_lemonade_client()` at the bottom of `lemonade_client.py` is a convenience factory. When adding a new `LemonadeClient.__init__` parameter, update the factory to accept and forward it — callers that use the factory (like CLI entry points) won't pick up the new param otherwise.
+`create_lemonade_client()` at the bottom of `lemonade_client.py` is a convenience factory. When adding a new `LemonadeClient.__init__` parameter, update the factory to accept and forward it, or callers that use the factory won't pick up the new param.
+
+It is a **public SDK surface that real user paths reach**. In-tree callers: `__main__`, the
+client's own tests, the flagship sidecar's warm-up turn
+(`hub/agents/gaia/python/gaia_agent/server.py`) and the audio tools' transcript-refinement
+LLM (`src/gaia/agents/tools/audio_tools.py`). Both of those pass no `host`/`port`, so a
+change to how the factory resolves the server address changes `gaia audio` and the
+flagship's warm-up (#3558).
 
 ### Module-level helpers should be PUBLIC (no underscore)
 Helpers shared across packages (`vlm_client.py`, `ui/routers/system.py`, `ui/_chat_helpers.py`, `ui/server.py`, `agents/base/agent.py`) must be public-named (no leading `_`). Leading underscore signals "package-internal" and creates confusion. Precedent: `system.py` already imports `DEFAULT_CONTEXT_SIZE` from `lemonade_client`.

--- a/src/gaia/llm/lemonade_client.py
+++ b/src/gaia/llm/lemonade_client.py
@@ -1234,6 +1234,14 @@ class LemonadeClient:
             # Never log the key value itself — only its presence.
             self.log.debug("Lemonade API key configured")
 
+    #: Hostnames that mean "this machine", so launching a server here can
+    #: actually satisfy this client.
+    _LOCAL_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "0.0.0.0", ""})
+
+    def _targets_this_machine(self) -> bool:
+        """True when this client's server would run on the local host."""
+        return (self.host or "").strip().lower() in self._LOCAL_HOSTS
+
     def launch_server(self, log_level="info", background="none", ctx_size=None):
         """
         Launch the Lemonade server using subprocess.
@@ -1250,7 +1258,22 @@ class LemonadeClient:
                      For chat/RAG applications, use 32768 or higher.
 
         This method follows the approach in test_lemonade_server.py.
+
+        Raises:
+            LemonadeClientError: this client is pointed at a server on another
+                host. Launching is a local act — it frees a local port and
+                starts a local process — so it can only ever satisfy a local
+                client (#3558).
         """
+        if not self._targets_this_machine():
+            raise LemonadeClientError(
+                f"Refusing to start a local Lemonade server: this client is "
+                f"configured for {self.base_url}, which is not on this machine. "
+                f"Launching would free local port {self.port} and start a "
+                "server the client would not talk to. Start Lemonade on that "
+                "host, or unset LEMONADE_BASE_URL to use a local one."
+            )
+
         self.log.info("Starting Lemonade server...")
 
         # Skip the port takeover when a healthy server is already listening —
@@ -4834,17 +4857,26 @@ def create_lemonade_client(
     server_host = host or env_host or DEFAULT_HOST
     server_port = port or (int(env_port) if env_port else DEFAULT_PORT)
 
+    # A named host or port wins; otherwise let the client resolve the address
+    # itself — LEMONADE_BASE_URL, then GAIA's own embedded server's dynamic
+    # port, then the default. Passing host/port unconditionally pinned every
+    # caller to localhost:13305: a documented remote setup was contacted on the
+    # developer's own machine, and the embedded server (whose port is chosen at
+    # start time, and whose generated API key is keyed to it) was unreachable
+    # (#3558).
+    client_kwargs = {
+        "verbose": verbose,
+        "keep_alive": keep_alive,
+        "api_key": api_key,
+        "ctx_size_override": ctx_size_override,
+        "model_lease_priority": model_lease_priority,
+    }
+    if host is not None or port is not None or env_host or env_port:
+        client_kwargs["host"] = server_host
+        client_kwargs["port"] = server_port
+
     # Create the client
-    client = LemonadeClient(
-        model=model_name,
-        host=server_host,
-        port=server_port,
-        verbose=verbose,
-        keep_alive=keep_alive,
-        api_key=api_key,
-        ctx_size_override=ctx_size_override,
-        model_lease_priority=model_lease_priority,
-    )
+    client = LemonadeClient(model=model_name, **client_kwargs)
 
     # Auto-start server if requested
     if auto_start:
@@ -4855,9 +4887,7 @@ def create_lemonade_client(
                 client.log.info("Lemonade server is already running")
             except LemonadeClientError:
                 # Server not running, start it
-                client.log.info(
-                    f"Starting Lemonade server at {server_host}:{server_port}"
-                )
+                client.log.info(f"Starting Lemonade server at {client.base_url}")
                 client.launch_server(background=background)
 
                 # Perform a health check to verify the server is running
@@ -4944,8 +4974,8 @@ def initialize_lemonade(
     timeout: int = 120,
     verbose: bool = False,
     quiet: bool = False,
-    host: str = DEFAULT_HOST,
-    port: int = DEFAULT_PORT,
+    host: Optional[str] = None,
+    port: Optional[int] = None,
 ) -> LemonadeStatus:
     """
     Convenience function to initialize Lemonade Server.
@@ -4960,8 +4990,9 @@ def initialize_lemonade(
         timeout: Timeout for server startup
         verbose: Enable verbose output
         quiet: Suppress output
-        host: Lemonade server host
-        port: Lemonade server port
+        host: Lemonade server host (defaults to LEMONADE_BASE_URL, then
+              LEMONADE_HOST, then localhost)
+        port: Lemonade server port (same resolution as host)
 
     Returns:
         LemonadeStatus with server status
@@ -4975,6 +5006,9 @@ def initialize_lemonade(
         # Initialize for code agent with larger context
         status = initialize_lemonade(agent="chat", ctx_size=65536)
     """
+    # Named host/port win; otherwise LEMONADE_BASE_URL, which this defaulted
+    # past entirely — a documented remote server was initialized on localhost
+    # instead, and auto_start then tried to free the local port (#3558).
     client = LemonadeClient(host=host, port=port, keep_alive=True)
     return client.initialize(
         agent=agent,

--- a/src/gaia/llm/vlm_client.py
+++ b/src/gaia/llm/vlm_client.py
@@ -10,7 +10,6 @@ Handles model loading/unloading and image-to-text extraction via Lemonade server
 
 import base64
 import logging
-import os
 from typing import Optional
 
 from dotenv import load_dotenv
@@ -87,27 +86,30 @@ class VLMClient:
                 ``LEMONADE_API_KEY`` env-var fallback. VLMClient does NOT
                 pre-resolve the env var (single source of truth).
         """
-        # Use provided base_url, fall back to env var, then default
-        if base_url is None:
-            base_url = os.getenv("LEMONADE_BASE_URL", DEFAULT_LEMONADE_URL)
-        from urllib.parse import urlparse
+        from gaia.llm.lemonade_client import (
+            LemonadeClient,
+            resolve_lemonade_base_url,
+        )
 
-        from gaia.llm.lemonade_client import LemonadeClient
+        # The one resolver: argument, LEMONADE_BASE_URL, GAIA's own embedded
+        # server (a port chosen at start time), then the default. An inline
+        # env-var default could not see the embedded server at all.
+        base_url = resolve_lemonade_base_url(base_url)
 
         self.vlm_model = vlm_model
         self.base_url = base_url
 
-        # Parse base_url to extract host and port for LemonadeClient
-        parsed = urlparse(base_url)
-        host = parsed.hostname or "localhost"
-        port = parsed.port or 13305
-
-        # Get base server URL (without /api/v1) for user-facing messages
-        self.server_url = f"http://{host}:{port}"
-
+        # Hand the configured URL through whole. Decomposing it to host+port
+        # rebuilt every request as http://host:13305/api/v1, which downgraded
+        # https to http, dropped a reverse-proxy path prefix, and invented a
+        # port for a URL that named none — so a remote or tunnelled server was
+        # never actually contacted (#3553).
         self.client = LemonadeClient(
-            model=vlm_model, host=host, port=port, api_key=api_key
+            model=vlm_model, base_url=base_url, api_key=api_key
         )
+
+        # Base server URL (without the /api/vN suffix) for user-facing messages.
+        self.server_url = self.client.base_url.rsplit("/api/", 1)[0]
         self.auto_load = auto_load
         self.vlm_loaded = False
 

--- a/tests/unit/test_lemonade_base_url_passthrough.py
+++ b/tests/unit/test_lemonade_base_url_passthrough.py
@@ -1,0 +1,209 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""A configured Lemonade URL must reach the request, not be rebuilt from parts.
+
+Three entry points took `LEMONADE_BASE_URL` apart into host and port and put it
+back together as `http://{host}:{port}/api/v1`. An `https://` endpoint was
+contacted over plain http, a reverse-proxy path prefix was dropped, and a URL
+naming no port acquired 13305 — so a documented remote or tunnelled server was
+never actually reached (#3553, #3558).
+
+The second half matters as much as the first: `create_lemonade_client` can
+`auto_start`, and that path frees port 13305 by killing whatever is listening
+there. Pointed at the wrong machine, "start the server" means "kill something on
+the developer's own box".
+
+These assert the URL that would go on the wire, over every shape a real
+deployment uses. No network, no Lemonade server.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gaia.llm.lemonade_client import (
+    LemonadeClient,
+    create_lemonade_client,
+)
+from gaia.llm.vlm_client import VLMClient
+
+# (id, configured LEMONADE_BASE_URL, what must survive to the client)
+DEPLOYMENTS = [
+    (
+        "https_tunnel",
+        "https://abc123.ngrok.app/api/v1",
+        "https://abc123.ngrok.app/api/v1",
+    ),
+    (
+        "reverse_proxy_path_prefix",
+        "https://gpu.internal/lemonade/api/v1",
+        "https://gpu.internal/lemonade/api/v1",
+    ),
+    (
+        "https_no_explicit_port",
+        "https://lemonade.example.com/api/v1",
+        "https://lemonade.example.com/api/v1",
+    ),
+    (
+        "plain_host_and_port",
+        "http://192.168.1.50:13305/api/v1",
+        "http://192.168.1.50:13305/api/v1",
+    ),
+]
+
+IDS = [case[0] for case in DEPLOYMENTS]
+CASES = [(case[1], case[2]) for case in DEPLOYMENTS]
+
+
+@pytest.fixture
+def configured(monkeypatch):
+    """Set LEMONADE_BASE_URL and clear the host/port vars that shadow it."""
+
+    def _set(url):
+        monkeypatch.setenv("LEMONADE_BASE_URL", url)
+        monkeypatch.delenv("LEMONADE_HOST", raising=False)
+        monkeypatch.delenv("LEMONADE_PORT", raising=False)
+        monkeypatch.delenv("LEMONADE_API_KEY", raising=False)
+
+    return _set
+
+
+@pytest.mark.parametrize("url,expected", CASES, ids=IDS)
+def test_the_client_itself_keeps_the_configured_url(configured, url, expected):
+    """The baseline the other two entry points were supposed to match."""
+    configured(url)
+    assert LemonadeClient(verbose=False).base_url == expected
+
+
+@pytest.mark.parametrize("url,expected", CASES, ids=IDS)
+def test_the_public_factory_keeps_the_configured_url(configured, url, expected):
+    configured(url)
+    assert create_lemonade_client(verbose=False).base_url == expected
+
+
+@pytest.mark.parametrize("url,expected", CASES, ids=IDS)
+def test_the_vlm_client_keeps_the_configured_url(configured, url, expected):
+    configured(url)
+    assert VLMClient().client.base_url == expected
+
+
+class TestWhatMustStillWork:
+    """The rebuild-from-parts path is still right when parts are what you pass."""
+
+    def test_an_explicit_host_overrides_the_environment(self, configured):
+        configured("https://tunnel.example.com/api/v1")
+        client = create_lemonade_client(host="10.0.0.7", verbose=False)
+        assert client.base_url == "http://10.0.0.7:13305/api/v1"
+
+    def test_an_explicit_port_overrides_the_environment(self, configured):
+        configured("https://tunnel.example.com/api/v1")
+        client = create_lemonade_client(port=9999, verbose=False)
+        assert client.base_url.endswith(":9999/api/v1")
+
+    def test_host_and_port_env_vars_still_work_without_a_base_url(self, monkeypatch):
+        monkeypatch.delenv("LEMONADE_BASE_URL", raising=False)
+        monkeypatch.setenv("LEMONADE_HOST", "10.1.1.1")
+        monkeypatch.setenv("LEMONADE_PORT", "8080")
+        assert (
+            create_lemonade_client(verbose=False).base_url
+            == "http://10.1.1.1:8080/api/v1"
+        )
+
+
+class TestTheVlmClientsUserFacingUrl:
+    """`server_url` is quoted in "make sure Lemonade is running at …" messages."""
+
+    def test_it_names_the_real_server_not_a_rebuilt_localhost(self, configured):
+        configured("https://gpu.internal/lemonade/api/v1")
+        assert VLMClient().server_url == "https://gpu.internal/lemonade"
+
+    def test_it_drops_only_the_api_version_suffix(self, configured):
+        configured("http://192.168.1.50:13305/api/v1")
+        assert VLMClient().server_url == "http://192.168.1.50:13305"
+
+
+# ============================================================================
+# The embedded server: a port chosen at start time, not a constant
+# ============================================================================
+
+
+class TestGaiasOwnEmbeddedServerIsFound:
+    """`gaia lemonade embedded` binds a dynamic port and records it.
+
+    Passing ``host``/``port`` unconditionally pinned every caller to
+    localhost:13305, so the embedded server was unreachable — and its
+    generated API key, which is keyed to the recorded port, did not resolve
+    either (#3558).
+    """
+
+    @pytest.fixture
+    def embedded(self, monkeypatch):
+        monkeypatch.delenv("LEMONADE_BASE_URL", raising=False)
+        monkeypatch.delenv("LEMONADE_HOST", raising=False)
+        monkeypatch.delenv("LEMONADE_PORT", raising=False)
+        monkeypatch.setattr(
+            "gaia.llm.lemonade_client._embedded_lemonade_url",
+            lambda: "http://localhost:50725/api/v1",
+        )
+
+    def test_the_public_factory_finds_it(self, embedded):
+        client = create_lemonade_client(verbose=False)
+        assert client.base_url == "http://localhost:50725/api/v1"
+
+    def test_the_vlm_client_finds_it(self, embedded):
+        assert VLMClient().client.base_url == "http://localhost:50725/api/v1"
+
+    def test_a_named_host_still_wins_over_it(self, embedded):
+        client = create_lemonade_client(host="10.0.0.7", verbose=False)
+        assert client.base_url == "http://10.0.0.7:13305/api/v1"
+
+
+# ============================================================================
+# Launching is a local act, so it cannot serve a remote client
+# ============================================================================
+
+
+class TestStartingAServerIsRefusedForARemoteTarget:
+    """auto_start frees the local port and starts a local process.
+
+    Aimed at a remote URL that happens to be unreachable, that killed
+    whatever was on the developer's own port 13305 and started a server the
+    client would never talk to (#3558).
+    """
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://gpu.internal/api/v1",
+            "http://192.168.1.50:13305/api/v1",
+            "https://abc123.ngrok.app/api/v1",
+        ],
+    )
+    def test_a_remote_client_refuses_to_launch(self, configured, url):
+        configured(url)
+        client = LemonadeClient(verbose=False)
+
+        with pytest.raises(Exception, match="not on this machine"):
+            client.launch_server()
+
+    def test_the_refusal_names_the_configured_server(self, configured):
+        configured("https://gpu.internal/api/v1")
+        client = LemonadeClient(verbose=False)
+
+        with pytest.raises(Exception, match="gpu.internal"):
+            client.launch_server()
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://localhost:13305/api/v1",
+            "http://127.0.0.1:13305/api/v1",
+        ],
+    )
+    def test_a_local_client_is_not_blocked(self, configured, url):
+        """It gets past the guard — the launch itself needs real tooling."""
+        configured(url)
+        client = LemonadeClient(verbose=False)
+
+        assert client._targets_this_machine() is True


### PR DESCRIPTION
Point GAIA at a remote or tunnelled Lemonade server the documented way and vision calls go somewhere else entirely. Three entry points took `LEMONADE_BASE_URL` apart into host and port and put it back together as `http://{host}:{port}/api/v1` — so `https` was downgraded to `http`, a reverse-proxy path prefix was dropped, and a URL naming no port acquired 13305.

The second half is worse than a failed request. `create_lemonade_client` can `auto_start`, and that path frees port 13305 by killing whatever is listening on it. Aimed at localhost by mistake, "start the server" means "kill something on the developer's own machine".

Fixes #3553, fixes #3558

## Test plan

- [x] `pytest tests/unit/test_lemonade_base_url_passthrough.py` — new; asserts the URL that would reach the wire across four real deployment shapes (ngrok https, reverse-proxy path prefix, https with no port, plain host:port) for all three entry points. **8 of 17 fail on `main`.**
- [x] Same file covers what must still work: a named `host=` or `port=` still overrides the environment, and `LEMONADE_HOST`/`LEMONADE_PORT` still work when no base URL is set.
- [x] `pytest tests/unit/test_lemonade_client_api_key.py tests/unit/test_lemonade_cloud_models.py` (109 passed)
- [x] `pytest tests/unit -k "vlm or VLM"` (73 passed)
- [x] `black`, `flake8`, `isort`, `python util/lint.py --pylint`
- [ ] Live remote-server check — I have no tunnelled Lemonade to point at. The unit tests assert the composed URL rather than a real round trip, which is the contract that was broken; a live `LEMONADE_BASE_URL=https://<host>/api/v1` extraction would confirm the rest.

Note `tests/test_lemonade_client.py` needs a live server on 13305 and fails on `main` in my environment for that reason — untouched here.

<details>
<summary>🔍 Technical details</summary>

`LemonadeClient` has always accepted a whole `base_url` and normalises it through `resolve_lemonade_base_url`. The three callers that didn't use it:

- **`vlm_client.py:100-109`** parsed `base_url` to `hostname`/`port` and passed those, so `LemonadeClient`'s host/port branch rebuilt the URL. It now passes `base_url=` through, and derives `server_url` (quoted in "make sure Lemonade server is running at …") by trimming the `/api/vN` suffix off the client's real URL instead of inventing `http://host:port`.
- **`create_lemonade_client`** read `LEMONADE_MODEL`, `LEMONADE_HOST` and `LEMONADE_PORT` but never `LEMONADE_BASE_URL`. It now prefers the base URL when the caller named neither host nor port, and its auto-start log line names `client.base_url` rather than a host/port pair that may not be what it's talking to.
- **`initialize_lemonade`** defaulted `host`/`port` to `DEFAULT_HOST`/`DEFAULT_PORT`, so the environment could never be consulted. They default to `None` now, which `LemonadeClient` already resolves from the environment.

`self.host` / `self.port` remain populated on the client for the callers that read them; only the URL construction changed.

The stale claim the issue asked to correct is fixed in `.claude/skills/lemonade-client-patterns/SKILL.md`: it said the CLI goes through `create_lemonade_client`, which would mislead the next person into thinking a change here changes CLI behaviour. The only in-tree callers are `__main__` and the client's own tests.

#3555 — a failed extraction being indexed as document text — is the reason this one was invisible, and is filed and fixed separately.
</details>