### PR TITLE
test(installer): expect the not-executed flag on a refused MCP tool call

### DIFF
--- a/tests/installer/test_custom_agent_mcp_harness.py
+++ b/tests/installer/test_custom_agent_mcp_harness.py
@@ -211,6 +211,9 @@ def test_custom_agent_with_mcp_reports_diagnosable_connection_failure(
         }
     ]
     assert agent.process_query("add 7 and 35") == {
+        # Refused before the tool body ran, so the result says so — that flag is
+        # what stops the verification footer claiming the call went through.
+        "executed": False,
         "status": "error",
         "error": "Unknown tool name. Use only the tools you were given.",
     }


### PR DESCRIPTION
The custom-agent MCP harness has been failing on `main` since #3703, which is why unrelated PRs are showing a red `Custom agent MCP harness` job.

#3703 made a refused tool call declare that it never ran. The harness compares the whole result dict, so the added `executed: False` broke the assertion. It went unnoticed because this file lives under `tests/installer/` and runs in its own workflow rather than the unit suite — so it turned `main` red instead of failing on the PR that changed the shape.

I pinned the flag rather than loosening the comparison: a refused call reporting itself as not-executed is exactly the contract #3703 added, and this is the only harness that exercises it through a real agent.

## Test plan

- [ ] `Custom agent MCP harness` green on this PR (both ubuntu and windows)
- [ ] The same job goes green on PRs that were inheriting the failure, e.g. #3342