### PR TITLE
fix(vlm): raise when vision extraction fails instead of indexing the error

### DIFF
--- a/docs/spec/vlm-client.mdx
+++ b/docs/spec/vlm-client.mdx
@@ -185,10 +185,14 @@ class VLMClient:
         Returns:
             Extracted text in markdown format
 
+        Raises:
+            VLMExtractionError: the page was not read. Never returns an error
+                string — a caller that indexes the return value would otherwise
+                index the error as the page's content (#3555).
+
         Note:
             - Ensures VLM is loaded before extraction
             - Uses default OCR prompt if none provided
-            - Returns error message if extraction fails
 
         Default Prompt:
             "You are an OCR system. Extract ALL visible text from this image
@@ -337,9 +341,11 @@ def extract_from_image(
 ) -> str:
     # Ensure VLM is loaded
     if not self._ensure_vlm_loaded():
-        error_msg = "VLM model not available"
+        error_msg = (
+            f"VLM model '{self.vlm_model}' is not available at {self.server_url}"
+        )
         logger.error(error_msg)
-        return f"[VLM extraction failed: {error_msg}]"
+        raise VLMExtractionError(error_msg, page_num, image_num)
 
     # Encode image as base64
     image_b64 = base64.b64encode(image_bytes).decode("utf-8")
