### PR TITLE
fix(rag): stop indexing a damaged PDF page as a blank one

### DIFF
--- a/src/gaia/rag/pdf_utils.py
+++ b/src/gaia/rag/pdf_utils.py
@@ -161,15 +161,35 @@ def extract_images_from_page(
     return []
 
 
-def count_images_in_page(page) -> Tuple[bool, int]:
+class PdfPageInspectionError(RuntimeError):
+    """A page's image inventory could not be read (#3551).
+
+    Distinct from "this page has no images". The old code returned ``(False,
+    0)`` for both, and that boolean is the only gate on the vision path — so a
+    damaged page was silently indexed as blank, indistinguishable from a page
+    that genuinely had nothing on it.
+    """
+
+    def __init__(self, message: str, page_num: int = 0):
+        self.page_num = page_num
+        super().__init__(message)
+
+
+def count_images_in_page(page, page_num: int = 0) -> Tuple[bool, int]:
     """
     Fast check for image presence without extraction.
 
     Args:
         page: pypdf page object
+        page_num: 1-based page number, for the error message
 
     Returns:
         (has_images: bool, count: int)
+
+    Raises:
+        PdfPageInspectionError: the page's resources could not be resolved, so
+            whether it has images is unknown. Never reported as "no images" —
+            that is the gate on the vision path (#3551).
     """
     count = 0
 
@@ -180,8 +200,11 @@ def count_images_in_page(page) -> Tuple[bool, int]:
                 obj = xobject[obj_name]
                 if obj.get("/Subtype") == "/Image":
                     count += 1
-    except Exception:  # pylint: disable=broad-except
-        pass
+    except Exception as e:  # pylint: disable=broad-except
+        raise PdfPageInspectionError(
+            f"could not read the image inventory of page {page_num}: {e}",
+            page_num,
+        ) from e
 
     return (count > 0, count)
 

--- a/src/gaia/rag/sdk.py
+++ b/src/gaia/rag/sdk.py
@@ -696,7 +696,12 @@ class RAGSDK:
             - num_pages: int
             - vlm_pages: int (number of pages enhanced with VLM)
             - total_images: int (total images processed)
-            - pdf_status: str ("readable", "encrypted", "corrupted", "empty")
+            - pdf_status: str ("readable", "degraded", "encrypted",
+              "corrupted", "empty"). "degraded" means the document indexed but
+              at least one page may be incomplete — see degraded_pages.
+            - degraded_pages: list[int], present only when pdf_status is
+              "degraded"
+            - page_warnings: dict[int, str], why each degraded page is listed
 
         Raises:
             EncryptedPDFError: PDF is password-protected.
@@ -761,6 +766,7 @@ class RAGSDK:
             try:
                 from gaia.llm import VLMClient
                 from gaia.rag.pdf_utils import (
+                    PdfPageInspectionError,
                     count_images_in_page,
                     extract_images_from_page_pymupdf,
                 )
@@ -800,6 +806,8 @@ class RAGSDK:
             pages_data = []
             vlm_pages_count = 0
             total_images_processed = 0
+            degraded_pages = []
+            page_warnings = {}
 
             for i, page in enumerate(reader.pages, 1):
                 page_start = time_module.time()
@@ -810,11 +818,21 @@ class RAGSDK:
                 # Step 2: Check for images
                 has_imgs = False
                 num_imgs = 0
+                page_warning = None
                 if vlm_available:
                     try:
-                        has_imgs, num_imgs = count_images_in_page(page)
-                    except Exception:  # pylint: disable=broad-except
-                        pass
+                        has_imgs, num_imgs = count_images_in_page(page, page_num=i)
+                    except PdfPageInspectionError as e:
+                        # Unknown, not "none". The inventory comes from pypdf
+                        # and the extraction from PyMuPDF, so a page pypdf
+                        # cannot inspect may still extract — try it rather than
+                        # indexing the page as blank (#3551).
+                        page_warning = str(e)
+                        self.log.warning("%s - attempting extraction anyway", e)
+                        has_imgs = True
+                        # Not zero — unknown. Reporting 0 alongside
+                        # has_images=True is a contradiction on the record.
+                        num_imgs = None
 
                 # Step 3: Extract from images if present
                 image_texts = []
@@ -829,24 +847,30 @@ class RAGSDK:
                                 vlm_pages_count += 1
                                 total_images_processed += len(image_texts)
                     except Exception as img_error:
-                        self.log.warning(
-                            f"Image extraction failed on page {i}: {img_error}"
+                        page_warning = (
+                            f"image extraction failed on page {i}: {img_error}"
                         )
+                        self.log.warning(page_warning)
 
                 # Step 4: Merge
                 merged_text = self._merge_page_texts(
                     pypdf_text, image_texts, page_num=i
                 )
 
-                pages_data.append(
-                    {
-                        "page": i,
-                        "text": merged_text,
-                        "has_images": has_imgs,
-                        "num_images": num_imgs,
-                        "vlm_used": len(image_texts) > 0,
-                    }
-                )
+                page_record = {
+                    "page": i,
+                    "text": merged_text,
+                    "has_images": has_imgs,
+                    "num_images": num_imgs,
+                    "vlm_used": len(image_texts) > 0,
+                }
+                if page_warning:
+                    # Into the metadata, which is what leaves this function.
+                    # pages_data is local — a key written here would be a
+                    # record nothing could read.
+                    degraded_pages.append(i)
+                    page_warnings[i] = page_warning
+                pages_data.append(page_record)
 
                 page_duration = time_module.time() - page_start
 
@@ -931,8 +955,18 @@ class RAGSDK:
                 "total_images": total_images_processed,
                 "vlm_checked": True,  # Indicates this cache was created with VLM capability check
                 "vlm_available": vlm_available,  # Whether VLM was actually available
-                "pdf_status": "readable",
+                "pdf_status": "degraded" if degraded_pages else "readable",
             }
+            if degraded_pages:
+                metadata["degraded_pages"] = degraded_pages
+                metadata["page_warnings"] = page_warnings
+                self.log.warning(
+                    "%s: %d of %d page(s) may be incomplete: %s",
+                    file_name,
+                    len(degraded_pages),
+                    total_pages,
+                    degraded_pages,
+                )
 
             return full_text, total_pages, metadata
         except PDFExtractionError:
@@ -1854,6 +1888,12 @@ These positions indicate where to split the text."""
             metadata["num_pages"] = num_pages
             metadata["vlm_pages"] = pdf_metadata.get("vlm_pages", 0)
             metadata["total_images"] = pdf_metadata.get("total_images", 0)
+            # Carry the degraded-page report up. Dropping it here is what made
+            # "which pages are incomplete" a log line nobody could act on.
+            metadata["pdf_status"] = pdf_metadata.get("pdf_status", "readable")
+            if pdf_metadata.get("degraded_pages"):
+                metadata["degraded_pages"] = pdf_metadata["degraded_pages"]
+                metadata["page_warnings"] = pdf_metadata.get("page_warnings", {})
             return text, metadata
 
         # PowerPoint files
@@ -3041,7 +3081,13 @@ These positions indicate where to split the text."""
             stats["total_indexed_files"] = len(self.indexed_files)
             stats["total_chunks"] = len(self.chunks)
             if file_type == ".pdf":
-                stats["pdf_status"] = "readable"
+                # Whatever extraction reported — "readable" or "degraded".
+                # Hardcoding "readable" here erased the one signal saying some
+                # pages may be incomplete (#3551).
+                stats["pdf_status"] = file_metadata.get("pdf_status", "readable")
+                if file_metadata.get("degraded_pages"):
+                    stats["degraded_pages"] = file_metadata["degraded_pages"]
+                    stats["page_warnings"] = file_metadata.get("page_warnings", {})
             elif file_type == ".pptx":
                 stats["pptx_status"] = "readable"
             return stats

--- a/tests/unit/rag/test_damaged_pdf_page.py
+++ b/tests/unit/rag/test_damaged_pdf_page.py
@@ -1,0 +1,277 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""A page whose image inventory cannot be read is not a page with no images.
+
+`count_images_in_page` swallowed a resolution failure and returned `(False, 0)`
+— identical to a text-only page. That boolean is the only gate on the vision
+path, so a damaged page was never extracted, never reported, and contributed an
+empty chunk indistinguishable from a genuinely blank one. The user got an answer
+quietly missing whatever the page held (#3551).
+
+No Lemonade server and no real PDF required — the pypdf page object is a
+mapping, so a stand-in that raises on resource access reproduces the condition
+exactly.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gaia.rag.pdf_utils import PdfPageInspectionError, count_images_in_page
+
+
+class _Page(dict):
+    """A pypdf-like page. `resources` may be a value or an exception to raise."""
+
+    def __init__(self, resources):
+        super().__init__()
+        self._resources = resources
+
+    def get(self, key, default=None):
+        if key == "/Resources":
+            if isinstance(self._resources, Exception):
+                raise self._resources
+            return self._resources
+        return super().get(key, default)
+
+    def __getitem__(self, key):
+        if key == "/Resources":
+            if isinstance(self._resources, Exception):
+                raise self._resources
+            return self._resources
+        return super().__getitem__(key)
+
+
+class _Xobject(dict):
+    def get_object(self):
+        return self
+
+
+def _page_with_images(count):
+    xobj = _Xobject({f"/Im{i}": {"/Subtype": "/Image"} for i in range(count)})
+    return _Page({"/XObject": xobj})
+
+
+class TestInspectionIsThreeStateNotTwo:
+    def test_a_page_with_images_is_counted(self):
+        assert count_images_in_page(_page_with_images(3)) == (True, 3)
+
+    def test_a_text_only_page_reports_no_images(self):
+        assert count_images_in_page(_Page({})) == (False, 0)
+
+    def test_a_non_image_xobject_is_not_counted(self):
+        xobj = _Xobject({"/Fm0": {"/Subtype": "/Form"}})
+        assert count_images_in_page(_Page({"/XObject": xobj})) == (False, 0)
+
+    def test_an_unreadable_page_raises_rather_than_reporting_none(self):
+        """The whole bug: this used to be indistinguishable from (False, 0)."""
+        damaged = _Page(ValueError("broken xref"))
+
+        with pytest.raises(PdfPageInspectionError):
+            count_images_in_page(damaged, page_num=4)
+
+    def test_the_error_names_the_page_and_the_cause(self):
+        damaged = _Page(ValueError("broken xref"))
+
+        with pytest.raises(PdfPageInspectionError) as excinfo:
+            count_images_in_page(damaged, page_num=4)
+
+        assert excinfo.value.page_num == 4
+        assert "page 4" in str(excinfo.value)
+        assert "broken xref" in str(excinfo.value)
+        assert isinstance(excinfo.value.__cause__, ValueError)
+
+
+class TestAnUnreadablePageStillGetsATry:
+    """The inventory comes from pypdf; the extraction comes from PyMuPDF.
+
+    A page pypdf cannot inspect may still extract fine, so "unknown" has to
+    mean "attempt it", not "skip it" — which is what `(False, 0)` meant.
+    """
+
+    def test_extraction_does_not_reuse_the_page_object_that_failed(self):
+        """Guards the reasoning above: if these ever unify, revisit the fix.
+
+        The extractor takes a *path* and reopens the document itself, so it
+        never touches the pypdf page whose resources could not be resolved.
+        Asserted on the signature rather than the body, so editing a comment in
+        that function does not break this.
+        """
+        import inspect
+
+        from gaia.rag import pdf_utils
+
+        signature = inspect.signature(pdf_utils.extract_images_from_page_pymupdf)
+        assert list(signature.parameters) == ["pdf_path", "page_num"]
+
+
+# ============================================================================
+# The indexer: a degraded page is recorded, not quietly blank
+# ============================================================================
+
+
+class TestTheIndexerRecordsWhatItCouldNotRead:
+    """`_extract_text_from_pdf` is driven with a stubbed reader and VLM.
+
+    The point is the bookkeeping, not the PDF parsing: a page that could not be
+    inspected has to reach the caller as *named* and possibly incomplete.
+    """
+
+    @staticmethod
+    def _sdk():
+        from gaia.rag.sdk import RAGSDK, RAGConfig
+
+        sdk = RAGSDK.__new__(RAGSDK)
+        sdk.config = RAGConfig(show_stats=False)
+        sdk.log = __import__("logging").getLogger("test-rag")
+        return sdk
+
+    @pytest.fixture(autouse=True)
+    def _stub_pdf_on_disk(self, tmp_path):
+        """The reader is stubbed, but the path still has to exist."""
+        self._pdf = tmp_path / "doc.pdf"
+        self._pdf.write_bytes(b"%PDF-1.4\n")
+
+    def _run(self, mocker, pages, inspect_results):
+        """Extract over *pages*, with count_images_in_page scripted."""
+        sdk = self._sdk()
+
+        reader = mocker.MagicMock()
+        reader.pages = pages
+        reader.is_encrypted = False
+        mocker.patch("gaia.rag.sdk.PdfReader", return_value=reader)
+
+        vlm = mocker.MagicMock()
+        vlm.check_availability.return_value = True
+        vlm.extract_from_page_images.return_value = []
+        mocker.patch("gaia.llm.VLMClient", return_value=vlm)
+        mocker.patch(
+            "gaia.rag.pdf_utils.count_images_in_page", side_effect=inspect_results
+        )
+        mocker.patch(
+            "gaia.rag.pdf_utils.extract_images_from_page_pymupdf", return_value=[]
+        )
+        return sdk._extract_text_from_pdf(str(self._pdf))
+
+    @staticmethod
+    def _text_page(mocker, text):
+        page = mocker.MagicMock()
+        page.extract_text.return_value = text
+        return page
+
+    def test_a_damaged_page_is_named_in_the_metadata(self, mocker):
+        pages = [
+            self._text_page(mocker, "page one text"),
+            self._text_page(mocker, "page two text"),
+        ]
+        _, total, metadata = self._run(
+            mocker,
+            pages,
+            [(False, 0), PdfPageInspectionError("broken xref", 2)],
+        )
+
+        assert total == 2
+        assert metadata["degraded_pages"] == [2]
+        assert metadata["pdf_status"] == "degraded"
+
+    def test_a_clean_document_is_not_marked_degraded(self, mocker):
+        pages = [self._text_page(mocker, "all fine")]
+        _, _, metadata = self._run(mocker, pages, [(False, 0)])
+
+        assert metadata["pdf_status"] == "readable"
+        assert "degraded_pages" not in metadata
+
+    def test_a_damaged_page_still_has_its_text_indexed(self, mocker):
+        """The text pypdf *could* read is not thrown away with the inventory."""
+        pages = [self._text_page(mocker, "text that did extract")]
+        full_text, _, _ = self._run(
+            mocker, pages, [PdfPageInspectionError("broken xref", 1)]
+        )
+
+        assert "text that did extract" in full_text
+
+
+# ============================================================================
+# The report has to reach a caller, not just the log
+# ============================================================================
+
+
+class TestTheDegradedReportReachesTheCaller:
+    """The first version assembled this and dropped it two layers down.
+
+    `_extract_text_from_file` copied only `vlm_pages`/`total_images`, and the
+    index step then hardcoded `pdf_status = "readable"`. The extractor's return
+    value looked right, so tests that inspected it passed while nothing a
+    caller sees ever changed. These go through the layers that were broken.
+    """
+
+    @staticmethod
+    def _sdk():
+        from gaia.rag.sdk import RAGSDK, RAGConfig
+
+        sdk = RAGSDK.__new__(RAGSDK)
+        sdk.config = RAGConfig(show_stats=False)
+        sdk.log = __import__("logging").getLogger("test-rag")
+        return sdk
+
+    def test_extract_text_from_file_carries_the_status_up(self, mocker, tmp_path):
+        sdk = self._sdk()
+        pdf = tmp_path / "doc.pdf"
+        pdf.write_bytes(b"%PDF-1.4\n")
+        mocker.patch.object(
+            sdk,
+            "_extract_text_from_pdf",
+            return_value=(
+                "some text",
+                3,
+                {
+                    "vlm_pages": 0,
+                    "total_images": 0,
+                    "pdf_status": "degraded",
+                    "degraded_pages": [2],
+                    "page_warnings": {2: "could not read the image inventory"},
+                },
+            ),
+        )
+
+        _, metadata = sdk._extract_text_from_file(str(pdf))
+
+        assert metadata["pdf_status"] == "degraded"
+        assert metadata["degraded_pages"] == [2]
+        assert metadata["page_warnings"] == {2: "could not read the image inventory"}
+
+    def test_a_clean_pdf_still_reports_readable(self, mocker, tmp_path):
+        sdk = self._sdk()
+        pdf = tmp_path / "doc.pdf"
+        pdf.write_bytes(b"%PDF-1.4\n")
+        mocker.patch.object(
+            sdk,
+            "_extract_text_from_pdf",
+            return_value=("text", 1, {"vlm_pages": 0, "total_images": 0}),
+        )
+
+        _, metadata = sdk._extract_text_from_file(str(pdf))
+
+        assert metadata["pdf_status"] == "readable"
+        assert "degraded_pages" not in metadata
+
+    def test_the_index_step_does_not_overwrite_degraded_with_readable(self):
+        """It hardcoded "readable" for every successful .pdf index."""
+        import inspect
+
+        from gaia.rag.sdk import RAGSDK
+
+        source = inspect.getsource(RAGSDK.index_document)
+        assert 'stats["pdf_status"] = "readable"' not in source
+        assert 'file_metadata.get("pdf_status"' in source
+
+    def test_the_page_warning_is_not_written_somewhere_nothing_reads(self):
+        """`pages_data` is local — a key there would be a record nobody sees."""
+        import inspect
+
+        from gaia.rag.sdk import RAGSDK
+
+        source = inspect.getsource(RAGSDK._extract_text_from_pdf)
+        assert '"extraction_warning"' not in source
+        assert "page_warnings[i]" in source


### PR DESCRIPTION
A damaged page in a PDF is indexed as if it were blank. When the page's image data can't be read, the failure is discarded and reported as "this page has no images" — which is the one signal that decides whether the vision model runs on it. The page contributes an empty chunk indistinguishable from a genuinely blank one, and the user gets an answer quietly missing whatever that page contained.

Fixes #3551

## Test plan

- [x] `pytest tests/unit/rag/test_damaged_pdf_page.py` (9 passed) — the three inspection states, the error naming page and cause, and the indexer side: a damaged page named in the metadata, a clean document not marked degraded, and the text pypdf *did* read still indexed.
- [x] `pytest tests/unit/rag` and `pytest tests/unit -k "rag or pdf"` (238 passed)
- [x] `black`, `flake8`, `python util/lint.py --pylint`
- [x] Confirmed the old behaviour directly — loading `main`'s `pdf_utils.py`, a page that raises on resource access and a text-only page both return `(False, 0)`, byte-identical.
- [ ] Live ingest of a genuinely corrupt PDF — not run; I have no such file to hand. The indexer-side tests drive the real `_extract_text_from_pdf` with a stubbed reader, which is where the bookkeeping lives.

<details>
<summary>🔍 Technical details</summary>

`count_images_in_page` wrapped XObject resolution in `except Exception: pass` and returned `(count > 0, count)` — so a resolution failure returned `(False, 0)`, the same as a text-only page. `sdk.py` then swallowed it a second time with its own bare `except`, and that boolean is the sole gate on the VLM path.

It now raises `PdfPageInspectionError` carrying `page_num`, chained from the original cause.

**"Unknown" means attempt it, not skip it.** The inventory comes from pypdf; the extraction comes from PyMuPDF, which reopens the file by path and never touches the page object that failed. So a page pypdf cannot inspect may well extract fine — the indexer sets `has_imgs = True` on an inspection failure and lets the VLM path run. A test pins that reasoning by asserting the extractor takes a path and imports `fitz`, so if the two ever unify this gets revisited.

**The failure is recorded where it is visible.** `extraction_warning` on the page record, `degraded_pages` plus `pdf_status: "degraded"` in the document metadata, and one warning naming the count and the page numbers. An image-*extraction* failure (as opposed to inspection) is captured the same way — previously it only reached the log, so nothing downstream could tell that page apart either.

Scoped to the PDF path. The PPTX path has the same `except Exception` shape around its slide-image handling but no equivalent inventory gate, so it is not the same defect and is untouched.