### PR TITLE
fix(ui): let a document on a reconnected drive come back

### DIFF
--- a/src/gaia/ui/document_monitor.py
+++ b/src/gaia/ui/document_monitor.py
@@ -65,6 +65,7 @@ class DocumentMonitor:
         index_fn: Callable[[Path], Awaitable[int]],
         interval: float = DEFAULT_INTERVAL,
         active_tasks: Optional[Dict[str, Any]] = None,
+        startup_delay: float = 5.0,
     ):
         """Initialize the document monitor.
 
@@ -76,10 +77,13 @@ class DocumentMonitor:
             active_tasks: Dict of currently active indexing tasks (doc_id → Task).
                           Used to avoid re-indexing docs that are being indexed
                           by user action.
+            startup_delay: Seconds to wait before the first sweep, letting the
+                          server finish starting. Lowered by tests.
         """
         self._db = db
         self._index_fn = index_fn
         self._interval = interval
+        self._startup_delay = startup_delay
         self._active_tasks = active_tasks or {}
         self._task: Optional[asyncio.Task] = None
         self._reindexing: Set[str] = set()  # doc IDs currently being re-indexed
@@ -120,7 +124,7 @@ class DocumentMonitor:
     async def _run_loop(self) -> None:
         """Main polling loop: sleep, check documents, repeat."""
         # Initial delay to let the server finish starting up
-        await asyncio.sleep(5.0)
+        await asyncio.sleep(self._startup_delay)
 
         while not self._stop_event.is_set():
             try:
@@ -177,6 +181,20 @@ class DocumentMonitor:
                 continue
 
             current_mtime, current_size = file_info
+
+            # Repair before the fast path — a reconnected drive keeps its mtime.
+            if status == "missing":
+                logger.info(
+                    "Indexed file is reachable again: %s (doc_id=%s)",
+                    filepath,
+                    doc_id,
+                )
+                self._db.update_document_status(doc_id, "complete")
+                status = "complete"
+                # Size too: mtime alone is trustworthy only while the monitor
+                # has been watching, and it was not.
+                if current_size != doc.get("file_size"):
+                    stored_mtime = None
 
             # Fast path: mtime unchanged → skip hash computation
             if stored_mtime is not None and current_mtime == stored_mtime:

--- a/tests/unit/chat/ui/test_document_monitor.py
+++ b/tests/unit/chat/ui/test_document_monitor.py
@@ -329,3 +329,169 @@ class TestDocumentMonitor:
             assert updated["indexing_status"] == "failed"
         finally:
             await monitor.stop()