@@ -404,14 +410,34 @@ Output format: Clean markdown with the ACTUAL text from the image."""
             )
             return extracted_text
         else:
-            logger.error(f"Unexpected VLM response format: {response}")
-            return "[VLM extraction failed: unexpected response format]"
+            error_msg = self._parse_vlm_error(response)
+            logger.error(error_msg)
+            raise VLMExtractionError(error_msg, page_num, image_num)
 
+    except VLMExtractionError:
+        raise
     except Exception as e:
         logger.error(
             f"VLM extraction failed for page {page_num}, image {image_num}: {e}"
         )
-        return f"[VLM extraction failed: {str(e)}]"
+        raise VLMExtractionError(str(e), page_num, image_num) from e
+```
+
+### Error Handling
+
+A failure raises rather than returning text. Callers translate it at their own
+boundary — the RAG PDF/PPTX paths skip the page and record a warning, the vision
+tools return an error envelope, and `providers.lemonade.vision()` propagates.
+Nothing that failed is ever indexed as content (#3555).
+
+```python
+from gaia.llm import VLMExtractionError
+
+try:
+    text = vlm.extract_from_image(image_bytes, page_num=7)
+except VLMExtractionError as e:
+    # e.page_num / e.image_num name what could not be read
+    log.warning("Skipping page %s: %s", e.page_num, e)
 ```
 
 ### Server URL Parsing
@@ -551,10 +577,8 @@ def test_extract_from_image_vlm_not_loaded():
         vlm = VLMClient(auto_load=False)
 
         image_bytes = b"fake_image_data"
-        result = vlm.extract_from_image(image_bytes)
-
-        assert "[VLM extraction failed" in result
-        assert "not available" in result
+        with pytest.raises(VLMExtractionError, match="not available"):
+            vlm.extract_from_image(image_bytes)
 
 def test_extract_from_image_extraction_error():
     """Test extraction failure."""
@@ -566,10 +590,8 @@ def test_extract_from_image_extraction_error():
         vlm.client.chat_completions = Mock(side_effect=Exception("Network error"))
 
         image_bytes = b"fake_image_data"
-        result = vlm.extract_from_image(image_bytes)
-
-        assert "[VLM extraction failed" in result
-        assert "Network error" in result
+        with pytest.raises(VLMExtractionError, match="Network error"):
+            vlm.extract_from_image(image_bytes)
 
 def test_extract_from_image_with_custom_prompt():
     """Test extraction with custom prompt."""
@@ -826,11 +848,11 @@ try:
     with open("image.png", "rb") as f:
         text = vlm.extract_from_image(f.read())
 
-    if "[VLM extraction failed" in text:
-        print(f"Extraction failed: {text}")
-    else:
-        print(f"Success: {len(text)} chars extracted")
+    print(f"Success: {len(text)} chars extracted")
 
+except VLMExtractionError as e:
+    # The page was not read. Never index `text` here — there is none.
+    print(f"Page {e.page_num} could not be read: {e}")
 except Exception as e:
     print(f"Error: {e}")
 finally:

--- a/src/gaia/llm/__init__.py
+++ b/src/gaia/llm/__init__.py
@@ -5,6 +5,12 @@
 from .base_client import LLMClient
 from .exceptions import NotSupportedError
 from .factory import create_client
-from .vlm_client import VLMClient
+from .vlm_client import VLMClient, VLMExtractionError
 
-__all__ = ["create_client", "LLMClient", "VLMClient", "NotSupportedError"]
+__all__ = [
+    "create_client",
+    "LLMClient",
+    "VLMClient",
+    "VLMExtractionError",
+    "NotSupportedError",
+]

--- a/src/gaia/llm/vlm_client.py
+++ b/src/gaia/llm/vlm_client.py
@@ -58,6 +58,24 @@ def detect_image_mime_type(image_bytes: bytes) -> str:
     return "image/png"
 
 
+class VLMExtractionError(RuntimeError):
+    """Vision extraction did not produce text (#3555).
+
+    Raised instead of returning ``"[VLM extraction failed: …]"`` as the page's
+    content. No caller anywhere checked for that prefix, so the message was
+    chunked, embedded into the document index, retrieved, and quoted back as an
+    answer — with nothing indicating the page had never been read.
+    """
+
+    def __init__(self, message: str, page_num: int = 1, image_num: int = 1):
+        self.page_num = page_num
+        self.image_num = image_num
+        super().__init__(
+            f"Vision extraction failed for page {page_num}, image {image_num}: "
+            f"{message}"
+        )
+
+
 class VLMClient:
     """
     VLM client for extracting text from images using Lemonade server.
@@ -199,12 +217,20 @@ class VLMClient:
 
         Returns:
             Extracted text in markdown format
+
+        Raises:
+            VLMExtractionError: the page was not read. Never returns an error
+                string — a caller that indexes the return value would otherwise
+                index the error as content (#3555).
         """
         # Ensure VLM is loaded
         if not self._ensure_vlm_loaded():
-            error_msg = "VLM model not available"
+            error_msg = (
+                f"VLM model '{self.vlm_model}' is not available at "
+                f"{self.server_url}"
+            )
             logger.error(error_msg)
-            return f"[VLM extraction failed: {error_msg}]"
+            raise VLMExtractionError(error_msg, page_num, image_num)
 
         # Encode image as base64 and detect MIME type
         # Note: Image size optimization happens in pdf_utils.py during extraction
@@ -279,8 +305,10 @@ Output format: Clean markdown with the ACTUAL text from the image."""
                 # Check for specific error types and provide helpful messages
                 error_msg = self._parse_vlm_error(response)
                 logger.error(error_msg)
-                return f"[VLM extraction failed: {error_msg}]"
+                raise VLMExtractionError(error_msg, page_num, image_num)
 
+        except VLMExtractionError:
+            raise
         except Exception as e:
             logger.error(
                 f"VLM extraction failed for page {page_num}, image {image_num}: {e}"
@@ -288,7 +316,7 @@ Output format: Clean markdown with the ACTUAL text from the image."""
             import traceback
 
             logger.debug(traceback.format_exc())
-            return f"[VLM extraction failed: {str(e)}]"
+            raise VLMExtractionError(str(e), page_num, image_num) from e
 
     def _parse_vlm_error(self, response: dict) -> str:
         """Parse VLM error response and return a helpful error message."""

--- a/src/gaia/vlm/structured_extraction.py
+++ b/src/gaia/vlm/structured_extraction.py
@@ -30,7 +30,7 @@ Example:
 import logging
 from typing import Any, Dict, List, Optional
 
-from gaia.llm import VLMClient
+from gaia.llm import VLMClient, VLMExtractionError
 from gaia.utils import extract_json_from_text
 
 logger = logging.getLogger(__name__)
@@ -160,6 +160,7 @@ class StructuredVLMExtractor:
 
         # Process pages
         pages_data = []
+        failed_pages = []
         aggregated_timeline = {} if extract_timelines else None
 
         for i, page_num in enumerate(pages_to_process, 1):
@@ -177,43 +178,56 @@ class StructuredVLMExtractor:
             if not image_bytes:
                 continue
 
-            # Extract data from page
+            # Extract data from page. One page that cannot be read is a failed
+            # PAGE, not a failed document — aborting here would throw away every
+            # page already processed, and a model answering a table prompt in
+            # prose is ordinary.
             page_data = {"page": page_num}
+            try:
+                # Tables
+                if extract_tables:
+                    page_data["tables"] = self.extract_table(
+                        image_bytes, page_num=page_num
+                    )
 
-            # Tables
-            if extract_tables:
-                page_data["tables"] = self.extract_table(image_bytes, page_num=page_num)
+                # Timelines
+                if extract_timelines:
+                    timeline_data = self.extract_timeline(
+                        image_bytes,
+                        status_types=timeline_status_types
+                        or ["Category1", "Category2"],
+                        page_num=page_num,
+                    )
+                    page_data["timeline"] = timeline_data
 
-            # Timelines
-            if extract_timelines:
-                timeline_data = self.extract_timeline(
-                    image_bytes,
-                    status_types=timeline_status_types or ["Category1", "Category2"],
-                    page_num=page_num,
+                    # Aggregate
+                    if aggregated_timeline is not None:
+                        for status, hours in timeline_data.items():
+                            aggregated_timeline[status] = (
+                                aggregated_timeline.get(status, 0.0) + hours
+                            )
+
+                # Fields or schema
+                if extract_fields:
+                    page_data["fields"] = self.extract_key_values(
+                        image_bytes, extract_fields, page_num=page_num
+                    )
+                elif schema:
+                    page_data["fields"] = self.extract_structured(
+                        image_bytes, schema, page_num=page_num
+                    )
+
+                # Raw text (always included)
+                page_data["raw_text"] = self.vlm.extract_from_image(
+                    image_bytes, page_num=page_num
                 )
-                page_data["timeline"] = timeline_data
-
-                # Aggregate
-                if aggregated_timeline is not None:
-                    for status, hours in timeline_data.items():
-                        aggregated_timeline[status] = (
-                            aggregated_timeline.get(status, 0.0) + hours
-                        )
-
-            # Fields or schema
-            if extract_fields:
-                page_data["fields"] = self.extract_key_values(
-                    image_bytes, extract_fields, page_num=page_num
-                )
-            elif schema:
-                page_data["fields"] = self.extract_structured(
-                    image_bytes, schema, page_num=page_num
-                )
-
-            # Raw text (always included)
-            page_data["raw_text"] = self.vlm.extract_from_image(
-                image_bytes, page_num=page_num
-            )
+            except VLMExtractionError as e:
+                # Named, so a caller can say WHICH pages are incomplete. The
+                # keys that did populate stay; the ones that did not are absent
+                # rather than zero-filled.
+                page_data["error"] = str(e)
+                failed_pages.append(page_num)
+                logger.warning("Page %s could not be read: %s", page_num, e)
 
             pages_data.append(page_data)
 
@@ -223,6 +237,7 @@ class StructuredVLMExtractor:
                 "source": doc_path.name,
                 "total_pages": total_pages,
                 "pages_processed": len(pages_data),
+                "pages_failed": failed_pages,
             },
             "pages": pages_data,
         }
@@ -299,11 +314,12 @@ IMPORTANT:
         if isinstance(data, list):
             logger.info(f"Extracted table with {len(data)} rows")
             return data
-        else:
-            logger.warning(
-                f"Table extraction failed or returned non-list: {type(data)}"
-            )
-            return []
+        raise VLMExtractionError(
+            f"the model's table output did not parse as a list (got "
+            f"{type(data).__name__}); returning an empty table would read as "
+            "a table with no rows",
+            page_num,
+        )
 
     def extract_key_values(
         self,
@@ -362,9 +378,12 @@ IMPORTANT:
         if isinstance(data, dict):
             logger.info(f"Extracted {len(data)} fields")
             return data
-        else:
-            logger.warning("Key-value extraction failed")
-            return {key: None for key in keys}
+        raise VLMExtractionError(
+            f"the model's key/value output did not parse as an object (got "
+            f"{type(data).__name__}); a null for every key is indistinguishable "
+            "from fields that are genuinely absent",
+            page_num,
+        )
 
     def extract_structured(
         self,
@@ -440,9 +459,12 @@ IMPORTANT:
         if isinstance(data, dict):
             logger.info(f"Extracted {len(data)} fields from schema")
             return data
-        else:
-            logger.warning("Structured extraction failed")
-            return {}
+        raise VLMExtractionError(
+            f"the model's output did not parse against the schema (got "
+            f"{type(data).__name__}); returning no fields would read as a page "
+            "with none of them",
+            page_num,
+        )
 
     def _parse_time_to_hours(self, time_str: str) -> float:
         """
@@ -464,9 +486,13 @@ IMPORTANT:
             else:
                 # Already a number
                 return float(time_str)
-        except (ValueError, IndexError):
-            logger.warning(f"Failed to parse time: {time_str}")
-            return 0.0
+        except (ValueError, IndexError) as e:
+            # 0.0 here was added into ``timeline_totals`` and reported as a
+            # measured number.
+            raise VLMExtractionError(
+                f"could not read {time_str!r} as a duration; counting it as "
+                "zero would be reported as a measured total"
+            ) from e
 
     def extract_chart_data(
         self,
@@ -609,20 +635,24 @@ ALL {len(categories)} fields REQUIRED."""
                     elif isinstance(value, (int, float)):
                         converted[cat] = float(value)
                     else:
-                        converted[cat] = 0.0
+                        raise VLMExtractionError(
+                            f"category {cat!r} came back as "
+                            f"{type(value).__name__}, not a duration; counting "
+                            "it as zero would be summed into the reported total",
+                            page_num,
+                        )
                 logger.info(f"Extracted chart data with {len(converted)} categories")
                 return converted
             else:
                 # Return as-is (strings, numbers, whatever VLM returned)
                 logger.info(f"Extracted chart data with {len(data)} categories")
                 return data
-        else:
-            logger.warning("Chart data extraction failed")
-            # Return appropriate defaults based on format
-            if value_format == "time_hms":
-                return {cat: "00:00:00" for cat in categories}
-            else:
-                return {cat: 0.0 for cat in categories}
+        raise VLMExtractionError(
+            f"the model's chart output did not parse as an object (got "
+            f"{type(data).__name__}); zero-filling every category would be "
+            "summed into the reported total and read as measured",
+            page_num,
+        )
 
     def extract_timeline(
         self,

--- a/tests/unit/test_structured_vlm_extraction.py
+++ b/tests/unit/test_structured_vlm_extraction.py
@@ -12,6 +12,7 @@ misparsing here would corrupt every downstream consumer (e.g. the EMR flow).
 
 import pytest
 
+from gaia.llm import VLMExtractionError
 from gaia.vlm.structured_extraction import StructuredVLMExtractor
 
 
@@ -63,17 +64,31 @@ def test_extract_table_empty_array_returns_empty_list(extractor):
     assert extractor.extract_table(b"fake-image") == []
 
 
-def test_extract_table_non_list_json_falls_back_to_empty(extractor):
-    # VLM misbehaves and returns an object instead of an array.
+def test_extract_table_non_list_json_raises(extractor):
+    """An object where a list was asked for is a parse failure, not zero rows.
+
+    Returning ``[]`` reads downstream as "this page has no table" (#3555).
+    """
     extractor.vlm.extract_from_image.return_value = '{"col1": "value1"}'
 
-    assert extractor.extract_table(b"fake-image") == []
+    with pytest.raises(VLMExtractionError, match="did not parse as a list"):
+        extractor.extract_table(b"fake-image")
 
 
-def test_extract_table_unparsable_text_falls_back_to_empty(extractor):
+def test_extract_table_unparsable_text_raises(extractor):
     extractor.vlm.extract_from_image.return_value = "I could not find a table."
 
-    assert extractor.extract_table(b"fake-image") == []
+    with pytest.raises(VLMExtractionError):
+        extractor.extract_table(b"fake-image")
+
+
+def test_a_table_parse_failure_names_the_page(extractor):
+    extractor.vlm.extract_from_image.return_value = "not json"
+
+    with pytest.raises(VLMExtractionError) as excinfo:
+        extractor.extract_table(b"fake-image", page_num=7)
+
+    assert excinfo.value.page_num == 7
 
 
 # ---------------------------------------------------------------------------
@@ -110,21 +125,20 @@ def test_extract_key_values_with_descriptions_builds_prompt(extractor):
     assert "the patient's full name" in kwargs["prompt"]
 
 
-def test_extract_key_values_malformed_output_defaults_keys_to_none(extractor):
+def test_extract_key_values_malformed_output_raises(extractor):
+    """A null per key is indistinguishable from fields genuinely absent."""
     extractor.vlm.extract_from_image.return_value = "not valid json at all"
 
-    data = extractor.extract_key_values(b"fake-image", keys=["a", "b", "c"])
+    with pytest.raises(VLMExtractionError, match="genuinely absent"):
+        extractor.extract_key_values(b"fake-image", keys=["a", "b", "c"])
 
-    assert data == {"a": None, "b": None, "c": None}
 
-
-def test_extract_key_values_non_dict_json_defaults_to_none(extractor):
+def test_extract_key_values_non_dict_json_raises(extractor):
     # VLM returns an array instead of the requested object.
     extractor.vlm.extract_from_image.return_value = '["a", "b"]'
 
-    data = extractor.extract_key_values(b"fake-image", keys=["a", "b"])
-
-    assert data == {"a": None, "b": None}
+    with pytest.raises(VLMExtractionError):
+        extractor.extract_key_values(b"fake-image", keys=["a", "b"])
 
 
 # ---------------------------------------------------------------------------
@@ -161,10 +175,12 @@ def test_extract_structured_empty_schema_still_calls_vlm(extractor):
     extractor.vlm.extract_from_image.assert_called_once()
 
 
-def test_extract_structured_malformed_output_returns_empty_dict(extractor):
+def test_extract_structured_malformed_output_raises(extractor):
+    """``{}`` reads as "the page had none of these fields" (#3555)."""
     extractor.vlm.extract_from_image.return_value = "garbage response"
 
-    assert extractor.extract_structured(b"fake-image", schema={"fields": {}}) == {}
+    with pytest.raises(VLMExtractionError, match="did not parse against the schema"):
+        extractor.extract_structured(b"fake-image", schema={"fields": {}})
 
 
 # ---------------------------------------------------------------------------
@@ -186,17 +202,11 @@ def test_parse_time_to_hours_valid_inputs(extractor, time_str, expected):
     assert extractor._parse_time_to_hours(time_str) == pytest.approx(expected)
 
 
-def test_parse_time_to_hours_malformed_returns_zero(extractor):
-    assert extractor._parse_time_to_hours("not-a-time") == 0.0
-
-
-def test_parse_time_to_hours_empty_string_returns_zero(extractor):
-    assert extractor._parse_time_to_hours("") == 0.0
-
-
-def test_parse_time_to_hours_trailing_colon_returns_zero(extractor):
-    # "14:" splits into ["14", ""] — int("") raises ValueError, caught -> 0.0
-    assert extractor._parse_time_to_hours("14:") == 0.0
+@pytest.mark.parametrize("time_str", ["not-a-time", "", "14:"])
+def test_parse_time_to_hours_malformed_raises(extractor, time_str):
+    """0.0 was summed into ``timeline_totals`` and reported as measured (#3555)."""
+    with pytest.raises(VLMExtractionError, match="as a duration"):
+        extractor._parse_time_to_hours(time_str)
 
 
 # ---------------------------------------------------------------------------
@@ -258,14 +268,16 @@ def test_extract_chart_data_time_hms_decimal_accepts_numeric_values(extractor):
     assert data == {"Active": 5.0, "Idle": 2.5}
 
 
-def test_extract_chart_data_time_hms_decimal_unexpected_type_defaults_zero(extractor):
+def test_extract_chart_data_time_hms_decimal_unexpected_type_raises(extractor):
+    """A zero here is summed into timeline_totals and reported as measured."""
     extractor.vlm.extract_from_image.return_value = '{"Active": null, "Idle": [1, 2]}'
 
-    data = extractor.extract_chart_data(
-        b"fake-image", categories=["Active", "Idle"], value_format="time_hms_decimal"
-    )
-
-    assert data == {"Active": 0.0, "Idle": 0.0}
+    with pytest.raises(VLMExtractionError, match="not a duration"):
+        extractor.extract_chart_data(
+            b"fake-image",
+            categories=["Active", "Idle"],
+            value_format="time_hms_decimal",
+        )
 
 
 def test_extract_chart_data_time_hms_returns_strings_as_is(extractor):
@@ -316,26 +328,15 @@ def test_extract_chart_data_auto_format_passthrough(extractor):
     assert data == {"A": "yes", "B": 3}
 
 
-def test_extract_chart_data_malformed_defaults_to_zero_for_non_time_format(extractor):
+@pytest.mark.parametrize("value_format", ["number", "time_hms", "time_hms_decimal"])
+def test_extract_chart_data_malformed_raises_for_every_format(extractor, value_format):
+    """Zero-filling every category reads as a chart that measured zero."""
     extractor.vlm.extract_from_image.return_value = "not json"
 
-    data = extractor.extract_chart_data(
-        b"fake-image", categories=["Q1", "Q2"], value_format="number"
-    )
-
-    assert data == {"Q1": 0.0, "Q2": 0.0}
-
-
-def test_extract_chart_data_malformed_defaults_to_zero_time_string_for_time_hms(
-    extractor,
-):
-    extractor.vlm.extract_from_image.return_value = "not json"
-
-    data = extractor.extract_chart_data(
-        b"fake-image", categories=["Active", "Idle"], value_format="time_hms"
-    )
-
-    assert data == {"Active": "00:00:00", "Idle": "00:00:00"}
+    with pytest.raises(VLMExtractionError, match="did not parse as an object"):
+        extractor.extract_chart_data(
+            b"fake-image", categories=["Q1", "Q2"], value_format=value_format
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -434,3 +435,78 @@ def test_extract_pdf_multipage_aggregates_timeline(extractor, tmp_path, mocker):
     }
     assert progress_calls == [(1, 2), (2, 2)]
     fake_doc.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# One page that cannot be read is a failed PAGE, not a failed document (#3555)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def two_page_doc(tmp_path, mocker):
+    """A two-page PDF whose paging and rendering are stubbed."""
+    pdf = tmp_path / "doc.pdf"
+    pdf.write_bytes(b"%PDF-1.4\n")
+
+    doc = mocker.MagicMock()
+    doc.__len__.return_value = 2
+    mocker.patch.dict(
+        "sys.modules", {"fitz": mocker.MagicMock(open=mocker.Mock(return_value=doc))}
+    )
+    # Imported inside extract(), so patch it at its source module.
+    mocker.patch("gaia.utils.pdf_page_to_image", return_value=b"fake-image")
+    return pdf
+
+
+class TestAFailedPageDoesNotDiscardTheDocument:
+    def test_the_good_page_still_comes_back(self, extractor, two_page_doc):
+        # Page 1 parses; page 2's table answer is prose, which models do.
+        extractor.vlm.extract_from_image.side_effect = [
+            '[{"col": "value"}]',  # page 1 table
+            "page one text",  # page 1 raw text
+            "There is no table on this page.",  # page 2 table -> raises
+        ]
+
+        result = extractor.extract(str(two_page_doc), extract_tables=True)
+
+        assert [p["page"] for p in result["pages"]] == [1, 2]
+        assert result["pages"][0]["tables"] == [{"col": "value"}]
+
+    def test_the_failed_page_is_named(self, extractor, two_page_doc):
+        extractor.vlm.extract_from_image.side_effect = [
+            '[{"col": "value"}]',
+            "page one text",
+            "There is no table on this page.",
+        ]
+
+        result = extractor.extract(str(two_page_doc), extract_tables=True)
+
+        assert result["metadata"]["pages_failed"] == [2]
+        assert "error" in result["pages"][1]
+
+    def test_a_clean_document_reports_no_failures(self, extractor, two_page_doc):
+        extractor.vlm.extract_from_image.return_value = "[]"
+
+        result = extractor.extract(str(two_page_doc), extract_tables=True)
+
+        assert result["metadata"]["pages_failed"] == []
+        assert all("error" not in p for p in result["pages"])
+
+    def test_a_failed_page_contributes_nothing_to_the_totals(
+        self, extractor, two_page_doc
+    ):
+        """The zeros this whole change exists to stop reporting as measured."""
+        extractor.vlm.extract_from_image.side_effect = [
+            '{"Active": "02:00:00"}',  # page 1 timeline
+            "page one text",
+            "could not read the chart",  # page 2 timeline -> raises
+        ]
+
+        result = extractor.extract(
+            str(two_page_doc),
+            extract_timelines=True,
+            timeline_status_types=["Active"],
+        )
+
+        assert result["metadata"]["pages_failed"] == [2]
+        assert result["aggregated_data"]["timeline_totals"] == {"Active": 2.0}

--- a/tests/unit/test_vlm_extraction_failures.py
+++ b/tests/unit/test_vlm_extraction_failures.py
@@ -1,0 +1,167 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""A page that was never read must not be indexed as that page's text.
+
+Vision extraction used to return `"[VLM extraction failed: …]"` when it failed.
+No caller anywhere checked for that prefix, so the message was chunked, embedded
+into the document index, retrieved, and quoted back as an answer — with nothing
+telling the user the page had never been read (#3555).
+
+These tests pin the new contract at the boundary that broke, and at each caller
+that has to translate it: a tool reports an error envelope, an ingest helper
+reports an error, and the page-level wrapper refuses to hand back partial text
+as if it were complete.
+
+No Lemonade server required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gaia.llm.vlm_client import VLMClient, VLMExtractionError
+
+
+@pytest.fixture
+def vlm():
+    """A VLMClient whose transport is a mock; nothing reaches the network."""
+    with patch("gaia.llm.lemonade_client.LemonadeClient"):
+        client = VLMClient(base_url="http://localhost:13305/api/v1")
+    client.client = MagicMock()
+    return client
+
+
+# ============================================================================
+# 1. Every failure site raises
+# ============================================================================
+
+
+class TestTheThreeFailureSites:
+    def test_an_unavailable_model_raises(self, vlm):
+        vlm._ensure_vlm_loaded = lambda: False
+
+        with pytest.raises(VLMExtractionError) as excinfo:
+            vlm.extract_from_image(b"fake-png", page_num=4, image_num=2)
+
+        assert excinfo.value.page_num == 4
+        assert excinfo.value.image_num == 2
+
+    def test_an_error_response_raises(self, vlm):
+        vlm._ensure_vlm_loaded = lambda: True
+        vlm.client.chat_completions.return_value = {"error": "model exploded"}
+
+        with pytest.raises(VLMExtractionError):
+            vlm.extract_from_image(b"fake-png")
+
+    def test_an_unexpected_exception_raises_with_the_cause_attached(self, vlm):
+        vlm._ensure_vlm_loaded = lambda: True
+        vlm.client.chat_completions.side_effect = ConnectionError("refused")
+
+        with pytest.raises(VLMExtractionError) as excinfo:
+            vlm.extract_from_image(b"fake-png")
+
+        assert isinstance(excinfo.value.__cause__, ConnectionError)
+
+    def test_the_message_names_the_page_and_image(self, vlm):
+        vlm._ensure_vlm_loaded = lambda: True
+        vlm.client.chat_completions.side_effect = ConnectionError("refused")
+
+        with pytest.raises(VLMExtractionError, match="page 9, image 3"):
+            vlm.extract_from_image(b"fake-png", page_num=9, image_num=3)
+
+    def test_a_successful_extraction_still_returns_its_text(self, vlm):
+        vlm._ensure_vlm_loaded = lambda: True
+        vlm.client.chat_completions.return_value = {
+            "choices": [{"message": {"content": "# Real page text"}}]
+        }
+
+        assert vlm.extract_from_image(b"fake-png") == "# Real page text"
+
+
+class TestNothingReturnsAnErrorString:
+    """The specific shape that used to be indexed as content."""
+
+    def test_a_failure_never_comes_back_as_a_return_value(self, vlm):
+        vlm._ensure_vlm_loaded = lambda: False
+        try:
+            result = vlm.extract_from_image(b"fake-png")
+        except VLMExtractionError:
+            return
+        pytest.fail(f"extraction returned {result!r} instead of raising")
+
+    def test_the_page_wrapper_does_not_swallow_it_into_partial_text(self, vlm):
+        """One bad image must not be reported as a page that extracted fine."""
+        vlm._ensure_vlm_loaded = lambda: True
+        vlm.client.chat_completions.side_effect = [
+            {"choices": [{"message": {"content": "first image"}}]},
+            ConnectionError("refused"),
+        ]
+        images = [
+            {"image_bytes": b"a", "width": 10, "height": 10, "size_kb": 1.0},
+            {"image_bytes": b"b", "width": 10, "height": 10, "size_kb": 1.0},
+        ]
+
+        with pytest.raises(VLMExtractionError):
+            vlm.extract_from_page_images(images, page_num=1)
+
+
+# ============================================================================
+# 2. Callers translate it at their own boundary
+# ============================================================================
+
+
+class TestToolCallersReportAnError:
+    """A tool must say the analysis failed, not return the error as the answer."""
+
+    @staticmethod
+    def _mixin(side_effect):
+        from gaia.vlm.mixin import VLMToolsMixin
+
+        class Host(VLMToolsMixin):
+            def __init__(self):
+                self.vlm_model = "test-vlm"
+                self.vlm_client = MagicMock()
+                self.vlm_client.extract_from_image.side_effect = side_effect
+
+        return Host()
+
+    def test_analyze_image_reports_an_error_envelope(self, tmp_path):
+        image = tmp_path / "chart.png"
+        image.write_bytes(b"not-really-a-png")
+        host = self._mixin(VLMExtractionError("model unavailable", 1, 1))
+
+        result = host._analyze_image(str(image), focus="all")
+
+        assert result["status"] == "error"
+        assert "description" not in result
+
+    def test_answer_question_reports_an_error_envelope(self, tmp_path):
+        image = tmp_path / "chart.png"
+        image.write_bytes(b"not-really-a-png")
+        host = self._mixin(VLMExtractionError("model unavailable", 1, 1))
+
+        result = host._answer_question_about_image(str(image), "what is this?")
+
+        assert result["status"] == "error"
+        assert "answer" not in result
+
+
+class TestIngestReportsAnError:
+    def test_image_ingest_reports_the_failure_rather_than_the_text(self, tmp_path):
+        from gaia.messaging import ingest
+
+        image = tmp_path / "photo.png"
+        image.write_bytes(b"not-really-a-png")
+
+        with patch.object(ingest, "VLMClient") as factory:
+            factory.return_value.extract_from_image.side_effect = VLMExtractionError(
+                "model unavailable", 1, 1
+            )
+            factory.return_value.vlm_model = "test-vlm"
+            result = ingest.ingest_image_to_vlm(str(image))
+
+        assert result["status"] == "error"
+        assert "text" not in result


### PR DESCRIPTION
When vision extraction fails on a PDF page, the error message was returned as if it were the page's text. It got chunked, embedded into the document index, retrieved later, and quoted back as an answer — the user seeing a confident answer built on an error string, with nothing anywhere indicating the page was never read.

Fixes #3555

## Test plan

- [x] `pytest tests/unit/test_vlm_extraction_failures.py` — new; all three failure sites raise, the message names the page and image, the original cause stays attached, a success still returns its text, and each caller translates it at its own boundary (tool → error envelope, ingest → error, page wrapper → propagates).
- [x] `pytest tests/unit/test_structured_vlm_extraction.py` (42 passed) — the placeholder tests now pin the raise.
- [x] `pytest tests/unit/test_ingest_helpers.py tests/unit/rag/test_pptx_extraction.py tests/unit/test_testing_utilities.py` and `pytest tests/unit -k "vlm or VLM or rag"` (267 passed)
- [x] `black`, `flake8`, `python util/lint.py --pylint`
- [x] Confirmed the old behaviour directly: loading `main`'s `vlm_client.py` and calling it with an unavailable model returns `'[VLM extraction failed: VLM model not available]'`, and with a refused connection `'[VLM extraction failed: refused]'`.
- [ ] Live PDF-with-images ingest against a broken VLM — not run; I have no failing VLM to point at. The unit tests cover each caller's translation, which is where the error used to leak into content.

<details>
<summary>🔍 Technical details</summary>

`VLMExtractionError` carries `page_num` and `image_num` so a caller can say which page it skipped. The three sites in `vlm_client.py` — model unavailable, VLM error response, and the catch-all — raise it; the catch-all chains with `from e` so the original traceback survives.

Every caller was already prepared:

| caller | what it does now |
|---|---|
| `rag/sdk.py` PDF (`:825`) and PPTX (`:1186`) | already `except Exception` per page → skips the page's images, logs a warning |
| `vlm/mixin.py` `analyze_image` / `answer_question_about_image` | already `except Exception` → returns `status: "error"` |
| `messaging/ingest.py` | already `except Exception` → returns `status: "error"` |
| `providers/lemonade.py` `vision()` | propagates, which is right for a provider method |

`structured_extraction.py` had the same shape in three more places: an unparsable table became `[]`, an unparsable schema result became `{}`, and an unreadable duration became `0.0`. That last one was then summed into `timeline_totals` and reported as a measured number. All three raise.

**One trade worth naming.** `extract_from_page_images` propagates, so one bad image on a page discards the good ones from that page too — the caller skips the page's images and logs. The alternative (return the images that worked, record the ones that didn't) needs a per-image error channel the RAG layer does not have today; failing the page is the conservative reading of "nothing that failed should ever be indexed". Happy to do the finer-grained version if you'd rather.
</details>