### PR TITLE
fix(talk): say when the microphone fails instead of printing "Listening…"

### DIFF
--- a/docs/guides/talk.mdx
+++ b/docs/guides/talk.mdx
@@ -85,7 +85,7 @@ Talk mode leans on two native libraries: PortAudio for the microphone, and espea
     ⠴ Listening...
     ```
 
-    Say "exit" or "quit" to end the session
+    Say "stop" to end the session
   </Step>
 </Steps>
 
@@ -93,7 +93,7 @@ Talk mode leans on two native libraries: PortAudio for the microphone, and espea
 
 <CardGroup cols={2}>
   <Card title="Exit Session" icon="door-open">
-    Say **"exit"** or **"quit"**
+    Say **"stop"**
   </Card>
 
   <Card title="Clear History" icon="rotate-right">
@@ -101,11 +101,7 @@ Talk mode leans on two native libraries: PortAudio for the microphone, and espea
   </Card>
 
   <Card title="Trigger Response" icon="pause">
-    Natural pauses (>1 second)
-  </Card>
-
-  <Card title="Stop Playback" icon="stop">
-    Press **Enter** during audio
+    Natural pauses (~1.3 seconds)
   </Card>
 </CardGroup>
 

--- a/src/gaia/audio/audio_client.py
+++ b/src/gaia/audio/audio_client.py
@@ -60,6 +60,13 @@ class AudioClient:
         self.mic_threshold = mic_threshold
         self.enable_tts = enable_tts
 
+        #: True once the session is stopping on purpose ("stop", Ctrl+C). The
+        #: supervisor cannot otherwise tell a requested quit from a dead
+        #: microphone: ``stop_recording`` clears the flag and then joins threads
+        #: that may be mid-transcribe, so the loop sees "not recording, still
+        #: alive" on the ordinary exit path too (#3554).
+        self._stop_requested = False
+
         # Audio state
         self.is_speaking = False
         self.tts_thread = None
@@ -80,11 +87,14 @@ class AudioClient:
         """Start a voice-based chat session."""
         try:
             self.log.debug("Initializing voice chat...")
+            self._stop_requested = False
+            # Only the words the loop actually matches. Enter-to-interrupt was
+            # advertised on every launch and implemented only in
+            # ``process_voice_input``, which nothing calls — so pressing Enter
+            # did nothing (#3554).
             print(
                 "Starting voice chat.\n"
-                "Say 'stop' to quit application "
-                "or 'restart' to clear the chat history.\n"
-                "Press Enter key to stop during audio playback."
+                "Say 'stop' to quit, or 'restart' to clear the chat history."
             )
 
             # Initialize TTS before starting voice chat
@@ -137,12 +147,22 @@ class AudioClient:
                         self.log.debug("Process thread stopped unexpectedly")
                         break
                     if not self.whisper_asr or not self.whisper_asr.is_recording:
-                        self.log.warning("Recording stopped unexpectedly")
+                        # Say why, on screen. This used to be a debug-level
+                        # warning, so a dead microphone read as an endless
+                        # "Listening…" (#3554).
+                        reason = getattr(self.whisper_asr, "mic_error", None)
+                        if reason:
+                            self.log.error(reason)
+                            print(f"\n{reason}")
+                        elif not self._stop_requested:
+                            self.log.warning("Recording stopped unexpectedly")
+                            print("\nRecording stopped. Voice input is not active.")
                         break
                     await asyncio.sleep(0.1)
 
             except KeyboardInterrupt:
                 self.log.info("Received keyboard interrupt")
+                self._stop_requested = True
                 print("\nStopping voice chat...")
             except Exception as e:
                 self.log.error(f"Error in main processing loop: {str(e)}")
@@ -203,7 +223,12 @@ class AudioClient:
 
                 interrupt_event.set()
                 if text_queue:
-                    text_queue.put("__HALT__")  # Signal TTS to stop immediately
+                    # Non-blocking: a wedged queue must not swallow the
+                    # interrupt the user just asked for.
+                    try:
+                        text_queue.put_nowait("__HALT__")
+                    except queue.Full:
+                        self.log.debug("TTS queue full; halt signal dropped")
 
             # Start keyboard listener thread
             keyboard_thread = threading.Thread(target=keyboard_listener)
@@ -212,6 +237,34 @@ class AudioClient:
 
             if self.enable_tts:
                 text_queue = queue.Queue(maxsize=100)
+
+                # Latched once the queue wedges. Without it every remaining
+                # chunk waits the full timeout again — a 200-chunk answer
+                # becomes minutes of stalled printing and 200 identical
+                # errors, which is the hang this is meant to close.
+                speech_dropped = False
+
+                def speak(item):
+                    """Hand *item* to TTS; never block the answer on it.
+
+                    The queue is bounded, so a consumer that died takes the
+                    LLM stream down with it once 100 chunks pile up. Speech is
+                    the optional half — drop it and keep printing (#3554).
+                    """
+                    nonlocal speech_dropped
+                    if speech_dropped:
+                        return False
+                    try:
+                        text_queue.put(item, timeout=5.0)
+                        return True
+                    except queue.Full:
+                        speech_dropped = True
+                        self.log.error(
+                            "Voice output is not keeping up and has been "
+                            "dropped for the rest of this reply; the text is "
+                            "unaffected."
+                        )
+                        return False
 
                 # Define status callback to update speaking state
                 def tts_status_callback(is_speaking):
@@ -250,7 +303,7 @@ class AudioClient:
                     if interrupt_event.is_set():
                         self.log.debug("Keyboard interrupt detected, stopping...")
                         if text_queue:
-                            text_queue.put("__END__")
+                            speak("__END__")
                         break
 
                     if self.transcription_queue.qsize() > 0:
@@ -258,7 +311,7 @@ class AudioClient:
                             "New input detected during generation, stopping..."
                         )
                         if text_queue:
-                            text_queue.put("__END__")
+                            speak("__END__")
                         # Use LLMClient to halt generation
                         if self.llm_client.halt_generation():
                             self.log.debug("Generation interrupted for new input.")
@@ -273,10 +326,10 @@ class AudioClient:
                                 if len(initial_buffer) >= 20 or chunk.endswith(
                                     ("\n", ". ", "! ", "? ")
                                 ):
-                                    text_queue.put(initial_buffer)
+                                    speak(initial_buffer)
                                     initial_buffer_sent = True
                             else:
-                                text_queue.put(chunk)
+                                speak(chunk)
                         accumulated_response += chunk
 
                 # Send any remaining buffered content
@@ -285,12 +338,12 @@ class AudioClient:
                         # Small delay for very short responses
                         if len(initial_buffer) <= 20:
                             await asyncio.sleep(0.1)
-                        text_queue.put(initial_buffer)
-                    text_queue.put("__END__")
+                        speak(initial_buffer)
+                    speak("__END__")
 
             except Exception as e:
                 if text_queue:
-                    text_queue.put("__END__")
+                    speak("__END__")
                 raise e
             finally:
                 if self.tts_thread and self.tts_thread.is_alive():
@@ -317,7 +370,11 @@ class AudioClient:
 
         except Exception as e:
             if text_queue:
-                text_queue.put("__END__")
+                # Bounded: a wedged queue must not turn one failure into a hang.
+                try:
+                    text_queue.put("__END__", timeout=5.0)
+                except queue.Full:
+                    self.log.debug("TTS queue full; end signal dropped")
             raise e
         finally:
             if self.tts_thread and self.tts_thread.is_alive():
@@ -359,9 +416,13 @@ class AudioClient:
             daemon=True,
         )
         tts_thread.start()
-        # Send the whole text and end
-        text_queue.put(text)
-        text_queue.put("__END__")
+        # Send the whole text and end. Bounded, so a TTS thread that died on a
+        # broken output device cannot block the caller (#3554).
+        try:
+            text_queue.put(text, timeout=5.0)
+            text_queue.put("__END__", timeout=5.0)
+        except queue.Full:
+            self.log.error("Voice output is not consuming; speech skipped.")
         tts_thread.join(timeout=5.0)
 
     def _check_mic_levels(self):
@@ -401,7 +462,14 @@ class AudioClient:
             else:
                 self.log.debug(f"Mic check passed (peak level: {max_energy:.4f})")
         except Exception as e:
-            self.log.debug(f"Mic level check skipped: {e}")
+            # A device that cannot be opened is the thing the user needs to
+            # know about first, not a debug line nobody sees (#3554).
+            self.log.error(f"Microphone check failed: {e}")
+            print(
+                f"WARNING: Could not open the microphone ({e}).\n"
+                f"  - Try a different device: gaia talk --audio-device-index <N>\n"
+                f"  - List devices with: gaia test asr-list-audio-devices"
+            )
         finally:
             if stream:
                 stream.stop()
@@ -433,6 +501,10 @@ class AudioClient:
                     # Handle special commands
                     if cleaned_text in ["stop"]:
                         print("\nStopping voice chat...")
+                        # Before stop_recording: the supervisor polls every
+                        # 0.1s and would otherwise report this quit as a
+                        # failure while the threads join (#3554).
+                        self._stop_requested = True
                         self.whisper_asr.stop_recording()
                         break
 

--- a/src/gaia/audio/audio_recorder.py
+++ b/src/gaia/audio/audio_recorder.py
@@ -48,6 +48,12 @@ class AudioRecorder:
         self.audio_queue = queue.Queue()
         self.stream = None  # Add stream as class attribute
 
+        #: Why the microphone stopped, set by the capture thread. ``None`` until
+        #: something goes wrong. Capture runs on its own thread, so raising
+        #: there reaches nobody — the caller reads this to say what happened
+        #: instead of printing "Listening…" at a dead device (#3554).
+        self.mic_error = None
+
         # Voice detection parameters
         self.SILENCE_THRESHOLD = 0.003
         self.MIN_AUDIO_LENGTH = self.RATE * 0.25
@@ -71,8 +77,31 @@ class AudioRecorder:
         """Detect if audio chunk contains speech based on amplitude."""
         return np.abs(audio_chunk).mean() > self.SILENCE_THRESHOLD
 
+    def device_error_message(self, verb: str, error: Exception) -> str:
+        """One actionable line naming the device and what to try next."""
+        try:
+            name = sd.query_devices(self.device_index)["name"]
+            device = f"[{self.device_index}] {name}"
+        except Exception:  # noqa: BLE001 - the device is what is broken
+            device = (
+                f"index {self.device_index}"
+                if self.device_index is not None
+                else "the default input device"
+            )
+        return (
+            f"Microphone unavailable: could not {verb} {device} ({error}). "
+            "Pick another with `gaia talk --audio-device-index <N>`; list them "
+            "with `gaia test asr-list-audio-devices`."
+        )
+
     def _record_audio(self):
-        """Internal method to record audio."""
+        """Internal method to record audio.
+
+        Any failure clears ``is_recording`` and records the reason on
+        ``mic_error``. This runs on its own thread, so the old ``raise`` reached
+        nobody and left the flag set — which is what kept ``gaia talk`` printing
+        "Listening…" at a microphone that never opened (#3554).
+        """
         try:
             device_info = sd.query_devices(self.device_index)
             self.log.debug(f"Using audio device: {device_info['name']}")
@@ -148,13 +177,18 @@ class AudioRecorder:
                             silence_counter = 0
 
                 except Exception as e:
-                    self.log.error(f"Error reading from stream: {e}")
+                    self.mic_error = self.device_error_message("read from", e)
+                    self.log.error(self.mic_error)
                     break
 
         except Exception as e:
-            self.log.error(f"Error with device {self.device_index}: {e}")
-            raise
+            # Opening or querying the device failed, so recording never began.
+            self.mic_error = self.device_error_message("open", e)
+            self.log.error(self.mic_error)
         finally:
+            # Always clear the flag: the supervisor loop polls it to notice the
+            # capture thread is gone, and it is the only way out of "Listening…".
+            self.is_recording = False
             try:
                 if self.stream is not None:
                     self.stream.stop()
@@ -208,6 +242,7 @@ class AudioRecorder:
             return
 
         # Set recording flag before starting threads
+        self.mic_error = None
         self.is_recording = True
 
         # Start record thread

--- a/src/gaia/audio/kokoro_tts.py
+++ b/src/gaia/audio/kokoro_tts.py
@@ -322,6 +322,21 @@ class KokoroTTS:
 
         return audio, combined_phonemes, stats
 
+    @staticmethod
+    def _drain_text_queue(text_queue: queue.Queue) -> None:
+        """Consume until the producer's terminator, so it never blocks.
+
+        The producer puts onto a bounded queue; with no consumer it wedges at
+        100 chunks and the LLM stream stops mid-answer.
+        """
+        while True:
+            try:
+                item = text_queue.get(timeout=30.0)
+            except queue.Empty:
+                return
+            if item in ("__END__", "__HALT__", None):
+                return
+
     def generate_speech_streaming(
         self, text_queue: queue.Queue, status_callback=None, interrupt_event=None
     ) -> None:
@@ -330,15 +345,32 @@ class KokoroTTS:
         buffer = ""
         audio_buffer = queue.Queue(maxsize=100)  # Buffer for processed audio chunks
 
-        # Initialize audio stream
-        stream = sd.OutputStream(
-            samplerate=24000,
-            channels=1,
-            dtype=np.float32,
-            blocksize=2400,  # 100ms buffer
-            latency="low",
-        )
-        stream.start()
+        # Initialize audio stream. Inside a try: this used to raise straight out
+        # of the TTS thread, and the producer then blocked forever on a full
+        # text_queue — a broken speaker froze the whole answer (#3554).
+        try:
+            stream = sd.OutputStream(
+                samplerate=24000,
+                channels=1,
+                dtype=np.float32,
+                blocksize=2400,  # 100ms buffer
+                latency="low",
+            )
+            stream.start()
+        except Exception as e:
+            message = (
+                f"Speaker unavailable: could not open audio output ({e}). "
+                "The reply is shown as text; voice output is off for this "
+                "session."
+            )
+            self.log.error(message)
+            print(f"\n{message}")
+            # Keep draining so the producer can finish its stream. Returning
+            # here would leave it blocked on a queue nobody reads.
+            self._drain_text_queue(text_queue)
+            if status_callback:
+                status_callback(False)
+            return
         self.log.debug("Audio stream initialized")
 
         # Playback thread function

--- a/src/gaia/audio/whisper_asr.py
+++ b/src/gaia/audio/whisper_asr.py
@@ -94,7 +94,13 @@ class WhisperAsr(AudioRecorder):
         self.transcription_queue = transcription_queue
 
     def _record_audio_streaming(self):
-        """Record audio for streaming mode - puts chunks directly into queue."""
+        """Record audio for streaming mode - puts chunks directly into queue.
+
+        Any failure clears ``is_recording`` and records the reason on
+        ``mic_error``. This runs on its own thread, so raising here reaches
+        nobody: leaving the flag set is what left ``gaia talk`` printing
+        "Listening…" forever against a microphone that never opened (#3554).
+        """
         try:
             # Log device info
             if self.device_index is not None:
@@ -158,20 +164,32 @@ class WhisperAsr(AudioRecorder):
                         audio_buffer = audio_buffer[chunk_size - overlap_size :]
 
                 except Exception as e:
-                    self.log.error(f"Error reading from stream: {e}")
+                    self.mic_error = self.device_error_message("read from", e)
+                    self.log.error(self.mic_error)
                     break
 
             # Process any remaining audio
             if len(audio_buffer) > self.RATE * 0.5:  # At least 0.5 seconds
                 self.audio_queue.put(audio_buffer.copy())
 
+        except Exception as e:
+            # Opening or querying the device failed, so recording never began.
+            self.mic_error = self.device_error_message("open", e)
+            self.log.error(self.mic_error)
         finally:
+            # Always clear the flag: the supervisor loop polls it to notice the
+            # capture thread is gone, and it is the only way out of "Listening…".
+            self.is_recording = False
             if self.stream:
-                self.stream.stop()
-                self.stream.close()
+                try:
+                    self.stream.stop()
+                    self.stream.close()
+                except Exception as e:  # noqa: BLE001 - teardown of a dead device
+                    self.log.debug(f"Ignoring error closing the input stream: {e}")
 
     def start_recording_streaming(self):
         """Start recording in streaming mode."""
+        self.mic_error = None
         self.is_recording = True
         self.record_thread = threading.Thread(target=self._record_audio_streaming)
         self.record_thread.start()

--- a/src/gaia/talk/README.md
+++ b/src/gaia/talk/README.md
@@ -39,8 +39,7 @@ python src/gaia/talk/app.py --system-prompt "You are a helpful cooking assistant
 - **Voice Input**: Uses Whisper ASR for speech recognition
 - **Voice Output**: Uses Kokoro TTS for speech synthesis  
 - **Direct LLM**: Communicates directly with LLM via LLMClient (no agent server needed)
-- **Interrupts**: Press Enter to interrupt generation or TTS
-- **Commands**: Say "stop" to quit the application
+- **Commands**: Say "stop" to quit the application, or "restart" to clear the chat history
 - **Stats**: Optional performance statistics display
 - **Flexible**: Supports both local LLM and OpenAI API
 
@@ -54,5 +53,5 @@ python src/gaia/talk/app.py --system-prompt "You are a helpful cooking assistant
 ## Controls
 
 - **Speak**: Just talk normally - the app will detect when you stop speaking
-- **Interrupt**: Press Enter during generation or speech playback
 - **Quit**: Say "stop" or press Ctrl+C
+- **Clear history**: Say "restart"

--- a/tests/unit/test_mic_failure_reporting.py
+++ b/tests/unit/test_mic_failure_reporting.py
@@ -1,0 +1,432 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""A microphone that does not work has to say so, not print "Listening…".
+
+`gaia talk` spun on "Listening…" indefinitely when the mic failed: capture runs
+on its own thread, so the `raise` reached nobody, `is_recording` stayed set, and
+the supervisor loop had no reason to stop waiting. The device error was logged
+at debug level, so nothing reached the user (#3554).
+
+Two more claims on the same screen were false: every launch advertised
+Enter-to-interrupt, whose only implementation nothing calls, and the guide told
+users to say "exit" or "quit" when the loop matches only "stop".
+
+No audio hardware required — `sounddevice` is patched, which is exactly the
+failure being reproduced.
+"""
+
+from __future__ import annotations
+
+import queue
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("numpy")
+
+# ``sounddevice`` needs real audio hardware to install on a CI runner, and the
+# modules under test already treat it as optional (``sd = None`` on
+# ImportError). A stand-in keeps these tests running everywhere — and a mic
+# failure is exactly what they reproduce, so the fake IS the scenario.
+if "sounddevice" not in sys.modules:
+    _fake = types.ModuleType("sounddevice")
+    _fake.query_devices = lambda *a, **k: {"index": 0, "name": "Fake Mic"}
+    _fake.InputStream = MagicMock()
+    _fake.OutputStream = MagicMock()
+    sys.modules["sounddevice"] = _fake
+
+import sounddevice as sd  # noqa: E402
+
+from gaia.audio.audio_recorder import AudioRecorder  # noqa: E402
+
+
+@pytest.fixture
+def recorder():
+    """A recorder with the device layer stubbed out."""
+    with patch.object(
+        sd, "query_devices", return_value={"index": 0, "name": "Fake Mic"}
+    ):
+        rec = AudioRecorder(device_index=0)
+    rec.log = MagicMock()
+    return rec
+
+
+class TestACaptureFailureStopsRecording:
+    """The flag is the only way out of the supervisor's wait loop."""
+
+    def test_a_device_that_cannot_open_clears_is_recording(self, recorder):
+        recorder.is_recording = True
+        with patch.object(sd, "InputStream", side_effect=OSError("device busy")):
+            recorder._record_audio()
+
+        assert recorder.is_recording is False
+
+    def test_a_device_that_cannot_open_records_why(self, recorder):
+        recorder.is_recording = True
+        with patch.object(sd, "InputStream", side_effect=OSError("device busy")):
+            recorder._record_audio()
+
+        assert recorder.mic_error
+        assert "device busy" in recorder.mic_error
+
+    def test_a_read_failure_mid_session_also_clears_it(self, recorder):
+        stream = MagicMock()
+        stream.read.side_effect = OSError("input overflowed")
+        recorder.is_recording = True
+        with patch.object(sd, "InputStream", return_value=stream):
+            recorder._record_audio()
+
+        assert recorder.is_recording is False
+        assert "input overflowed" in recorder.mic_error
+
+    def test_it_does_not_raise_out_of_the_thread(self, recorder):
+        """Raising here reached nobody; that is why the flag matters."""
+        recorder.is_recording = True
+        with patch.object(sd, "InputStream", side_effect=OSError("device busy")):
+            recorder._record_audio()  # must not raise
+
+
+class TestTheMessageIsActionable:
+    def test_it_names_the_device(self, recorder):
+        message = recorder.device_error_message("open", OSError("nope"))
+        assert "Fake Mic" in message
+        assert "[0]" in message
+
+    def test_it_says_what_to_try_next(self, recorder):
+        message = recorder.device_error_message("open", OSError("nope"))
+        assert "--audio-device-index" in message
+        assert "asr-list-audio-devices" in message
+
+    def test_it_copes_when_even_the_device_query_fails(self, recorder):
+        with patch.object(sd, "query_devices", side_effect=OSError("no such device")):
+            message = recorder.device_error_message("open", OSError("nope"))
+        assert "index 0" in message
+
+    def test_it_names_the_default_device_when_none_was_chosen(self, recorder):
+        recorder.device_index = None
+        with patch.object(sd, "query_devices", side_effect=OSError("boom")):
+            message = recorder.device_error_message("open", OSError("nope"))
+        assert "default input device" in message
+
+
+class TestStartingRecordingClearsAStaleError:
+    def test_a_previous_failure_does_not_persist(self, recorder):
+        recorder.mic_error = "something from last time"
+        recorder.is_recording = False
+        with (
+            patch.object(sd, "InputStream", return_value=MagicMock()),
+            patch("threading.Thread"),
+        ):
+            recorder.start_recording()
+
+        assert recorder.mic_error is None
+
+
+class TestTheLaunchBannerOnlyClaimsWhatWorks:
+    """Enter-to-interrupt was advertised and never implemented."""
+
+    @staticmethod
+    def _banner_source() -> str:
+        import inspect
+
+        from gaia.audio.audio_client import AudioClient
+
+        return inspect.getsource(AudioClient.start_voice_chat)
+
+    def test_it_no_longer_advertises_enter_to_interrupt(self):
+        assert "Press Enter key to stop" not in self._banner_source()
+
+    def test_it_still_names_the_words_the_loop_matches(self):
+        source = self._banner_source()
+        assert "'stop'" in source
+        assert "'restart'" in source
+
+
+class TestTheGuideMatchesTheCode:
+    """The doc said "exit"/"quit"; only "stop" is recognised."""
+
+    @staticmethod
+    def _guide() -> str:
+        from pathlib import Path
+
+        root = Path(__file__).resolve().parents[2]
+        return (root / "docs" / "guides" / "talk.mdx").read_text(encoding="utf-8")
+
+    def test_it_does_not_tell_users_to_say_exit_or_quit(self):
+        guide = self._guide()
+        assert 'Say "exit" or "quit"' not in guide
+        assert 'Say **"exit"** or **"quit"**' not in guide
+
+    def test_it_tells_users_to_say_stop(self):
+        assert 'Say **"stop"**' in self._guide()
+
+    def test_it_does_not_advertise_enter_to_interrupt(self):
+        assert "Press **Enter** during audio" not in self._guide()
+
+    def test_the_stop_word_in_the_guide_is_the_one_the_code_matches(self):
+        import inspect
+
+        from gaia.audio.audio_client import AudioClient
+
+        source = inspect.getsource(AudioClient._process_audio_wrapper)
+        assert 'cleaned_text in ["stop"]' in source
+
+
+class TestAFailedSpeakerDoesNotWedgeTheAnswer:
+    """The producer puts onto a bounded queue; a dead consumer blocked it."""
+
+    def test_the_drain_helper_releases_the_producer(self):
+        from gaia.audio.kokoro_tts import KokoroTTS
+
+        text_queue = queue.Queue(maxsize=3)
+        text_queue.put("one")
+        text_queue.put("__END__")
+
+        KokoroTTS._drain_text_queue(text_queue)
+
+        assert text_queue.empty()
+
+    @pytest.mark.parametrize("terminator", ["__END__", "__HALT__", None])
+    def test_it_stops_at_every_terminator(self, terminator):
+        from gaia.audio.kokoro_tts import KokoroTTS
+
+        text_queue = queue.Queue()
+        text_queue.put(terminator)
+
+        KokoroTTS._drain_text_queue(text_queue)
+
+        assert text_queue.empty()
+
+    def test_the_output_stream_is_opened_inside_a_try(self):
+        """Opened outside it, a device failure killed the consumer thread."""
+        import inspect
+
+        from gaia.audio.kokoro_tts import KokoroTTS
+
+        source = inspect.getsource(KokoroTTS.generate_speech_streaming)
+        before_open = source.split("sd.OutputStream")[0]
+        assert "try:" in before_open
+        assert "_drain_text_queue" in source
+
+
+# ============================================================================
+# The success path: quitting normally must not look like a failure
+# ============================================================================
+
+
+class TestARequestedStopIsNotReportedAsAFailure:
+    """The gap the review found: nothing exercised a normal launch-and-quit.
+
+    `stop_recording()` clears `is_recording` and *then* joins threads that may
+    be mid-transcribe. Through that whole window the supervisor sees "not
+    recording, thread still alive" — the same state a dead microphone leaves —
+    and its 0.1s poll makes that essentially every quit, not a rare race.
+    """
+
+    @staticmethod
+    def _client():
+        from gaia.audio.audio_client import AudioClient
+
+        client = AudioClient.__new__(AudioClient)
+        client.log = MagicMock()
+        client._stop_requested = False
+        client.whisper_asr = MagicMock()
+        client.whisper_asr.mic_error = None
+        client.whisper_asr.is_recording = False
+        return client
+
+    @staticmethod
+    def _supervisor_message(client):
+        """The branch the supervisor loop takes, as the user would see it."""
+        reason = getattr(client.whisper_asr, "mic_error", None)
+        if reason:
+            return reason
+        if not client._stop_requested:
+            return "Recording stopped. Voice input is not active."
+        return None
+
+    def test_a_requested_stop_prints_nothing(self):
+        client = self._client()
+        client._stop_requested = True
+
+        assert self._supervisor_message(client) is None
+
+    def test_an_unrequested_stop_still_reports(self):
+        client = self._client()
+
+        assert "not active" in self._supervisor_message(client)
+
+    def test_a_mic_error_wins_over_everything(self):
+        client = self._client()
+        client._stop_requested = True
+        client.whisper_asr.mic_error = "Microphone unavailable: could not open …"
+
+        assert "Microphone unavailable" in self._supervisor_message(client)
+
+    def test_the_stop_word_sets_the_flag_before_stopping(self):
+        """Order matters: set after, and the supervisor already misreported."""
+        import inspect
+
+        from gaia.audio.audio_client import AudioClient
+
+        source = inspect.getsource(AudioClient._process_audio_wrapper)
+        flag = source.index("self._stop_requested = True")
+        stop = source.index("self.whisper_asr.stop_recording()", flag - 400)
+        assert flag < stop
+
+    def test_ctrl_c_sets_it_too(self):
+        import inspect
+
+        from gaia.audio.audio_client import AudioClient
+
+        source = inspect.getsource(AudioClient.start_voice_chat)
+        block = source.split("except KeyboardInterrupt:")[1][:300]
+        assert "self._stop_requested = True" in block
+
+    def test_a_new_session_clears_a_previous_stop(self):
+        import inspect
+
+        from gaia.audio.audio_client import AudioClient
+
+        source = inspect.getsource(AudioClient.start_voice_chat)
+        assert "self._stop_requested = False" in source
+
+
+class TestDroppedSpeechIsDecidedOnce:
+    """ "Dropped for the rest of this reply" has to mean it.
+
+    Without a latch every remaining chunk waits the full timeout again, so a
+    long answer stalls in five-second steps — the hang, slower.
+    """
+
+    @staticmethod
+    def _speak_with_a_full_queue():
+        """Rebuild the guard over a queue nothing consumes."""
+        import queue as _queue
+
+        text_queue = _queue.Queue(maxsize=1)
+        text_queue.put("already full")
+        log = MagicMock()
+        state = {"dropped": False}
+
+        def speak(item):
+            if state["dropped"]:
+                return False
+            try:
+                text_queue.put(item, timeout=0.05)
+                return True
+            except _queue.Full:
+                state["dropped"] = True
+                log.error("dropped")
+                return False
+
+        return speak, log, state
+
+    def test_the_first_failure_latches(self):
+        speak, _, state = self._speak_with_a_full_queue()
+
+        assert speak("one") is False
+        assert state["dropped"] is True
+
+    def test_later_chunks_return_immediately(self):
+        import time
+
+        speak, _, _ = self._speak_with_a_full_queue()
+        speak("one")  # latches
+
+        started = time.time()
+        for i in range(50):
+            assert speak(f"chunk {i}") is False
+        assert time.time() - started < 0.05
+
+    def test_the_error_is_logged_once_not_per_chunk(self):
+        speak, log, _ = self._speak_with_a_full_queue()
+
+        for i in range(10):
+            speak(f"chunk {i}")
+
+        assert log.error.call_count == 1
+
+    def test_the_real_guard_is_latched(self):
+        """Pins the production code, not just this reconstruction.
+
+        The guard lives in ``process_voice_input``, which nothing in the tree
+        calls today — see ``TestTheLivePlaybackPathIsBounded`` for the path
+        ``gaia talk`` actually takes.
+        """
+        import inspect
+
+        from gaia.audio.audio_client import AudioClient
+
+        source = inspect.getsource(AudioClient.process_voice_input)
+        assert "speech_dropped = False" in source
+        assert "nonlocal speech_dropped" in source
+        assert "if speech_dropped:" in source
+
+
+class TestTheLivePlaybackPathIsBounded:
+    """``gaia talk`` speaks through ``speak_text``, not ``process_voice_input``.
+
+    TalkSDK → ``start_voice_chat(voice_processor)`` → ``_process_audio_wrapper``
+    → the callback → ``speak_text``. The queue hang #3554 describes has the same
+    shape on both, but only this one is reachable.
+    """
+
+    def test_speak_text_never_puts_without_a_timeout(self):
+        import inspect
+
+        from gaia.audio.audio_client import AudioClient
+
+        source = inspect.getsource(AudioClient.speak_text)
+        for line in source.splitlines():
+            if "text_queue.put(" in line:
+                assert "timeout=" in line or "put_nowait" in line, line
+
+    def test_speak_text_survives_a_consumer_that_never_reads(self, monkeypatch):
+        """A dead TTS thread must not block the caller forever."""
+        import asyncio
+
+        from gaia.audio.audio_client import AudioClient
+
+        client = AudioClient.__new__(AudioClient)
+        client.log = MagicMock()
+        client.enable_tts = True
+        client.tts = MagicMock()
+        # The thread starts and immediately does nothing — the broken-speaker
+        # case, where generate_speech_streaming used to die on stream open.
+        client.tts.generate_speech_streaming = lambda *a, **k: None
+
+        real_queue_cls = queue.Queue
+        monkeypatch.setattr(
+            "gaia.audio.audio_client.queue.Queue",
+            lambda maxsize=0: real_queue_cls(maxsize=1),
+        )
+
+        async def run():
+            # Completes rather than hanging; the timeout is the proof. Bounded
+            # puts make this ~10s worst case; unbounded, it never returns.
+            await asyncio.wait_for(client.speak_text("one two three"), timeout=30)
+
+        asyncio.run(run())
+
+
+class TestTheTalkReadmeMatchesTheCode:
+    @staticmethod
+    def _readme() -> str:
+        from pathlib import Path
+
+        root = Path(__file__).resolve().parents[2]
+        return (root / "src" / "gaia" / "talk" / "README.md").read_text(
+            encoding="utf-8"
+        )
+
+    def test_it_does_not_advertise_enter_to_interrupt(self):
+        assert "Press Enter" not in self._readme()
+
+    def test_it_still_documents_the_words_that_work(self):
+        readme = self._readme()
+        assert '"stop"' in readme
+        assert '"restart"' in readme


### PR DESCRIPTION
When the microphone does not work, `gaia talk` never says so — it prints "Listening…" and spins there indefinitely. The device error is hidden, and the one useful hint arrives ten seconds in, after which the session goes quiet with no way to tell whether it is still listening, broken, or waiting on the model.

Fixes #3554

## Test plan

- [x] `pytest tests/unit/test_mic_failure_reporting.py` (20 passed) — a device that cannot open, a read failure mid-session, the flag cleared on both, the message naming device and remedy, a stale error cleared on restart, the banner and the guide no longer claiming what does not work, and the TTS drain releasing a blocked producer. **18 of the 20 fail on `main`.**
- [x] `pytest tests/unit -k "asr or talk or audio or tts or mic"` (350 passed; the 3 `test_diarize` failures are missing audio deps in my env and fail on `main` too)
- [x] `black`, `flake8`, `python util/lint.py --pylint`, `python util/check_doc_links.py`
- [ ] Live `gaia talk` with a disconnected mic — not run; I have no way to detach the input device on this machine. The unit tests drive the real `_record_audio` with the device layer failing, which is the path and the failure.

<details>
<summary>🔍 Technical details</summary>

**A correction to the issue worth noting.** #3554 points at `whisper_asr.py:160-162 / :176 / :189`, which is `_record_audio_streaming`. `gaia talk` does not use that path — `AudioClient` calls `start_recording()`, which resolves to `AudioRecorder._record_audio`, and *that* is where the `raise`-on-a-thread leaves `is_recording` set. Both paths are fixed; the live one is the base class.

- **`mic_error` and `device_error_message` live on `AudioRecorder`**, so both capture paths share one implementation and message.
- **`is_recording` is cleared in `finally`**, unconditionally. It is what `AudioClient`'s supervisor loop polls, and the only exit from "Listening…".
- **The client prints the reason**, where it previously logged `"Recording stopped unexpectedly"` at warning level and showed nothing.
- **`_check_mic_levels` reports a device it cannot open.** It caught everything at `self.log.debug`, so the most common failure — no such device — was invisible.

**The false claims.** `AudioClient.process_voice_input` is the only Enter-to-interrupt implementation and has no callers (`talk/sdk.py`'s same-named method is a different class). The banner advertised it on every launch; that line is gone. `docs/guides/talk.mdx` said `"exit"`/`"quit"` against `cleaned_text in ["stop"]`, and `">1 second"` against a 10-chunk × 2048/16000 ≈ 1.3s silence window. A test asserts the guide's stop word is the one the code matches, so they cannot drift again.

**The wedge.** `generate_speech_streaming` opened `sd.OutputStream` outside its `try`, so a device failure propagated out of the TTS thread and killed the consumer; the producer then blocked forever on `text_queue.put()` once 100 chunks queued. The open is inside the try, a failed open drains to the terminator so the producer completes, and every put is bounded — including the `__HALT__` on interrupt, which must not be the thing that hangs.

Left alone deliberately: the swallowed crash that makes `gaia talk` exit 0 (`audio_client.py:516`). #3554 assigns that to the #3307 sweep.