+
+
+class TestAReconnectedDriveIsRepaired:
+    """A document on a removable or network drive came back "missing" forever.
+
+    Unplugging the drive marks it missing, correctly. Plugging it back in
+    changes nothing about the file, so its mtime still matches — and the
+    monitor's fast path returned before anything could clear the status. Only
+    a manual re-index brought it back (#3552).
+    """
+
+    @staticmethod
+    def _indexed(db, temp_file):
+        file_stat = os.stat(temp_file)
+        return db.add_document(
+            filename="on-a-usb-stick.txt",
+            filepath=temp_file,
+            file_hash=_compute_file_hash(temp_file),
+            file_size=file_stat.st_size,
+            chunk_count=3,
+            file_mtime=file_stat.st_mtime,
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_missing_document_recovers_when_the_file_returns(
+        self, db, temp_file
+    ):
+        doc_id = self._indexed(db, temp_file)["id"]
+        # The state one sweep with the drive unplugged leaves behind.
+        db.update_document_status(doc_id, "missing")
+
+        monitor = DocumentMonitor(
+            db=db, index_fn=_dummy_index, interval=0.2, startup_delay=0.0
+        )
+        await monitor.start()
+        try:
+            for _ in range(40):
+                if db.get_document(doc_id)["indexing_status"] != "missing":
+                    break
+                await asyncio.sleep(0.1)
+        finally:
+            await monitor.stop()
+
+        assert db.get_document(doc_id)["indexing_status"] == "complete"
+
+    @pytest.mark.asyncio
+    async def test_recovery_does_not_require_re_indexing(self, db, temp_file):
+        """The file is unchanged; re-reading it would be wasted work."""
+        doc_id = self._indexed(db, temp_file)["id"]
+        db.update_document_status(doc_id, "missing")
+
+        calls = [0]
+
+        async def tracking_index(filepath) -> int:
+            calls[0] += 1
+            return 10
+
+        monitor = DocumentMonitor(
+            db=db, index_fn=tracking_index, interval=0.2, startup_delay=0.0
+        )
+        await monitor.start()
+        try:
+            for _ in range(40):
+                if db.get_document(doc_id)["indexing_status"] != "missing":
+                    break
+                await asyncio.sleep(0.1)
+            await asyncio.sleep(0.5)
+        finally:
+            await monitor.stop()
+
+        assert db.get_document(doc_id)["indexing_status"] == "complete"
+        assert calls[0] == 0
+
+    @pytest.mark.asyncio
+    async def test_a_file_that_is_still_gone_stays_missing(self, db, tmp_path):
+        gone = tmp_path / "still-unplugged.txt"
+        gone.write_text("content")
+        file_stat = os.stat(gone)
+        doc = db.add_document(
+            filename="still-unplugged.txt",
+            filepath=str(gone),
+            file_hash=_compute_file_hash(str(gone)),
+            file_size=file_stat.st_size,
+            chunk_count=3,
+            file_mtime=file_stat.st_mtime,
+        )
+        gone.unlink()
+
+        monitor = DocumentMonitor(
+            db=db, index_fn=_dummy_index, interval=0.2, startup_delay=0.0
+        )
+        await monitor.start()
+        try:
+            for _ in range(40):
+                if db.get_document(doc["id"])["indexing_status"] == "missing":
+                    break
+                await asyncio.sleep(0.1)
+            # And it must STAY missing across further sweeps.
+            await asyncio.sleep(0.5)
+        finally:
+            await monitor.stop()
+
+        assert db.get_document(doc["id"])["indexing_status"] == "missing"
+
+    @pytest.mark.asyncio
+    async def test_a_file_changed_while_away_is_still_re_indexed(self, db, temp_file):
+        """Repairing the status must not short-circuit a real content change."""
+        doc_id = self._indexed(db, temp_file)["id"]
+        db.update_document_status(doc_id, "missing")
+
+        time.sleep(0.1)
+        with open(temp_file, "a") as f:
+            f.write("\nedited while the drive was out")
+
+        index_called = asyncio.Event()
+
+        async def tracking_index(filepath) -> int:
+            index_called.set()
+            return 10
+
+        monitor = DocumentMonitor(
+            db=db, index_fn=tracking_index, interval=0.2, startup_delay=0.0
+        )
+        await monitor.start()
+        try:
+            await asyncio.wait_for(index_called.wait(), timeout=10.0)
+        finally:
+            await monitor.stop()
+
+        assert db.get_document(doc_id)["chunk_count"] == 10
+
+    @pytest.mark.asyncio
+    async def test_a_file_swapped_while_away_is_re_read_despite_its_mtime(
+        self, db, temp_file
+    ):
+        """mtime is only trustworthy while the monitor was watching.
+
+        A restore or an rsync that preserves timestamps looks unchanged, and
+        the missing window is exactly the period nothing was watching — so the
+        size is checked on that one transition.
+        """
+        doc_id = self._indexed(db, temp_file)["id"]
+        db.update_document_status(doc_id, "missing")
+
+        # Same mtime, different content: what `cp -p` leaves behind.
+        stat_before = os.stat(temp_file)
+        with open(temp_file, "w") as f:
+            f.write("completely different content, restored from a backup")
+        os.utime(temp_file, (stat_before.st_atime, stat_before.st_mtime))
+
+        index_called = asyncio.Event()
+
+        async def tracking_index(filepath) -> int:
+            index_called.set()
+            return 7
+
+        monitor = DocumentMonitor(
+            db=db, index_fn=tracking_index, interval=0.2, startup_delay=0.0
+        )
+        await monitor.start()
+        try:
+            await asyncio.wait_for(index_called.wait(), timeout=10.0)
+        finally:
+            await monitor.stop()
+
+        assert db.get_document(doc_id)["chunk_count"] == 7


### PR DESCRIPTION
A document on a removable or network drive is marked "missing" the moment the drive is disconnected — correctly — and then stays missing forever, even after the drive is plugged back in. Nothing short of re-indexing the file brings it back.

Fixes #3552

## Test plan

- [x] `pytest tests/unit/chat/ui/test_document_monitor.py` (19 passed) — four new cases driving the real monitor against a real file and database: a missing document recovering when the file returns, recovery costing no re-index, a file that is *still* gone staying missing across several sweeps, and a file edited while the drive was out still being re-indexed. **The two recovery cases fail on `main`**; the two guard cases pass on both, which is the point of having them.
- [x] `pytest tests/unit -k "monitor or document"` (185 passed)
- [x] `black`, `flake8`, `isort`, `python util/lint.py --pylint`
- [ ] Live probe with a real external drive — not run; I have no removable drive to unplug here. The tests reproduce the state a disconnect leaves (status `missing`, mtime unchanged) rather than simulating the hardware.

<details>
<summary>🔍 Technical details</summary>

`_get_file_info` returning `None` sets the document to `"missing"`. On a later sweep the file is readable again — but reconnecting a drive doesn't change the file, so `current_mtime == stored_mtime` and the fast path `continue`s before anything can reset the status.

The repair goes *before* that check: a readable file whose stored status is `"missing"` goes back to `"complete"`, and the local `status` is updated too so the rest of the pass sees the corrected value. Then the mtime check runs as before and decides whether a re-read is actually needed.

Two properties the tests pin, because both are easy to break while fixing this:

- **No re-index for an unchanged file.** The content is identical; re-reading it would be wasted work on what may be a slow network drive.
- **A file edited while the drive was out is still re-indexed.** Repairing the status must not short-circuit the mtime path that would catch the change.