### PR TITLE
fix(hub): stop recording a failed first install as installed

### DIFF
--- a/src/gaia/hub/installer.py
+++ b/src/gaia/hub/installer.py
@@ -1159,15 +1159,6 @@ def install(
                 _write_agent_yaml(
                     agent_id, resolved_version, install_dir, base_url, fetcher
                 )
-                _write_sentinel(
-                    agent_id,
-                    resolved_version,
-                    language,
-                    artifact["sha256"],
-                    install_dir,
-                    artifact_kind=artifact_kind,
-                    executable=generic_name,
-                )
                 # Prime the ACTIVE environment (not just this process) so a
                 # later, unrelated `gaia` invocation using the same
                 # interpreter/venv can import this wheel too (#2358) — closes
@@ -1178,10 +1169,33 @@ def install(
                         install_dir / SITE_PACKAGES_DIRNAME,
                         active_env_site_packages,
                     )
+                # LAST, after everything that can fail. The sentinel is what
+                # every later command reads as "this agent is installed", so
+                # writing it earlier left a first install that died on an
+                # unwritable site-packages looking installed and importable
+                # nowhere (#3549).
+                _write_sentinel(
+                    agent_id,
+                    resolved_version,
+                    language,
+                    artifact["sha256"],
+                    install_dir,
+                    artifact_kind=artifact_kind,
+                    executable=generic_name,
+                )
             except Exception:
                 # Install failed mid-write — restore the backup if we made one so
                 # the user is left with a working previous version, not a stub.
                 _restore_backup_if_present(agent_id, root)
+                # Only a FIRST install is cleared. "No backup" is not the same
+                # question: binary agents deliberately skip the snapshot (they
+                # are replaced in place so a running sidecar's data directory
+                # is not moved out from under it), so treating a missing backup
+                # as a first install would delete a working binary agent and
+                # its sidecar state on a failed UPDATE — most likely when the
+                # agent is running and its executable cannot be replaced.
+                if not updated:
+                    _clear_failed_install(agent_id, root)
                 raise
 
             # --- hot-register ---
@@ -1391,15 +1405,40 @@ def _discard_backup(agent_id: str, install_root: Path) -> None:
         shutil.rmtree(backup, ignore_errors=True)
 
 
-def _restore_backup_if_present(agent_id: str, install_root: Path) -> None:
+def _restore_backup_if_present(agent_id: str, install_root: Path) -> bool:
+    """Roll back to the previous version. True when a backup was restored.
+
+    A binary agent has no backup even on an update — it is replaced in place —
+    so ``False`` here does NOT mean "there was nothing installed before".
+    """
     backup = _backup_dir(agent_id, install_root)
     if not backup.exists():
-        return
+        return False
     install_dir = agent_install_dir(agent_id, install_root)
     if install_dir.exists():
         shutil.rmtree(install_dir, ignore_errors=True)
     shutil.move(str(backup), str(install_dir))
     logger.info("installer: restored %s from backup after failed install", agent_id)
+    return True
+
+
+def _clear_failed_install(agent_id: str, install_root: Path) -> None:
+    """Remove a first install that failed, so nothing reads it as present.
+
+    There is no previous version to fall back to, and a sentinel left behind
+    makes every later command believe the agent is installed while nothing can
+    import it (#3549). Re-running the install would not clear it either — the
+    record looks valid.
+    """
+    install_dir = agent_install_dir(agent_id, install_root)
+    if not install_dir.exists():
+        return
+    shutil.rmtree(install_dir, ignore_errors=True)
+    logger.info(
+        "installer: removed the failed first install of %s so it is not "
+        "reported as installed",
+        agent_id,
+    )
 
 
 def _deregister(agent_id: str, registry: Any) -> None:

--- a/tests/unit/test_hub_installer.py
+++ b/tests/unit/test_hub_installer.py
@@ -1612,3 +1612,238 @@ def test_default_run_pip_raises_when_every_frontend_fails(monkeypatch):
 
     with pytest.raises(InstallError, match="every pip frontend failed"):
         installer._default_run_pip(["--target", "/nonexistent", "some-package"])
+
+
+# ---------------------------------------------------------------------------
+# A failed FIRST install must not be recorded as installed (#3549)
+# ---------------------------------------------------------------------------
+#
+# `_write_sentinel` ran before `_add_wheel_agent_to_active_env_path`, which
+# raises when the active environment's site-packages is not writable. The
+# failure handler only restores a *backup*, and a first install has none — so
+# the command exited non-zero while the agent read as installed and was
+# importable in no new process. Re-running did not clear it: the record looked
+# valid.
+
+
+def _fail_env_priming(monkeypatch, exc=None):
+    """Make the last step of a wheel install fail, as a read-only env would."""
+
+    def boom(*_args, **_kwargs):
+        raise exc or InstallError("site-packages is not writable")
+
+    monkeypatch.setattr(installer, "_add_wheel_agent_to_active_env_path", boom)
+
+
+def test_a_failed_first_install_is_not_recorded_as_installed(tmp_path, monkeypatch):
+    manifest = _manifest()
+    _fail_env_priming(monkeypatch)
+
+    with pytest.raises(InstallError):
+        install(
+            "demo",
+            manifest=manifest,
+            base_url=BASE,
+            fetcher=_make_fetcher(manifest),
+            run_pip=lambda args: None,
+            install_root=tmp_path,
+        )
+
+    assert read_sentinel("demo", tmp_path) is None
+    assert "demo" not in list_installed(tmp_path)
+
+
+def test_a_failed_first_install_leaves_nothing_behind(tmp_path, monkeypatch):
+    manifest = _manifest()
+    _fail_env_priming(monkeypatch)
+
+    with pytest.raises(InstallError):
+        install(
+            "demo",
+            manifest=manifest,
+            base_url=BASE,
+            fetcher=_make_fetcher(manifest),
+            run_pip=lambda args: None,
+            install_root=tmp_path,
+        )
+
+    assert not (tmp_path / "demo").exists()
+
+
+def test_retrying_after_a_failed_first_install_succeeds(tmp_path, monkeypatch):
+    """The state a stale sentinel used to make unrecoverable."""
+    manifest = _manifest()
+    _fail_env_priming(monkeypatch)
+    with pytest.raises(InstallError):
+        install(
+            "demo",
+            manifest=manifest,
+            base_url=BASE,
+            fetcher=_make_fetcher(manifest),
+            run_pip=lambda args: None,
+            install_root=tmp_path,
+        )
+
+    monkeypatch.undo()
+    result = install(
+        "demo",
+        manifest=manifest,
+        base_url=BASE,
+        fetcher=_make_fetcher(manifest),
+        run_pip=lambda args: None,
+        install_root=tmp_path,
+    )
+
+    assert result.version == "1.0.0"
+    assert read_sentinel("demo", tmp_path).version == "1.0.0"
+
+
+def test_a_failed_UPDATE_still_rolls_back_to_the_previous_version(
+    tmp_path, monkeypatch
+):
+    """The existing behaviour must not regress: a backup wins over deletion."""
+    v1 = _manifest(version="1.0.0")
+    install(
+        "demo",
+        manifest=v1,
+        base_url=BASE,
+        fetcher=_make_fetcher(v1),
+        run_pip=lambda args: None,
+        install_root=tmp_path,
+    )
+
+    v2 = _manifest(version="2.0.0", artifact_bytes=b"wheel-v2")
+    _fail_env_priming(monkeypatch)
+    with pytest.raises(InstallError):
+        install(
+            "demo",
+            manifest=v2,
+            base_url=BASE,
+            fetcher=_make_fetcher(v2, artifact_bytes=b"wheel-v2"),
+            run_pip=lambda args: None,
+            install_root=tmp_path,
+        )
+
+    assert read_sentinel("demo", tmp_path).version == "1.0.0"
+
+
+def test_the_sentinel_is_written_after_every_step_that_can_fail(tmp_path):
+    """Ordering is the fix; pin it so a future edit cannot undo it."""
+    import inspect
+
+    source = inspect.getsource(installer.install)
+    prime = source.index("_add_wheel_agent_to_active_env_path(")
+    sentinel = source.index("_write_sentinel(")
+    assert prime < sentinel
+
+
+def _sidecar_manifest(agent_id="demo", version="1.0.0", artifact_bytes=b"bin-bytes"):
+    """A sidecar (binary) manifest — the kind that skips the backup snapshot."""
+    sha = hashlib.sha256(artifact_bytes).hexdigest()
+    filename = f"{agent_id}-{version}-{installer.current_platform_key()}"
+    return {
+        "id": agent_id,
+        "language": "python",
+        "security_tier": "verified",
+        "latest_version": version,
+        "requirements": {"platforms": []},
+        "versions": {
+            version: {
+                "version": version,
+                "artifacts": [
+                    {
+                        "filename": filename,
+                        "path": f"agents/{agent_id}/{version}/{filename}",
+                        "size_bytes": len(artifact_bytes),
+                        "sha256": sha,
+                        "content_type": "application/octet-stream",
+                        "platform": installer.current_platform_key(),
+                    }
+                ],
+            }
+        },
+    }
+
+
+def _sidecar_fetcher(manifest, artifact_bytes=b"bin-bytes"):
+    version = manifest["latest_version"]
+    path = manifest["versions"][version]["artifacts"][0]["path"]
+
+    def fetcher(url):
+        if url.endswith("/gaia-agent.yaml"):
+            return b"id: demo\nname: Demo\n"
+        if url == f"{BASE}/{path}":
+            return artifact_bytes
+        raise AssertionError(f"unexpected fetch url: {url}")
+
+    return fetcher
+
+
+def test_a_failed_binary_UPDATE_does_not_delete_the_working_install(
+    tmp_path, monkeypatch
+):
+    """Binary agents skip the backup, so "no backup" is not "first install".
+
+    Treating the two as the same wipes the previous working binary and any
+    sidecar state beside it — most likely when the agent is running and its
+    executable cannot be replaced, which the installer already tells the user
+    to retry after closing (#3549 review).
+    """
+    v1 = _sidecar_manifest(version="1.0.0")
+    install(
+        "demo",
+        manifest=v1,
+        base_url=BASE,
+        fetcher=_sidecar_fetcher(v1),
+        run_pip=lambda args: None,
+        install_root=tmp_path,
+    )
+    assert read_sentinel("demo", tmp_path).version == "1.0.0"
+
+    # Sidecar state living alongside the binary.
+    state = tmp_path / "demo" / "sidecar-state.json"
+    state.write_text('{"kept": true}')
+
+    v2 = _sidecar_manifest(version="2.0.0", artifact_bytes=b"bin-v2")
+
+    def running_sidecar(*_args, **_kwargs):
+        raise InstallError("The agent appears to be running — close it and retry")
+
+    monkeypatch.setattr(installer, "_install_binary_artifact", running_sidecar)
+
+    with pytest.raises(InstallError):
+        install(
+            "demo",
+            manifest=v2,
+            base_url=BASE,
+            fetcher=_sidecar_fetcher(v2, artifact_bytes=b"bin-v2"),
+            run_pip=lambda args: None,
+            install_root=tmp_path,
+        )
+
+    assert (tmp_path / "demo").exists()
+    assert read_sentinel("demo", tmp_path).version == "1.0.0"
+    assert state.exists(), "sidecar state was deleted by the failure handler"
+
+
+def test_a_failed_binary_FIRST_install_is_still_cleared(tmp_path, monkeypatch):
+    """The fix must still hold for the case it was written for."""
+    manifest = _sidecar_manifest()
+
+    def boom(*_args, **_kwargs):
+        raise InstallError("no space left on device")
+
+    monkeypatch.setattr(installer, "_install_binary_artifact", boom)
+
+    with pytest.raises(InstallError):
+        install(
+            "demo",
+            manifest=manifest,
+            base_url=BASE,
+            fetcher=_sidecar_fetcher(manifest),
+            run_pip=lambda args: None,
+            install_root=tmp_path,
+        )
+
+    assert read_sentinel("demo", tmp_path) is None
+    assert not (tmp_path / "demo").exists()


### PR DESCRIPTION
If the first install of a hub agent fails at the last step — because the environment's site-packages is not writable — the agent is still recorded on disk as installed. Every later command believes the agent is there, but nothing can import it outside the process that ran the install, so the user gets confusing import failures instead of the clear "install failed, check permissions" the install command already printed. Re-running the install doesn't clear it either: the record looks valid.

Fixes #3549

## Test plan

- [x] `pytest tests/unit/test_hub_installer.py` (85 passed) — five new cases: nothing recorded after a failed first install, nothing left on disk, a retry then succeeding, a failed *update* still rolling back to the previous version, and the write ordering pinned. **3 of the 5 fail on `main`**; the other two are the existing behaviour this must not regress, and they pass on both.
- [x] `pytest tests/unit -k "hub or install"` (1005 passed)
- [x] `black`, `flake8`, `isort`, `python util/lint.py --pylint`
- [ ] Live probe with a read-only site-packages — not run. The tests make `_add_wheel_agent_to_active_env_path` raise, which is exactly what an unwritable site-packages does there; I didn't want to chmod a real environment on this machine.

Note `test_install_real_wheel_lands_in_site_packages_and_is_importable` and `test_default_run_pip_falls_back_to_python_pip_when_uv_missing` fail in my environment on `main` too — they shell out to a pip frontend that isn't available here.

<details>
<summary>🔍 Technical details</summary>

Two halves, both needed:

**The sentinel is written last.** It was written before `_add_wheel_agent_to_active_env_path`, which correctly raises `InstallError` on `OSError` — fail-loudly by design, and the reason the command exits non-zero. Nothing between the two needs it, so it simply moves after. A test asserts the ordering on the source so a future edit cannot quietly undo it.

**The failure path handles a first install.** `_restore_backup_if_present` returns immediately when there is no backup, which is precisely the first-install case. It now returns a bool, and when nothing was restored the handler removes what this attempt created. An update is unaffected: a backup exists, it wins, and the previous version comes back — pinned by its own test.