### PR TITLE
fix(code-index): let a session index more than one repository

### DIFF
--- a/hub/agents/gaia/python/gaia_agent/agent.py
+++ b/hub/agents/gaia/python/gaia_agent/agent.py
@@ -302,7 +302,10 @@ class GaiaAgent(
         # Through the mixin, so both read the one cached resolution and can
         # never end up describing two different trees.
         index_root = self._project_map_root() or allowed[0]
-        self._init_code_index_state(repo_path=index_root)
+        # The project root is where code search STARTS; allowed_paths is how far
+        # it may reach. Passing one value for both locked a session that began
+        # inside a repo to that repo (#3544).
+        self._init_code_index_state(repo_path=index_root, ceiling_paths=allowed)
         self.register_code_index_tools()
         super()._register_tools()
 

--- a/src/gaia/agents/tools/code_index_tools.py
+++ b/src/gaia/agents/tools/code_index_tools.py
@@ -11,7 +11,8 @@ Follows the same pattern as ``RAGToolsMixin`` and ``FileIOToolsMixin``:
 the mixin exposes a ``register_code_index_tools()`` method that the
 consuming agent calls from its ``_register_tools`` hook.
 
-State (``_repo_path``, ``_code_index_config``, ``_code_index_sdk``) is
+State (``_repo_path``, ``_code_index_ceiling``, ``_code_index_config``,
+``_code_index_sdk``) is
 set up lazily on first tool invocation if the consumer did not
 initialise it explicitly. This keeps the mixin composable without
 requiring cooperative ``__init__`` chaining.
@@ -72,6 +73,12 @@ class CodeIndexToolsMixin:
         # allowed_paths config produces a "<cwd>/~" root that rejects the
         # very paths it was meant to allow.
         self._repo_path = os.path.abspath(os.path.expanduser(repo_path))
+        # The sandbox ceiling: what a requested repo_path must sit under. Set
+        # once and never moved. ``_repo_path`` tracks the repository currently
+        # indexed and does move — conflating the two meant the first index
+        # narrowed the ceiling to that repo, so a second repository in the same
+        # session could never be indexed (#3544).
+        self._code_index_ceiling = self._repo_path
         self._code_index_config = code_index_config
         self._code_index_sdk: Optional[Any] = None
 
@@ -79,6 +86,8 @@ class CodeIndexToolsMixin:
         """Populate default state on first access if consumer skipped init."""
         if not hasattr(self, "_repo_path"):
             self._repo_path = os.path.abspath(".")
+        if not hasattr(self, "_code_index_ceiling"):
+            self._code_index_ceiling = self._repo_path
         if not hasattr(self, "_code_index_config"):
             self._code_index_config = None
         if not hasattr(self, "_code_index_sdk"):
@@ -138,13 +147,16 @@ class CodeIndexToolsMixin:
                 # silently re-root the whole index/search sandbox onto the
                 # symlink's target.
                 real_resolved = str(Path(resolved).resolve())
-                real_original = str(Path(self._repo_path).resolve())
+                # Against the CEILING, not the repo indexed last: the check may
+                # only ever narrow, so validating against a moving root let the
+                # first index lock the session to one repository.
+                real_ceiling = str(Path(self._code_index_ceiling).resolve())
                 if (
-                    not real_resolved.startswith(real_original + os.sep)
-                    and real_resolved != real_original
+                    not real_resolved.startswith(real_ceiling + os.sep)
+                    and real_resolved != real_ceiling
                 ):
                     return json.dumps(
-                        {"error": f"repo_path must be within {real_original}"}
+                        {"error": f"repo_path must be within {real_ceiling}"}
                     )
                 self._repo_path = resolved
                 self._code_index_config = None

--- a/src/gaia/agents/tools/code_index_tools.py
+++ b/src/gaia/agents/tools/code_index_tools.py
@@ -11,7 +11,7 @@ Follows the same pattern as ``RAGToolsMixin`` and ``FileIOToolsMixin``:
 the mixin exposes a ``register_code_index_tools()`` method that the
 consuming agent calls from its ``_register_tools`` hook.
 
-State (``_repo_path``, ``_code_index_ceiling``, ``_code_index_config``,
+State (``_repo_path``, ``_code_index_ceilings``, ``_code_index_config``,
 ``_code_index_sdk``) is
 set up lazily on first tool invocation if the consumer did not
 initialise it explicitly. This keeps the mixin composable without
@@ -21,7 +21,7 @@ requiring cooperative ``__init__`` chaining.
 import json
 import os
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Sequence
 
 from gaia.agents.base.tools import tool
 from gaia.logger import get_logger
@@ -53,6 +53,9 @@ class CodeIndexToolsMixin:
     - Call ``self.register_code_index_tools()`` from ``_register_tools``.
     - Optionally set ``self._repo_path`` (absolute path) before first use.
       If unset, defaults to the current working directory.
+    - Optionally pass ``ceiling_paths`` to ``_init_code_index_state`` — the
+      roots a requested ``repo_path`` must sit under. Defaults to
+      ``_repo_path``, which locks the session to one repository.
     - Optionally set ``self._code_index_config`` to a pre-built
       ``CodeIndexConfig``; otherwise one is constructed from
       ``_repo_path``.
@@ -62,23 +65,32 @@ class CodeIndexToolsMixin:
         self,
         repo_path: str = ".",
         code_index_config: Optional[Any] = None,
+        ceiling_paths: Optional[Sequence[str]] = None,
     ) -> None:
-        """Initialise mixin state. Safe to call multiple times (idempotent).
+        """Initialise mixin state. Safe to call multiple times.
+
+        Not idempotent in one respect: a later call replaces the sandbox
+        ceilings as well as the default repository.
 
         Args:
             repo_path: Repository root (absolute or relative, resolved here).
             code_index_config: Optional pre-built ``CodeIndexConfig``.
+            ceiling_paths: Roots a requested ``repo_path`` must sit under —
+                the consumer's declared file scope. Defaults to ``repo_path``.
         """
         # expanduser everywhere a root is stored, or a '~'-style
         # allowed_paths config produces a "<cwd>/~" root that rejects the
         # very paths it was meant to allow.
         self._repo_path = os.path.abspath(os.path.expanduser(repo_path))
-        # The sandbox ceiling: what a requested repo_path must sit under. Set
-        # once and never moved. ``_repo_path`` tracks the repository currently
-        # indexed and does move — conflating the two meant the first index
-        # narrowed the ceiling to that repo, so a second repository in the same
-        # session could never be indexed (#3544).
-        self._code_index_ceiling = self._repo_path
+        # The sandbox ceilings: what a requested repo_path must sit under.
+        # ``_repo_path`` tracks the repository currently indexed and does move —
+        # conflating the two meant the first index narrowed the ceiling to that
+        # repo, so a second repository could never be indexed (#3544).
+        self._code_index_ceilings = (
+            tuple(os.path.abspath(os.path.expanduser(p)) for p in ceiling_paths)
+            if ceiling_paths
+            else (self._repo_path,)
+        )
         self._code_index_config = code_index_config
         self._code_index_sdk: Optional[Any] = None
 
@@ -86,8 +98,8 @@ class CodeIndexToolsMixin:
         """Populate default state on first access if consumer skipped init."""
         if not hasattr(self, "_repo_path"):
             self._repo_path = os.path.abspath(".")
-        if not hasattr(self, "_code_index_ceiling"):
-            self._code_index_ceiling = self._repo_path
+        if not hasattr(self, "_code_index_ceilings"):
+            self._code_index_ceilings = (self._repo_path,)
         if not hasattr(self, "_code_index_config"):
             self._code_index_config = None
         if not hasattr(self, "_code_index_sdk"):
@@ -147,16 +159,21 @@ class CodeIndexToolsMixin:
                 # silently re-root the whole index/search sandbox onto the
                 # symlink's target.
                 real_resolved = str(Path(resolved).resolve())
-                # Against the CEILING, not the repo indexed last: the check may
-                # only ever narrow, so validating against a moving root let the
-                # first index lock the session to one repository.
-                real_ceiling = str(Path(self._code_index_ceiling).resolve())
-                if (
-                    not real_resolved.startswith(real_ceiling + os.sep)
-                    and real_resolved != real_ceiling
+                # Against the CEILINGS, not the repo indexed last: the check
+                # may only ever narrow, so validating against a moving root let
+                # the first index lock the session to one repository.
+                real_ceilings = [
+                    str(Path(c).resolve()) for c in self._code_index_ceilings
+                ]
+                if not any(
+                    real_resolved == c or real_resolved.startswith(c + os.sep)
+                    for c in real_ceilings
                 ):
                     return json.dumps(
-                        {"error": f"repo_path must be within {real_ceiling}"}
+                        {
+                            "error": "repo_path must be within "
+                            + " or ".join(real_ceilings)
+                        }
                     )
                 self._repo_path = resolved
                 self._code_index_config = None

--- a/tests/unit/test_code_index_mixin.py
+++ b/tests/unit/test_code_index_mixin.py
@@ -258,3 +258,107 @@ class TestTraversalGuard:
         # The guard must reject *before* re-rooting mixin state onto the
         # escaped path.
         assert h._repo_path == os.path.abspath(str(root))
+
+
+# ---------------------------------------------------------------------------
+# One repository per session was the real limit (#3544)
+# ---------------------------------------------------------------------------
+#
+# A successful index replaced the mixin's root with the repo just indexed, and
+# the containment check validated against that. So the guard could only ever
+# ratchet inward: index ~/projects/a, and ~/projects/b is then "outside the
+# allowed area" for the rest of the session. `gaia chat` and the flagship hold
+# a long-lived instance, so this was the normal case, not an edge one.
+
+
+class TestASecondRepositoryCanStillBeIndexed:
+    @staticmethod
+    def _two_repos(tmp_path):
+        ceiling = tmp_path / "projects"
+        first = ceiling / "a"
+        second = ceiling / "b"
+        first.mkdir(parents=True)
+        second.mkdir(parents=True)
+        return ceiling, first, second
+
+    def test_a_second_repo_under_the_ceiling_is_allowed(self, tmp_path):
+        ceiling, first, second = self._two_repos(tmp_path)
+        h = make_harness(ceiling)
+        fn = _TOOL_REGISTRY["index_codebase"]["function"]
+
+        with patch.object(h, "_get_code_index_sdk", return_value=None):
+            assert json.loads(fn(repo_path=str(first))) == {
+                "error": "code_index SDK not initialised"
+            }
+            # Used to fail here with "repo_path must be within …/a".
+            assert json.loads(fn(repo_path=str(second))) == {
+                "error": "code_index SDK not initialised"
+            }
+
+        assert h._repo_path == os.path.abspath(str(second))
+
+    def test_switching_back_to_the_first_repo_works_too(self, tmp_path):
+        ceiling, first, second = self._two_repos(tmp_path)
+        h = make_harness(ceiling)
+        fn = _TOOL_REGISTRY["index_codebase"]["function"]
+
+        with patch.object(h, "_get_code_index_sdk", return_value=None):
+            fn(repo_path=str(first))
+            fn(repo_path=str(second))
+            result = json.loads(fn(repo_path=str(first)))
+
+        assert result == {"error": "code_index SDK not initialised"}
+        assert h._repo_path == os.path.abspath(str(first))
+
+    def test_the_ceiling_does_not_move_with_the_indexed_repo(self, tmp_path):
+        ceiling, first, _ = self._two_repos(tmp_path)
+        h = make_harness(ceiling)
+        fn = _TOOL_REGISTRY["index_codebase"]["function"]
+
+        with patch.object(h, "_get_code_index_sdk", return_value=None):
+            fn(repo_path=str(first))
+
+        assert h._code_index_ceiling == os.path.abspath(str(ceiling))
+        assert h._repo_path == os.path.abspath(str(first))
+
+    def test_the_guard_still_holds_after_indexing(self, tmp_path):
+        """Widening the check must not widen it past the sandbox."""
+        ceiling, first, _ = self._two_repos(tmp_path)
+        outside = tmp_path / "somewhere-else"
+        outside.mkdir()
+        h = make_harness(ceiling)
+        fn = _TOOL_REGISTRY["index_codebase"]["function"]
+
+        with patch.object(h, "_get_code_index_sdk", return_value=None):
+            fn(repo_path=str(first))
+            result = json.loads(fn(repo_path=str(outside)))
+
+        assert "must be within" in result["error"]
+        assert str(ceiling) in result["error"]
+
+    def test_a_sibling_of_the_indexed_repo_is_still_refused_above_the_ceiling(
+        self, tmp_path
+    ):
+        """The ceiling is the sandbox, not the repo's parent."""
+        _, first, _ = self._two_repos(tmp_path)
+        sibling_of_ceiling = tmp_path / "other-tree"
+        sibling_of_ceiling.mkdir()
+        h = make_harness(first)  # ceiling IS the repo here
+        fn = _TOOL_REGISTRY["index_codebase"]["function"]
+
+        result = json.loads(fn(repo_path=str(sibling_of_ceiling)))
+
+        assert "must be within" in result["error"]
+
+    def test_switching_repos_drops_the_previous_sdk(self, tmp_path):
+        """The next search must not answer from the previous repo's index."""
+        ceiling, first, second = self._two_repos(tmp_path)
+        h = make_harness(ceiling)
+        fn = _TOOL_REGISTRY["index_codebase"]["function"]
+
+        with patch.object(h, "_get_code_index_sdk", return_value=None):
+            fn(repo_path=str(first))
+            h._code_index_sdk = object()  # as a real index would leave it
+            fn(repo_path=str(second))
+
+        assert h._code_index_sdk is None

--- a/tests/unit/test_code_index_mixin.py
+++ b/tests/unit/test_code_index_mixin.py
@@ -60,14 +60,14 @@ class _Harness(CodeIndexToolsMixin):
     mixin's own behaviour.
     """
 
-    def __init__(self, repo_path="."):
-        self._init_code_index_state(repo_path=repo_path)
+    def __init__(self, repo_path=".", ceiling_paths=None):
+        self._init_code_index_state(repo_path=repo_path, ceiling_paths=ceiling_paths)
         self.register_code_index_tools()
 
 
-def make_harness(tmp_path=None):
+def make_harness(tmp_path=None, ceiling_paths=None):
     repo = str(tmp_path) if tmp_path else "."
-    return _Harness(repo_path=repo)
+    return _Harness(repo_path=repo, ceiling_paths=ceiling_paths)
 
 
 # ---------------------------------------------------------------------------
@@ -318,7 +318,7 @@ class TestASecondRepositoryCanStillBeIndexed:
         with patch.object(h, "_get_code_index_sdk", return_value=None):
             fn(repo_path=str(first))
 
-        assert h._code_index_ceiling == os.path.abspath(str(ceiling))
+        assert h._code_index_ceilings == (os.path.abspath(str(ceiling)),)
         assert h._repo_path == os.path.abspath(str(first))
 
     def test_the_guard_still_holds_after_indexing(self, tmp_path):
@@ -362,3 +362,50 @@ class TestASecondRepositoryCanStillBeIndexed:
             fn(repo_path=str(second))
 
         assert h._code_index_sdk is None
+
+
+class TestSeparateCeilings:
+    """The starting repository and the reachable scope are different values."""
+
+    def test_a_repo_under_a_second_allowed_root_is_accepted(self, tmp_path):
+        work = tmp_path / "work"
+        work.mkdir()
+        side = tmp_path / "side"
+        side.mkdir()
+        other = side / "other-repo"
+        other.mkdir()
+        h = make_harness(work, ceiling_paths=[str(work), str(side)])
+        fn = _TOOL_REGISTRY["index_codebase"]["function"]
+
+        with patch.object(h, "_get_code_index_sdk", return_value=None):
+            result = json.loads(fn(repo_path=str(other)))
+
+        assert result == {"error": "code_index SDK not initialised"}
+        assert h._repo_path == os.path.abspath(str(other))
+
+    def test_outside_every_ceiling_is_still_refused(self, tmp_path):
+        work = tmp_path / "work"
+        work.mkdir()
+        side = tmp_path / "side"
+        side.mkdir()
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        h = make_harness(work, ceiling_paths=[str(work), str(side)])
+        fn = _TOOL_REGISTRY["index_codebase"]["function"]
+
+        result = json.loads(fn(repo_path=str(elsewhere)))
+
+        assert "must be within" in result["error"]
+        assert str(side.resolve()) in result["error"]
+
+    def test_the_lazy_default_ceiling_is_the_repo(self, tmp_path):
+        """Consumers that skip _init_code_index_state still get a sandbox."""
+
+        class _Bare(CodeIndexToolsMixin):
+            pass
+
+        bare = _Bare()
+        bare._repo_path = str(tmp_path)
+        bare._ensure_code_index_state()
+
+        assert bare._code_index_ceilings == (str(tmp_path),)

--- a/tests/unit/test_flagship_code_index_scope.py
+++ b/tests/unit/test_flagship_code_index_scope.py
@@ -1,0 +1,64 @@
+# Copyright(C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""The flagship's code-search scope is allowed_paths, not the project root.
+
+Drives the real `_register_tools` line rather than the mixin with a
+test-supplied ceiling — the mixin tests cannot see what the agent passes in,
+which is where #3544 actually survived its first fix.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+gaia_agent = pytest.importorskip("gaia_agent.agent")
+chat_agent = pytest.importorskip("gaia_agent_chat.agent")
+GaiaAgent = gaia_agent.GaiaAgent
+GaiaAgentConfig = gaia_agent.GaiaAgentConfig
+ChatAgent = chat_agent.ChatAgent
+
+
+def _register_tools_only(config, project_root):
+    """Run just the flagship's tool-registration body, nothing else."""
+    agent = GaiaAgent.__new__(GaiaAgent)
+    agent.config = config
+    agent.observers = []  # __del__ runs on an agent that never ran __init__
+    with (
+        patch.object(GaiaAgent, "_maybe_build_skill_loader", return_value=None),
+        patch.object(GaiaAgent, "_maybe_build_skill_discovery", return_value=None),
+        patch.object(GaiaAgent, "register_skill_library_tools"),
+        patch.object(GaiaAgent, "register_skill_learning_tools"),
+        patch.object(GaiaAgent, "register_code_index_tools"),
+        patch.object(GaiaAgent, "_project_map_root", return_value=project_root),
+        patch.object(ChatAgent, "_register_tools"),
+    ):
+        agent._register_tools()
+    return agent
+
+
+def test_a_session_started_inside_a_repo_can_still_reach_the_others(tmp_path):
+    projects = tmp_path / "projects"
+    first = projects / "a"
+    first.mkdir(parents=True)
+    (projects / "b").mkdir()
+
+    agent = _register_tools_only(
+        GaiaAgentConfig(allowed_paths=[str(projects)]), str(first)
+    )
+
+    assert agent._repo_path == str(first)
+    assert agent._code_index_ceilings == (str(projects),)
+
+
+def test_every_allowed_root_is_reachable_not_just_the_first(tmp_path):
+    one = tmp_path / "one"
+    two = tmp_path / "two"
+    one.mkdir()
+    two.mkdir()
+
+    agent = _register_tools_only(
+        GaiaAgentConfig(allowed_paths=[str(one), str(two)]), str(one)
+    )
+
+    assert agent._code_index_ceilings == (str(one), str(two))


### PR DESCRIPTION
Once the agent has indexed one repository, asking it to index a second one in the same session always fails. The first index permanently narrows the agent's file scope to that repository, so any later path — a sibling checkout, another project under the same home directory — is rejected as outside the allowed area. The user has to restart the agent to index anything else, and the error gives no hint that this is why.

Fixes #3544

## Test plan

- [x] `pytest tests/unit/test_code_index_mixin.py` (19 passed) — six new cases: a second repo under the ceiling, switching back to the first, the ceiling not moving with the indexed repo, the traversal guard still holding *after* an index, a path above the ceiling still refused, and the previous repo's SDK dropped on switch. **3 fail on `main`.**
- [x] `pytest tests/unit -k "code_index"` (95 passed) — including the existing traversal-guard suite (`..`, absolute paths elsewhere, and a symlink planted inside the allowed root), which is the part that must not weaken.
- [x] `black`, `flake8`, `isort`, `python util/lint.py --pylint`
- [ ] Live two-repo session in the TUI — not run here; the unit tests drive the real tool function with the SDK stubbed, which is where the guard lives.

<details>
<summary>🔍 Technical details</summary>

`index_codebase` did `self._repo_path = resolved` on success, and the next call's containment check compared against `self._repo_path`. One value was doing two jobs — "what the LLM may point this tool at" and "what is indexed right now" — and only the first should be fixed.

`_code_index_ceiling` is now the first, set once in `_init_code_index_state` (and defaulted in `_ensure_code_index_state` for consumers that skip init). `_repo_path` remains the second and still moves.

The guard is not weakened: it validates the resolved, symlink-followed path against the resolved ceiling, exactly as before — a test asserts an outside path is still refused *after* an index has moved `_repo_path`, which is the case the old code got right only by accident of being too strict.

Switching repositories still clears `_code_index_config` / `_code_index_sdk`, so a search after switching cannot answer out of the previous repository's index; a test pins that. A per-path SDK cache would avoid rebuilding when switching back and forth — worth doing if that turns out to be a common pattern, but it is a separate change.