### PR TITLE
feat(tui): show what a session costs — time, steps, tools, tokens, dollars

### DIFF
--- a/docs/guides/terminal-hub.mdx
+++ b/docs/guides/terminal-hub.mdx
@@ -271,6 +271,8 @@ outright.
 | `/memory` | See what the agent has stored about you — read-only, `Esc` to dismiss |
 | `/model` | Switch the flagship agent's live model |
 | `/bypass` | Let the agent run tools without asking (off by default) |
+| `/cost` | What this session has spent — time, steps, tool calls, tokens, dollars |
+| `/cost help` | Where the rates come from, and how to set your own |
 
 Typing `/` as the first character of an empty composer opens a palette listing every
 command above with a one-line description, so there's no need to already know them or
@@ -310,6 +312,71 @@ multi-minute install. The transcript says the server was not started and names w
 still needs it: RAG, memory and the code index embed through Lemonade, which has no
 Claude equivalent. Run `gaia init --skip-chat-model`, or `/setup` in
 the composer, when you want those.
+
+## What a session costs
+
+`/cost` answers "what has this conversation spent", which is the question behind
+deciding whether a task is worth running on a cloud model at all:
+
+```
+Session so far — 12 turns on fireworks.glm-5p3
+
+  active time   14m 22s
+  agent steps   84
+  tool calls    132
+
+  input tokens  1.2M   (969.7k served from cache, 77%)
+  output tokens 93.0k
+
+  cost          $1.4083 USD  (input $0.3921 + cached $0.2521 + output $0.4092)
+                published rates as of 2026-09-13
+```
+
+Two things that line is careful about, because a cost readout that gets them wrong
+looks like a measurement and nobody re-checks it:
+
+- **Every number is measured, never estimated.** They are summed from what the
+  backend reported for each turn. A turn whose backend reported no token counts
+  still counts as a turn, contributes nothing to the token totals, and the view
+  says how many turns went unmeasured rather than quietly averaging over them.
+- **`active time` is the sum of the turns, not the clock.** The minutes you spend
+  reading an answer are not the agent working, so they are not in it.
+
+While a **metered** model is running — a cloud provider you are billed by, or Claude
+— the running spend also rides the status bar, so it is in front of you when you
+decide whether to ask the expensive follow-up. A local model costs nothing to run
+again and a gateway your organisation already pays for is not your bill, so neither
+shows the line.
+
+### Rates, and setting your own
+
+Rates for the models GAIA ships are built in, and every dollar figure is printed with
+the date they were read, so a stale card is visible rather than silent. A model with
+no published rate shows tokens and no dollars — an absent figure sends you to look it
+up, where a guessed one quietly prices your month wrong.
+
+To override one — a negotiated price, a tier that isn't listed, or a correction after
+a provider moves its prices — write `~/.gaia/model-prices.json`:
+
+```json
+{
+  "fireworks.glm-5p3": {
+    "input_per_mtok": 1.40,
+    "output_per_mtok": 4.40,
+    "cached_per_mtok": 0.26
+  }
+}
+```
+
+Dollars per million tokens; your file wins over the built-in rates, and the readout
+says which of the two it quoted. Keys match exactly first and then by longest prefix,
+so one entry can cover a whole family. Omitting `cached_per_mtok` bills cached input
+at the full input rate, and setting it to `0` means cached input is free — different
+offers, so they are written differently. `GAIA_MODEL_PRICES` overrides the path.
+
+If that file exists but can't be parsed, `/cost` says so and names the problem rather
+than reporting "no rate configured" — otherwise you would edit a file that is already
+being ignored.
 
 ## Running another agent
 

--- a/src/gaia/agents/base/agent.py
+++ b/src/gaia/agents/base/agent.py
@@ -495,6 +495,31 @@ def _sum_conversation_tokens(
     return total_input, total_output
 
 
+def _sum_cached_tokens(conversation: List[Dict[str, Any]]) -> int:
+    """Prompt tokens the backend served from its own cache this turn.
+
+    Reported by a cloud-routed step (Fireworks puts it in
+    ``prompt_tokens_details.cached_tokens``); a local llama.cpp run reports
+    nothing and sums to 0, which is the truth there rather than a gap — the
+    prompt genuinely was not served from a provider-side cache.
+
+    Worth its own total because it is the one token class that is billed
+    differently, and because a turn whose prompt is mostly cache is a very
+    different cost from one that is not.
+    """
+    total = 0
+    for entry in conversation:
+        if entry.get("role") != "system" or not isinstance(entry.get("content"), dict):
+            continue
+        content = entry["content"]
+        if content.get("type") != "stats" or "performance_stats" not in content:
+            continue
+        stats = content["performance_stats"]
+        if isinstance(stats, dict):
+            total += _safe_number(stats.get("cached_tokens"))
+    return total
+
+
 def _query_tok_per_s(conversation: List[Dict[str, Any]]) -> Optional[float]:
     """Turn's generation rate, from the backend's OWN per-call measurement.
 
@@ -6970,6 +6995,8 @@ Do NOT wrap conversational replies in JSON.
                     final_answer,
                     streaming=self.streaming,
                     total_tokens=pre_output_tokens,
+                    input_tokens=_pre_input_tokens,
+                    cached_tokens=_sum_cached_tokens(conversation),
                     ttft_seconds=_query_ttft_seconds(conversation),
                     tok_per_s=_query_tok_per_s(conversation),
                 )

--- a/src/gaia/agents/base/console.py
+++ b/src/gaia/agents/base/console.py
@@ -319,6 +319,8 @@ class OutputHandler(ABC):
         total_tokens: Optional[int] = None,
         ttft_seconds: Optional[float] = None,
         tok_per_s: Optional[float] = None,
+        input_tokens: Optional[int] = None,
+        cached_tokens: Optional[int] = None,
     ):
         """Print final answer/result.
 
@@ -1619,6 +1621,8 @@ class AgentConsole(TerminalConfirmationMixin, OutputHandler):
         total_tokens: Optional[int] = None,  # pylint: disable=unused-argument
         ttft_seconds: Optional[float] = None,  # pylint: disable=unused-argument
         tok_per_s: Optional[float] = None,  # pylint: disable=unused-argument
+        input_tokens: Optional[int] = None,  # pylint: disable=unused-argument
+        cached_tokens: Optional[int] = None,  # pylint: disable=unused-argument
     ) -> None:
         """
         Print the final answer with appropriate styling.
@@ -2581,6 +2585,8 @@ class SilentConsole(TerminalConfirmationMixin, OutputHandler):
         total_tokens: Optional[int] = None,  # pylint: disable=unused-argument
         ttft_seconds: Optional[float] = None,  # pylint: disable=unused-argument
         tok_per_s: Optional[float] = None,  # pylint: disable=unused-argument
+        input_tokens: Optional[int] = None,  # pylint: disable=unused-argument
+        cached_tokens: Optional[int] = None,  # pylint: disable=unused-argument
     ) -> None:
         """
         Print the final answer.

--- a/src/gaia/api/sse_handler.py
+++ b/src/gaia/api/sse_handler.py
@@ -218,6 +218,8 @@ class SSEOutputHandler(OutputHandler):
         total_tokens: Optional[int] = None,
         ttft_seconds: Optional[float] = None,
         tok_per_s: Optional[float] = None,
+        input_tokens: Optional[int] = None,
+        cached_tokens: Optional[int] = None,
     ):  # pylint: disable=unused-argument
         """Print final answer/result.
 

--- a/src/gaia/llm/lemonade_client.py
+++ b/src/gaia/llm/lemonade_client.py
@@ -644,6 +644,35 @@ def is_tool_calling_model(model_id: Optional[str]) -> bool:
     return True  # Unknown GGUF: optimistic default per Tier 0 findings
 
 
+def _usage_dict(usage: Any) -> Dict[str, Any]:
+    """The SDK's usage object as a plain dict, nested details included.
+
+    ``model_dump`` where the SDK offers it, attribute reads otherwise, so a
+    provider that returns a shape the SDK does not model (Fireworks' cached and
+    reasoning counts live in nested ``*_details`` objects) still survives the
+    trip to the caller.
+    """
+    if hasattr(usage, "model_dump"):
+        try:
+            return usage.model_dump(exclude_none=True)
+        except Exception:  # pragma: no cover - defensive, SDK-version specific
+            pass
+    out: Dict[str, Any] = {}
+    for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
+        value = getattr(usage, key, None)
+        if value is not None:
+            out[key] = value
+    for key in ("prompt_tokens_details", "completion_tokens_details"):
+        details = getattr(usage, key, None)
+        if details is None:
+            continue
+        if hasattr(details, "model_dump"):
+            out[key] = details.model_dump(exclude_none=True)
+        else:
+            out[key] = {k: v for k, v in vars(details).items() if not k.startswith("_")}
+    return out
+
+
 def _tool_call_deltas(delta: Any) -> Optional[List[Dict[str, Any]]]:
     """Plain-dict form of one streamed frame's ``tool_calls``, or ``None``.
 
@@ -1963,6 +1992,15 @@ class LemonadeClient:
             **kwargs,
         }
 
+        # An OpenAI-compatible stream sends usage only if asked. Without this
+        # a streamed turn reports no token counts at all, and the gap is
+        # invisible locally — llama.cpp answers the /stats poll, so the numbers
+        # appear to be there — while a cloud-routed model, whose /stats is all
+        # zeros, silently loses them. That is backwards: the counts matter most
+        # where the tokens are billed. Caller-supplied stream_options win.
+        if stream and "stream_options" not in data:
+            data["stream_options"] = {"include_usage": True}
+
         if stop:
             data["stop"] = stop
 
@@ -2149,6 +2187,13 @@ class LemonadeClient:
             "temperature": temperature,
             "max_completion_tokens": max_completion_tokens,
             "stream": True,
+            # An OpenAI-compatible stream sends its token accounting only if
+            # asked, in one final chunk that carries no choices. Without this a
+            # streamed turn reports no tokens at all — invisible locally, where
+            # llama.cpp answers the /stats poll instead, and total for a
+            # cloud-routed model whose /stats is all zeros. That is backwards:
+            # the counts matter most where the tokens are billed.
+            "stream_options": {"include_usage": True},
             **standard_kwargs,
         }
 
@@ -2173,6 +2218,21 @@ class LemonadeClient:
             tokens_generated = 0
             for chunk in stream:
                 tokens_generated += 1
+                # The usage chunk is the last one and carries no choices:
+                # forward it as its own frame rather than dropping it on the
+                # floor with the rest of the non-choice chunks.
+                usage = getattr(chunk, "usage", None)
+                if usage is not None and not chunk.choices:
+                    yield {
+                        "id": chunk.id,
+                        "object": "chat.completion.chunk",
+                        "created": chunk.created,
+                        "model": chunk.model,
+                        "choices": [],
+                        "usage": _usage_dict(usage),
+                    }
+                    continue
+
                 # Convert to dict format expected by our API
                 yield {
                     "id": chunk.id,

--- a/src/gaia/llm/lemonade_client.py
+++ b/src/gaia/llm/lemonade_client.py
@@ -5117,9 +5117,10 @@ if __name__ == "__main__":
             for chunk in client.chat_completions(
                 model=DEFAULT_MODEL_NAME, messages=messages, stream=True, timeout=30
             ):
-                if "choices" in chunk and chunk["choices"][0].get("delta", {}).get(
-                    "content"
-                ):
+                # The last chunk carries usage and no choices.
+                if not chunk.get("choices"):
+                    continue
+                if chunk["choices"][0].get("delta", {}).get("content"):
                     print(chunk["choices"][0]["delta"]["content"], end="", flush=True)
         except Exception as e:
             print(f"Streaming chat completion failed: {e}")

--- a/src/gaia/llm/providers/lemonade.py
+++ b/src/gaia/llm/providers/lemonade.py
@@ -441,20 +441,7 @@ class LemonadeProvider(LLMClient):
             # cloud-routed response carries (Fireworks reports both; a local
             # llama.cpp run reports neither, and 0 there means "none", not
             # "unmeasured" — the prompt genuinely was not served from a cache).
-            prompt_details = usage.get("prompt_tokens_details") or {}
-            completion_details = usage.get("completion_tokens_details") or {}
-            self._last_usage = {
-                "prompt_tokens": int(usage.get("prompt_tokens") or 0),
-                "completion_tokens": int(usage.get("completion_tokens") or 0),
-                "total_tokens": int(usage.get("total_tokens") or 0),
-                "cached_tokens": int(prompt_details.get("cached_tokens") or 0),
-                "reasoning_tokens": int(
-                    completion_details.get("reasoning_tokens") or 0
-                ),
-                "tokens_per_second": float(
-                    (timings or {}).get("predicted_per_second") or 0.0
-                ),
-            }
+            self._capture_usage(usage, response.get("timings"))
 
         if not response["choices"] or len(response["choices"]) == 0:
             raise ValueError("Empty choices in response from Lemonade Server")
@@ -526,6 +513,30 @@ class LemonadeProvider(LLMClient):
             }
         return self._backend.get_stats() or {}
 
+    def _capture_usage(self, usage: dict, timings: Optional[dict]) -> None:
+        """Record one response's token accounting.
+
+        Shared by the streamed and non-streamed paths so the two cannot report
+        different shapes for the same turn. cached/reasoning come from the
+        nested ``*_details`` objects a cloud-routed response carries; a local
+        llama.cpp run reports neither, and 0 there means "none" rather than
+        "unmeasured" — the prompt genuinely was not served from a cache.
+        """
+        if not isinstance(usage, dict):
+            return
+        prompt_details = usage.get("prompt_tokens_details") or {}
+        completion_details = usage.get("completion_tokens_details") or {}
+        self._last_usage = {
+            "prompt_tokens": int(usage.get("prompt_tokens") or 0),
+            "completion_tokens": int(usage.get("completion_tokens") or 0),
+            "total_tokens": int(usage.get("total_tokens") or 0),
+            "cached_tokens": int(prompt_details.get("cached_tokens") or 0),
+            "reasoning_tokens": int(completion_details.get("reasoning_tokens") or 0),
+            "tokens_per_second": float(
+                (timings or {}).get("predicted_per_second") or 0.0
+            ),
+        }
+
     def get_last_usage(self) -> Optional[dict]:
         """Token-usage dict from the most recent non-streaming ``chat()``
         call (#1891), or ``None`` when unavailable (a streaming call, or the
@@ -563,6 +574,11 @@ class LemonadeProvider(LLMClient):
             return out
 
         for chunk in response:
+            # The usage chunk arrives last and carries no choices. It is the
+            # only token accounting a streamed turn gets — see the
+            # stream_options request in lemonade_client.
+            if chunk.get("usage"):
+                self._capture_usage(chunk["usage"], timings=None)
             if "choices" in chunk and chunk["choices"]:
                 choice = chunk["choices"][0]
                 finish_reason = choice.get("finish_reason") or finish_reason

--- a/src/gaia/llm/providers/lemonade.py
+++ b/src/gaia/llm/providers/lemonade.py
@@ -437,10 +437,20 @@ class LemonadeProvider(LLMClient):
         usage = response.get("usage")
         if isinstance(usage, dict):
             timings = response.get("timings")
+            # cached/reasoning come from the nested *_details objects a
+            # cloud-routed response carries (Fireworks reports both; a local
+            # llama.cpp run reports neither, and 0 there means "none", not
+            # "unmeasured" — the prompt genuinely was not served from a cache).
+            prompt_details = usage.get("prompt_tokens_details") or {}
+            completion_details = usage.get("completion_tokens_details") or {}
             self._last_usage = {
                 "prompt_tokens": int(usage.get("prompt_tokens") or 0),
                 "completion_tokens": int(usage.get("completion_tokens") or 0),
                 "total_tokens": int(usage.get("total_tokens") or 0),
+                "cached_tokens": int(prompt_details.get("cached_tokens") or 0),
+                "reasoning_tokens": int(
+                    completion_details.get("reasoning_tokens") or 0
+                ),
                 "tokens_per_second": float(
                     (timings or {}).get("predicted_per_second") or 0.0
                 ),

--- a/src/gaia/llm/providers/lemonade.py
+++ b/src/gaia/llm/providers/lemonade.py
@@ -436,11 +436,6 @@ class LemonadeProvider(LLMClient):
         # HTTP round-trip and no last-request race.
         usage = response.get("usage")
         if isinstance(usage, dict):
-            timings = response.get("timings")
-            # cached/reasoning come from the nested *_details objects a
-            # cloud-routed response carries (Fireworks reports both; a local
-            # llama.cpp run reports neither, and 0 there means "none", not
-            # "unmeasured" — the prompt genuinely was not served from a cache).
             self._capture_usage(usage, response.get("timings"))
 
         if not response["choices"] or len(response["choices"]) == 0:
@@ -517,25 +512,30 @@ class LemonadeProvider(LLMClient):
         """Record one response's token accounting.
 
         Shared by the streamed and non-streamed paths so the two cannot report
-        different shapes for the same turn. cached/reasoning come from the
-        nested ``*_details`` objects a cloud-routed response carries; a local
-        llama.cpp run reports neither, and 0 there means "none" rather than
-        "unmeasured" — the prompt genuinely was not served from a cache.
+        different shapes for the same turn.
+
+        cached/reasoning ride the nested ``*_details`` objects and appear only
+        when the backend actually sent them. A reported 0 is a measurement —
+        the prompt was not served from a cache — so it is kept; a backend that
+        said nothing leaves the key out rather than having a 0 invented for it.
         """
         if not isinstance(usage, dict):
             return
-        prompt_details = usage.get("prompt_tokens_details") or {}
-        completion_details = usage.get("completion_tokens_details") or {}
-        self._last_usage = {
+        captured = {
             "prompt_tokens": int(usage.get("prompt_tokens") or 0),
             "completion_tokens": int(usage.get("completion_tokens") or 0),
             "total_tokens": int(usage.get("total_tokens") or 0),
-            "cached_tokens": int(prompt_details.get("cached_tokens") or 0),
-            "reasoning_tokens": int(completion_details.get("reasoning_tokens") or 0),
-            "tokens_per_second": float(
-                (timings or {}).get("predicted_per_second") or 0.0
-            ),
         }
+        for key, container in (
+            ("cached_tokens", usage.get("prompt_tokens_details")),
+            ("reasoning_tokens", usage.get("completion_tokens_details")),
+        ):
+            if isinstance(container, dict) and container.get(key) is not None:
+                captured[key] = int(container[key])
+        captured["tokens_per_second"] = float(
+            (timings or {}).get("predicted_per_second") or 0.0
+        )
+        self._last_usage = captured
 
     def get_last_usage(self) -> Optional[dict]:
         """Token-usage dict from the most recent non-streaming ``chat()``

--- a/src/gaia/ui/sse_handler.py
+++ b/src/gaia/ui/sse_handler.py
@@ -611,6 +611,8 @@ class SSEOutputHandler(OutputHandler):
         total_tokens: Optional[int] = None,
         ttft_seconds: Optional[float] = None,
         tok_per_s: Optional[float] = None,
+        input_tokens: Optional[int] = None,
+        cached_tokens: Optional[int] = None,
     ):
         if answer:
             scope_line = ""
@@ -663,6 +665,14 @@ class SSEOutputHandler(OutputHandler):
         # time as generation time and read an order of magnitude low.
         if tok_per_s is not None and math.isfinite(tok_per_s) and tok_per_s > 0:
             event["tok_per_s"] = round(tok_per_s, 1)
+        # Input and cached counts ride the same omit-don't-fake rule. Cached is
+        # reported at 0 rather than omitted when the turn had input tokens: a
+        # backend that counted the prompt and cached none of it is telling us
+        # zero, which is a different statement from "nobody counted".
+        if input_tokens is not None and input_tokens > 0:
+            event["input_tokens"] = input_tokens
+            if cached_tokens is not None and cached_tokens >= 0:
+                event["cached_tokens"] = cached_tokens
         # Dev-mode only. Gated on the same env var that produced the record, so
         # an ordinary turn's payload stays byte-identical to before this existed.
         record, self._turn_metrics = self._turn_metrics, None

--- a/src/gaia/ui/sse_translation.py
+++ b/src/gaia/ui/sse_translation.py
@@ -391,6 +391,8 @@ class CanonicalTranslator:
             ("tokens", "tokens"),
             ("ttft", "ttft"),
             ("tok_per_s", "tok_per_s"),
+            ("input_tokens", "input_tokens"),
+            ("cached_tokens", "cached_tokens"),
             # Dev-mode per-turn record, passed through verbatim — the client
             # decides what of it to show, so a new field needs no change here.
             ("metrics", "metrics"),

--- a/tests/test_lemonade_client.py
+++ b/tests/test_lemonade_client.py
@@ -2444,6 +2444,7 @@ class TestLemonadeClientIntegration(unittest.TestCase):
         # Collect the streamed chunks
         content = ""
         chunk_count = 0
+        usage = None
         print("Starting streaming chat completion test...")
 
         try:
@@ -2458,6 +2459,16 @@ class TestLemonadeClientIntegration(unittest.TestCase):
 
                 # Check chunk structure
                 self.assertIn("choices", chunk)
+
+                # The token accounting arrives in a final chunk that carries no
+                # choices — that is the OpenAI streaming shape when usage is
+                # requested, and the only place a streamed turn reports its
+                # tokens at all. Indexing choices[0] unconditionally crashes on
+                # it, which is how this was found.
+                if chunk.get("usage"):
+                    usage = chunk["usage"]
+                if not chunk["choices"]:
+                    continue
 
                 # Extract and accumulate content
                 delta = chunk["choices"][0].get("delta", {})
@@ -2474,6 +2485,16 @@ class TestLemonadeClientIntegration(unittest.TestCase):
             self.assertIn("1", content, "Response should include '1'")
             self.assertIn("2", content, "Response should include '2'")
             self.assertIn("3", content, "Response should include '3'")
+
+            # A streamed turn has to report its tokens. Without this the cost
+            # and tokens/sec readouts have nothing to sum, and the gap is
+            # invisible locally because /stats answers instead — only a real
+            # server proves it, which is why this assertion lives here.
+            self.assertIsNotNone(
+                usage, "streamed turn reported no usage — stream_options lost?"
+            )
+            self.assertGreater(usage.get("prompt_tokens", 0), 0)
+            self.assertGreater(usage.get("completion_tokens", 0), 0)
             print("✅ Streaming chat completion test passed")
 
         except LemonadeClientError as e:

--- a/tests/unit/chat/ui/test_sse_handler.py
+++ b/tests/unit/chat/ui/test_sse_handler.py
@@ -2060,3 +2060,47 @@ class TestStripBalancedJsonBlobs:
         text = 'oops {"kind": "email_pre_scan", "n": 1 and no close'
         out = _strip_balanced_json_blobs(text, self.KIND_RE)
         assert out == text  # incomplete object is not removed
+
+
+# ===========================================================================
+# Input / cached token reporting on the terminal answer event
+# ===========================================================================
+
+
+class TestInputAndCachedTokenEmission:
+    """What the answer event may claim about the prompt it was billed for.
+
+    Every figure here is either measured or absent — the surfaces downstream
+    turn these into a dollar amount, so a fabricated zero is not a harmless
+    default. Cached is emitted as an explicit ``0`` only alongside a real
+    input count: "the backend counted the prompt and cached none of it" and
+    "nobody counted" are different claims, and only the first is a zero.
+    """
+
+    def _answer(self, handler, **kwargs):
+        handler.print_final_answer("done", **kwargs)
+        return [e for e in _drain(handler) if e and e.get("type") == "answer"][0]
+
+    def test_measured_counts_are_reported(self, handler):
+        event = self._answer(handler, input_tokens=1200, cached_tokens=900)
+        assert event["input_tokens"] == 1200
+        assert event["cached_tokens"] == 900
+
+    def test_nothing_cached_is_an_explicit_zero(self, handler):
+        event = self._answer(handler, input_tokens=1200, cached_tokens=0)
+        assert event["cached_tokens"] == 0, "a measured zero must survive"
+
+    def test_an_unmeasured_prompt_reports_neither(self, handler):
+        event = self._answer(handler, input_tokens=None, cached_tokens=None)
+        assert "input_tokens" not in event
+        assert "cached_tokens" not in event
+
+    def test_cached_alone_is_not_reported(self, handler):
+        """Without an input count a cache share has nothing to be a share of."""
+        event = self._answer(handler, input_tokens=None, cached_tokens=500)
+        assert "cached_tokens" not in event
+
+    def test_a_zero_input_count_is_not_a_measurement(self, handler):
+        event = self._answer(handler, input_tokens=0, cached_tokens=0)
+        assert "input_tokens" not in event
+        assert "cached_tokens" not in event

--- a/tests/unit/test_agent_token_usage.py
+++ b/tests/unit/test_agent_token_usage.py
@@ -30,6 +30,7 @@ from gaia.agents.base.agent import (
     _query_tok_per_s,
     _query_ttft_seconds,
     _safe_number,
+    _sum_cached_tokens,
     _sum_conversation_tokens,
 )
 from gaia.agents.base.tools import _TOOL_REGISTRY, tool
@@ -510,3 +511,53 @@ class TestToolUsageRollup:
         or survive without the per-turn reset that _process_query_impl does."""
         agent = _make_agent()
         assert agent._tool_reported_usage == []
+
+
+class TestSumCachedTokens:
+    """Prompt tokens the provider served from its own cache, summed per turn.
+
+    Cached input bills at a fraction of the input rate, so this number is the
+    difference between a session costing what it looks like and costing several
+    times that. It is only ever a sum of what the backend reported — a step
+    that reported nothing contributes nothing, never a guess at what share of
+    the prompt "probably" hit the cache.
+    """
+
+    def test_sums_across_steps(self):
+        conversation = [
+            _stats_entry(1, prompt_tokens=1000, cached_tokens=600),
+            _stats_entry(2, prompt_tokens=1400, cached_tokens=1200),
+        ]
+        assert _sum_cached_tokens(conversation) == 1800
+
+    def test_a_step_that_reported_none_contributes_nothing(self):
+        conversation = [
+            _stats_entry(1, prompt_tokens=1000, cached_tokens=600),
+            _stats_entry(2, prompt_tokens=1400),
+        ]
+        assert _sum_cached_tokens(conversation) == 600
+
+    def test_a_local_backend_reporting_nothing_sums_to_zero(self):
+        conversation = [_stats_entry(1, prompt_tokens=1000, completion_tokens=50)]
+        assert _sum_cached_tokens(conversation) == 0
+
+    def test_non_stats_entries_are_ignored(self):
+        conversation = [
+            {"role": "user", "content": "cached_tokens=99999"},
+            {"role": "assistant", "content": "no"},
+            _stats_entry(1, cached_tokens=7),
+        ]
+        assert _sum_cached_tokens(conversation) == 7
+
+    def test_a_malformed_count_does_not_break_the_turn(self):
+        """A bad stat must never take down the run that carries it."""
+        conversation = [
+            _stats_entry(1, cached_tokens="lots"),
+            _stats_entry(2, cached_tokens=-5),
+            _stats_entry(3, cached_tokens=None),
+            _stats_entry(4, cached_tokens=11),
+        ]
+        assert _sum_cached_tokens(conversation) == 11
+
+    def test_an_empty_conversation_is_zero(self):
+        assert _sum_cached_tokens([]) == 0

--- a/tests/unit/test_lemonade_cloud_models.py
+++ b/tests/unit/test_lemonade_cloud_models.py
@@ -434,3 +434,50 @@ def test_cloud_sse_backend_error_uses_status_without_reflecting_body(
     assert remedy in str(error.value)
     assert reflected_key not in str(error.value)
     assert reflected_key not in caplog.text
+
+
+class TestCachedTokenCapture:
+    """A cached-token count is reported when measured and omitted when not.
+
+    Fireworks bills cached prompt tokens at a tenth of the input rate, so the
+    count drives a real dollar figure. That makes the absent case matter as
+    much as the present one: a backend that said nothing about caching must
+    not come back as "0 cached", which reads as a measurement and prices the
+    turn as if the whole prompt were billed fresh.
+    """
+
+    def capture(self, usage):
+        adapter = LemonadeProvider(model="Gemma-4-E4B-it-GGUF")
+        adapter._capture_usage(usage, timings=None)
+        return adapter._last_usage
+
+    def test_reported_counts_are_kept(self):
+        captured = self.capture(
+            {
+                "prompt_tokens": 120,
+                "completion_tokens": 8,
+                "total_tokens": 128,
+                "prompt_tokens_details": {"cached_tokens": 96},
+                "completion_tokens_details": {"reasoning_tokens": 3},
+            }
+        )
+        assert captured["cached_tokens"] == 96
+        assert captured["reasoning_tokens"] == 3
+
+    def test_a_reported_zero_is_a_measurement(self):
+        captured = self.capture(
+            {
+                "prompt_tokens": 120,
+                "completion_tokens": 8,
+                "total_tokens": 128,
+                "prompt_tokens_details": {"cached_tokens": 0},
+            }
+        )
+        assert captured["cached_tokens"] == 0
+
+    def test_an_unreported_count_is_left_out(self):
+        captured = self.capture(
+            {"prompt_tokens": 120, "completion_tokens": 8, "total_tokens": 128}
+        )
+        assert "cached_tokens" not in captured
+        assert "reasoning_tokens" not in captured

--- a/tui/internal/control/state.go
+++ b/tui/internal/control/state.go
@@ -82,7 +82,11 @@ type ChatState struct {
 type SessionCost struct {
 	Turns         int     `json:"turns"`
 	MeasuredTurns int     `json:"measured_turns"`
-	WallSeconds   float64 `json:"wall_seconds"`
+	// ActiveSeconds is the sum of the turns, not the session's wall clock —
+	// the time between turns is the user reading, not the agent working. A
+	// driver attributing a task's duration wants this; one that wants wall
+	// clock has to measure it itself.
+	ActiveSeconds float64 `json:"active_seconds"`
 	Steps         int     `json:"steps"`
 	ToolCalls     int     `json:"tool_calls"`
 	InputTokens   int     `json:"input_tokens"`

--- a/tui/internal/control/state.go
+++ b/tui/internal/control/state.go
@@ -67,6 +67,31 @@ type ChatState struct {
 	ViewportRows int  `json:"viewport_rows"`
 	HeaderRows   int  `json:"header_rows"`
 	HelpOpen     bool `json:"help_open"`
+
+	// Cost is what the session has spent so far, nil before the first turn.
+	Cost *SessionCost `json:"cost,omitempty"`
+}
+
+// SessionCost is the session ledger the TUI keeps: what a driver needs to
+// answer "what did that task cost" without re-deriving it from a transcript.
+//
+// Every field is summed from what the inference backend reported. A turn whose
+// backend reported no token counts is counted in Turns but contributes nothing
+// to the token totals, and MeasuredTurns says how many were measured — so a
+// caller can tell a genuinely cheap session from a partly-unmeasured one.
+type SessionCost struct {
+	Turns         int     `json:"turns"`
+	MeasuredTurns int     `json:"measured_turns"`
+	WallSeconds   float64 `json:"wall_seconds"`
+	Steps         int     `json:"steps"`
+	ToolCalls     int     `json:"tool_calls"`
+	InputTokens   int     `json:"input_tokens"`
+	OutputTokens  int     `json:"output_tokens"`
+	CachedTokens  int     `json:"cached_tokens"`
+	Model         string  `json:"model,omitempty"`
+	// USD is nil when no price is configured for this model — a cost readout
+	// must not invent a rate.
+	USD *float64 `json:"usd,omitempty"`
 }
 
 // Every view the TUI can report. A client waits on one of these, so they are

--- a/tui/internal/event/canonical.go
+++ b/tui/internal/event/canonical.go
@@ -174,13 +174,19 @@ type CanonicalFinalEvent struct {
 // agent ran with GAIA_TURN_LOG set. Nil on every ordinary turn and from any
 // agent older than the record — callers must treat absence as normal.
 type CanonicalUsage struct {
-	Steps     int                 `json:"steps"`
-	ToolsUsed int                 `json:"tools_used"`
-	Elapsed   float64             `json:"elapsed"`
-	Tokens    int                 `json:"tokens"`
-	TTFT      float64             `json:"ttft"`
-	TokPerS   float64             `json:"tok_per_s"`
-	Metrics   *CanonicalTurnStats `json:"-"`
+	Steps     int     `json:"steps"`
+	ToolsUsed int     `json:"tools_used"`
+	Elapsed   float64 `json:"elapsed"`
+	Tokens    int     `json:"tokens"`
+	TTFT      float64 `json:"ttft"`
+	TokPerS   float64 `json:"tok_per_s"`
+	// InputTokens is the prompt the turn sent, CachedTokens the part of it the
+	// backend served from its own cache. Cached is the one class billed
+	// differently, so a session total that does not separate it cannot be
+	// turned into a cost.
+	InputTokens  int                 `json:"input_tokens"`
+	CachedTokens int                 `json:"cached_tokens"`
+	Metrics      *CanonicalTurnStats `json:"-"`
 }
 
 // usageWire decodes the usage object with the record left as raw bytes, so a

--- a/tui/internal/ui/chat/canonical.go
+++ b/tui/internal/ui/chat/canonical.go
@@ -216,18 +216,31 @@ func (m ChatModel) handleCanonicalEvent(evt interface{}) (ChatModel, tea.Cmd, bo
 		// "cancelled" line settleTurn adds is the whole story, not a blank bubble.
 		if content != "" || !m.cancelPending {
 			m.messages = append(m.messages, Message{
-				Role:      RoleAssistant,
-				Content:   content,
-				Rendered:  components.RenderMarkdown(content),
-				Duration:  time.Since(m.queryStart),
-				TTFT:      ttft,
-				TokPerS:   usage.TokPerS,
-				Steps:     usage.Steps,
-				ToolsUsed: usage.ToolsUsed,
-				Tokens:    usage.Tokens,
-				Metrics:   usage.Metrics,
+				Role:         RoleAssistant,
+				Content:      content,
+				Rendered:     components.RenderMarkdown(content),
+				Duration:     time.Since(m.queryStart),
+				TTFT:         ttft,
+				TokPerS:      usage.TokPerS,
+				InputTokens:  usage.InputTokens,
+				CachedTokens: usage.CachedTokens,
+				Steps:        usage.Steps,
+				ToolsUsed:    usage.ToolsUsed,
+				Tokens:       usage.Tokens,
+				Metrics:      usage.Metrics,
 			})
 		}
+		// One ledger entry per turn, from what the backend reported. A turn
+		// with no token counts still counts as a turn — see sessionCost.
+		m.cost.add(turnCost{
+			duration:  time.Since(m.queryStart),
+			steps:     usage.Steps,
+			tools:     usage.ToolsUsed,
+			inTok:     usage.InputTokens,
+			outTok:    usage.Tokens,
+			cachedTok: usage.CachedTokens,
+			measured:  usage.InputTokens > 0 || usage.Tokens > 0,
+		})
 		// Drain here, not on doneMsg: streaming flips false in THIS handler, and doneMsg fires later, after a second query could already be in flight.
 		m.drainPendingPreScan()
 		m.streaming = false

--- a/tui/internal/ui/chat/hints.go
+++ b/tui/internal/ui/chat/hints.go
@@ -256,7 +256,14 @@ func (m ChatModel) sessionSpendHint() string {
 		return ""
 	}
 	if price := lookupPrice(m.modelID); price != nil {
-		return fmt.Sprintf("$%.3f this session", price.totalUSD(in, cached, out))
+		// Three decimals keep the status bar narrow, but a real spend must
+		// never render as "$0.000" — that reads as free, and the /cost view
+		// would disagree with it.
+		usd := price.totalUSD(in, cached, out)
+		if usd < 0.0005 {
+			return "<$0.001 this session"
+		}
+		return fmt.Sprintf("$%.3f this session", usd)
 	}
 	return fmt.Sprintf("%s tok this session", thousands(in+out))
 }
@@ -264,9 +271,14 @@ func (m ChatModel) sessionSpendHint() string {
 // isMeteredModel reports whether this session's inference is billed per token
 // to the user.
 //
-// Keyed on the model id's provider prefix rather than on modelRemote alone:
-// "remote" and "the user pays per token" are different claims, and an AMD
-// gateway is remote without being the user's bill.
+// Keyed on the provider rather than on modelRemote alone: "remote" and "the
+// user pays per token" are different claims, and an AMD gateway is remote
+// without being the user's bill. Claude is the other way round — it is the
+// most obviously metered thing the TUI runs, and it carries no provider
+// prefix on its model id, so it has to be recognised by its backend.
 func (m ChatModel) isMeteredModel() bool {
-	return m.modelRemote && strings.HasPrefix(m.modelID, "fireworks.")
+	if !m.modelRemote {
+		return false
+	}
+	return m.modelBackend == "claude" || strings.HasPrefix(m.modelID, "fireworks.")
 }

--- a/tui/internal/ui/chat/hints.go
+++ b/tui/internal/ui/chat/hints.go
@@ -4,6 +4,7 @@
 package chat
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/charmbracelet/x/ansi"
@@ -78,6 +79,14 @@ func (m ChatModel) statusHints() []hint {
 	}
 	if !m.followTail {
 		hints = append(hints, hint{text: "End to jump to latest", rank: rankOrient})
+	}
+
+	// What the session has spent, on the one row that is always drawn. A cost
+	// nobody sees until they think to ask for it is a cost nobody sees: the
+	// point of putting it here is that it is in front of you while you decide
+	// whether to ask the expensive follow-up.
+	if spend := m.sessionSpendHint(); spend != "" {
+		hints = append(hints, hint{text: spend, rank: rankSecondary})
 	}
 
 	// In an alt-screen app the wheel and the arrows are the ONLY way back to
@@ -227,4 +236,37 @@ func (m ChatModel) hintBudget() int {
 	// " ● " + name, the bar's own padding, and a gap before the hint.
 	used := 3 + ansi.StringWidth(m.agentName) + len(" connected") + 4
 	return m.width - used
+}
+
+// sessionSpendHint is the running cost for the status bar, or "" when there is
+// nothing worth saying.
+//
+// Only for a provider that bills per token. A local model costs nothing to run
+// again, so a spend line there is noise on the one row that always has to
+// carry the way out — and a gateway the organisation already pays for is not
+// the user's spend to watch either.
+//
+// Dollars when a price is configured, tokens otherwise — never a guessed rate.
+func (m ChatModel) sessionSpendHint() string {
+	if len(m.cost.turns) == 0 || !m.isMeteredModel() {
+		return ""
+	}
+	_, _, _, in, out, cached, _ := m.cost.totals()
+	if in+out == 0 {
+		return ""
+	}
+	if price := lookupPrice(m.modelID); price != nil {
+		return fmt.Sprintf("$%.3f this session", price.totalUSD(in, cached, out))
+	}
+	return fmt.Sprintf("%s tok this session", thousands(in+out))
+}
+
+// isMeteredModel reports whether this session's inference is billed per token
+// to the user.
+//
+// Keyed on the model id's provider prefix rather than on modelRemote alone:
+// "remote" and "the user pays per token" are different claims, and an AMD
+// gateway is remote without being the user's bill.
+func (m ChatModel) isMeteredModel() bool {
+	return m.modelRemote && strings.HasPrefix(m.modelID, "fireworks.")
 }

--- a/tui/internal/ui/chat/hints_test.go
+++ b/tui/internal/ui/chat/hints_test.go
@@ -6,6 +6,7 @@ package chat
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/charmbracelet/x/ansi"
 )
@@ -142,4 +143,55 @@ func joinHints(hints []hint) string {
 		out = append(out, h.text)
 	}
 	return strings.Join(out, hintSeparator)
+}
+
+// Claude is the most obviously metered thing the TUI runs: the user is paying
+// Anthropic per token. Keying the spend line on a "fireworks." prefix left
+// exactly that case with no running total.
+func TestClaudeSessionsShowTheirSpend(t *testing.T) {
+	spent := sessionCost{}
+	spent.add(turnCost{duration: time.Second, steps: 1, tools: 0,
+		inTok: 50000, outTok: 2000, cachedTok: 10000, measured: true})
+
+	for _, tc := range []struct {
+		name    string
+		model   ChatModel
+		metered bool
+	}{
+		{"claude", ChatModel{modelBackend: "claude", modelID: "claude-sonnet-5", modelRemote: true}, true},
+		{"fireworks", ChatModel{modelBackend: "fireworks", modelID: "fireworks.glm-5p3", modelRemote: true}, true},
+		{"amd gateway", ChatModel{modelBackend: "amd", modelID: "amd.gpt-4.1", modelRemote: true}, false},
+		{"local", ChatModel{modelBackend: "lemonade", modelID: "Gemma-4-E4B-it-GGUF"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := tc.model
+			m.cost = spent
+			if got := m.isMeteredModel(); got != tc.metered {
+				t.Fatalf("isMeteredModel = %v, want %v", got, tc.metered)
+			}
+			hint := m.sessionSpendHint()
+			if tc.metered && hint == "" {
+				t.Error("a metered session shows no running spend")
+			}
+			if !tc.metered && hint != "" {
+				t.Errorf("an unmetered session claims a spend: %q", hint)
+			}
+		})
+	}
+}
+
+// A session that really has spent something must never render as "$0.000" —
+// that reads as free, and /cost would disagree with the status bar.
+func TestATinySpendIsNotShownAsZero(t *testing.T) {
+	noPriceFile(t)
+	m := ChatModel{modelBackend: "fireworks", modelID: "fireworks.glm-5p3-flash", modelRemote: true}
+	m.cost.add(turnCost{duration: time.Second, steps: 1, inTok: 100, outTok: 10, measured: true})
+
+	hint := m.sessionSpendHint()
+	if strings.Contains(hint, "$0.000 ") {
+		t.Errorf("a real spend rendered as zero: %q", hint)
+	}
+	if !strings.Contains(hint, "<$0.001") {
+		t.Errorf("want a below-threshold marker, got %q", hint)
+	}
 }

--- a/tui/internal/ui/chat/introspect.go
+++ b/tui/internal/ui/chat/introspect.go
@@ -50,5 +50,30 @@ func (m ChatModel) controlChatState() *control.ChatState {
 		ViewportRows: m.viewport.Height,
 		HeaderRows:   m.contentHeaderRows(),
 		HelpOpen:     m.help.Open,
+		Cost:         m.controlSessionCost(),
 	}
+}
+
+// controlSessionCost publishes the session ledger, nil before the first turn.
+func (m ChatModel) controlSessionCost() *control.SessionCost {
+	if len(m.cost.turns) == 0 {
+		return nil
+	}
+	d, steps, tools, in, out, cached, measured := m.cost.totals()
+	sc := &control.SessionCost{
+		Turns:         len(m.cost.turns),
+		MeasuredTurns: measured,
+		WallSeconds:   d.Seconds(),
+		Steps:         steps,
+		ToolCalls:     tools,
+		InputTokens:   in,
+		OutputTokens:  out,
+		CachedTokens:  cached,
+		Model:         m.costModelName(),
+	}
+	if price := lookupPrice(m.modelID); price != nil {
+		usd := price.totalUSD(in, cached, out)
+		sc.USD = &usd
+	}
+	return sc
 }

--- a/tui/internal/ui/chat/introspect.go
+++ b/tui/internal/ui/chat/introspect.go
@@ -63,7 +63,7 @@ func (m ChatModel) controlSessionCost() *control.SessionCost {
 	sc := &control.SessionCost{
 		Turns:         len(m.cost.turns),
 		MeasuredTurns: measured,
-		WallSeconds:   d.Seconds(),
+		ActiveSeconds: d.Seconds(),
 		Steps:         steps,
 		ToolCalls:     tools,
 		InputTokens:   in,

--- a/tui/internal/ui/chat/message.go
+++ b/tui/internal/ui/chat/message.go
@@ -22,17 +22,19 @@ const (
 )
 
 type Message struct {
-	Role      MessageRole
-	Content   string
-	Rendered  string
-	ToolName  string
-	Success   *bool
-	Duration  time.Duration // time from query to answer
-	TTFT      time.Duration // backend-measured time to first token; 0 => not reported, omit from display
-	TokPerS   float64       // backend-measured generation rate; 0 => not reported, omit from display
-	Steps     int           // agent steps taken
-	ToolsUsed int           // tools invoked
-	Tokens    int           // real generated-token count; 0 => not reported, omit from display
+	Role         MessageRole
+	Content      string
+	Rendered     string
+	ToolName     string
+	Success      *bool
+	Duration     time.Duration // time from query to answer
+	TTFT         time.Duration // backend-measured time to first token; 0 => not reported, omit from display
+	TokPerS      float64       // backend-measured generation rate; 0 => not reported, omit from display
+	Steps        int           // agent steps taken
+	ToolsUsed    int           // tools invoked
+	Tokens       int           // real generated-token count; 0 => not reported, omit from display
+	InputTokens  int           // prompt tokens this turn sent; 0 => not reported
+	CachedTokens int           // prompt tokens served from the backend's cache
 
 	// Metrics is the agent's per-turn performance record. Nil unless the agent
 	// ran with GAIA_TURN_LOG set — every ordinary turn, and every turn from an

--- a/tui/internal/ui/chat/model.go
+++ b/tui/internal/ui/chat/model.go
@@ -1404,7 +1404,15 @@ func (m ChatModel) submit(query string) (tea.Model, tea.Cmd) {
 	case "/cost":
 		m.messages = append(m.messages, Message{
 			Role:    RoleStatus,
-			Content: m.cost.render(m.answerWidth(), m.costModelName(), lookupPrice(m.modelID)),
+			Content: m.cost.render(m.costModelName(), lookupPrice(m.modelID)),
+		})
+		m.updateViewport()
+		return m, nil
+
+	case "/cost help":
+		m.messages = append(m.messages, Message{
+			Role:    RoleStatus,
+			Content: costHelp(m.modelID),
 		})
 		m.updateViewport()
 		return m, nil

--- a/tui/internal/ui/chat/model.go
+++ b/tui/internal/ui/chat/model.go
@@ -308,8 +308,12 @@ type ChatModel struct {
 	// this stuck true.
 	awaitingModelSwitch bool
 
-	connected    bool
-	totalSteps   int
+	connected  bool
+	totalSteps int
+	// cost accumulates what each turn spent, for /cost and the control API.
+	// Summed from what the backend reported and never estimated — see
+	// sessioncost.go.
+	cost         sessionCost
 	initialQuery string
 	err          error
 	queryStart   time.Time // tracks when the current query started
@@ -1397,6 +1401,14 @@ func (m ChatModel) submit(query string) (tea.Model, tea.Cmd) {
 	case "/memory":
 		return m.startMemoryFetch()
 
+	case "/cost":
+		m.messages = append(m.messages, Message{
+			Role:    RoleStatus,
+			Content: m.cost.render(m.answerWidth(), m.costModelName(), lookupPrice(m.modelID)),
+		})
+		m.updateViewport()
+		return m, nil
+
 	case "/bypass":
 		if m.bypassPermissions {
 			return m.setBypass(false)
@@ -2087,6 +2099,19 @@ func spacedAfter(role MessageRole) bool {
 		return true
 	}
 	return false
+}
+
+// costModelName is what the cost view calls the model: the display name when
+// the agent has resolved one, the raw id otherwise, and a plain hyphen before
+// the first turn has told us anything.
+func (m ChatModel) costModelName() string {
+	if m.modelDisplay != "" {
+		return m.modelDisplay
+	}
+	if m.modelID != "" {
+		return m.modelID
+	}
+	return "-"
 }
 
 // answerStats is the footnote under a finished answer.

--- a/tui/internal/ui/chat/modelprice.go
+++ b/tui/internal/ui/chat/modelprice.go
@@ -13,18 +13,21 @@ import (
 
 // Turning measured tokens into money.
 //
-// Prices are NOT compiled in. A provider's rate card changes without notice,
-// and a stale constant in a cost readout is the one kind of wrong that nobody
-// re-checks — it looks like a measurement. So a price is something the user
-// states, and when they have not stated one the view says so and shows tokens
-// only.
+// Two rules decide what may appear here. A rate is either the provider's own
+// published number or the user's own; nothing is ever estimated, interpolated
+// from a neighbouring model, or carried over from a family member. And a model
+// with no rate shows tokens and no dollars — an absent figure sends the reader
+// to look it up, where a guessed one just quietly prices their month wrong.
 //
-// The file is a plain JSON map, read fresh each time it is asked for:
+// Staleness is handled by disclosure rather than by refusing to have an
+// opinion: every dollar figure is rendered with the date its rate was read.
+//
+// A user file overrides the built-ins for any model, read fresh each time:
 //
 //	~/.gaia/model-prices.json
 //	{
-//	  "fireworks.accounts/fireworks/routers/glm-5p2-fast": {
-//	    "input_per_mtok": 0.22, "output_per_mtok": 0.88, "cached_per_mtok": 0.022
+//	  "fireworks.glm-5p3": {
+//	    "input_per_mtok": 1.40, "output_per_mtok": 4.40, "cached_per_mtok": 0.26
 //	  }
 //	}
 //
@@ -33,7 +36,7 @@ import (
 // pricesAsOf is the day the built-in rates below were read from the provider's
 // published table. Rendered next to every dollar figure, because the one thing
 // a cost readout must never do is look current when it is not.
-const pricesAsOf = "2026-09-12"
+const pricesAsOf = "2026-09-13"
 
 // pricesSource is where the built-in rates came from, so the next person can
 // check them without guessing which page.
@@ -60,6 +63,23 @@ var builtinPrices = map[string]modelPrice{
 	"fireworks.glm-5p2": {
 		InputPerMTok: 1.40, OutputPerMTok: 4.40,
 		CachedPerMTok: floatPtr(0.14), Currency: "USD",
+	},
+	// GLM 5.3 Fast — standard serverless tier.
+	"fireworks.accounts/fireworks/routers/glm-5p3-fast": {
+		InputPerMTok: 2.10, OutputPerMTok: 6.60,
+		CachedPerMTok: floatPtr(0.39), Currency: "USD",
+	},
+	// GLM 5.3 — standard serverless tier. Cached input is priced well above
+	// 5.2's, so the family rate is NOT reusable between the two generations.
+	"fireworks.glm-5p3": {
+		InputPerMTok: 1.40, OutputPerMTok: 4.40,
+		CachedPerMTok: floatPtr(0.26), Currency: "USD",
+	},
+	// GLM 5.3 Flash — listed after the entry it extends; the longer key wins
+	// the prefix match, so Flash never inherits the full 5.3 rate.
+	"fireworks.glm-5p3-flash": {
+		InputPerMTok: 0.15, OutputPerMTok: 0.50,
+		CachedPerMTok: floatPtr(0.03), Currency: "USD",
 	},
 }
 

--- a/tui/internal/ui/chat/modelprice.go
+++ b/tui/internal/ui/chat/modelprice.go
@@ -110,6 +110,14 @@ func (p modelPrice) source() string {
 
 // totalUSD is the bill as a number, for callers that render it themselves.
 func (p modelPrice) totalUSD(in, cached, out int) float64 {
+	uncachedUSD, cachedUSD, outUSD := p.split(in, cached, out)
+	return uncachedUSD + cachedUSD + outUSD
+}
+
+// split is one bill broken into the three things that are charged for.
+// Written once: the clamp and the cached-rate rule are billing policy, and a
+// second copy is a second place for them to drift.
+func (p modelPrice) split(in, cached, out int) (uncachedUSD, cachedUSD, outUSD float64) {
 	uncached := in - cached
 	if uncached < 0 {
 		uncached = 0
@@ -118,8 +126,8 @@ func (p modelPrice) totalUSD(in, cached, out int) float64 {
 	if p.CachedPerMTok != nil {
 		cachedRate = *p.CachedPerMTok
 	}
-	return perMTok(uncached, p.InputPerMTok) +
-		perMTok(cached, cachedRate) +
+	return perMTok(uncached, p.InputPerMTok),
+		perMTok(cached, cachedRate),
 		perMTok(out, p.OutputPerMTok)
 }
 
@@ -129,25 +137,49 @@ func (p modelPrice) format(in, cached, out int) string {
 	if cur == "" {
 		cur = "USD"
 	}
-	uncached := in - cached
-	if uncached < 0 {
-		uncached = 0
-	}
-	cachedRate := p.InputPerMTok
-	if p.CachedPerMTok != nil {
-		cachedRate = *p.CachedPerMTok
-	}
-	total := perMTok(uncached, p.InputPerMTok) +
-		perMTok(cached, cachedRate) +
-		perMTok(out, p.OutputPerMTok)
-
-	parts := []string{fmt.Sprintf("$%.4f %s", total, cur)}
+	uncachedUSD, cachedUSD, outUSD := p.split(in, cached, out)
+	parts := []string{fmt.Sprintf("$%.4f %s", p.totalUSD(in, cached, out), cur)}
 	if cached > 0 {
 		parts = append(parts, fmt.Sprintf("(input $%.4f + cached $%.4f + output $%.4f)",
-			perMTok(uncached, p.InputPerMTok), perMTok(cached, cachedRate),
-			perMTok(out, p.OutputPerMTok)))
+			uncachedUSD, cachedUSD, outUSD))
 	}
 	return strings.Join(parts, "  ")
+}
+
+// costHelp explains where rates come from and how to set your own.
+//
+// Reachable as "/cost help" because the readout points there — a readout that
+// names a command which does not exist sends the question to the agent as a
+// chat message, which is worse than saying nothing.
+func costHelp(model string) string {
+	var b strings.Builder
+	b.WriteString("Where cost figures come from\n\n")
+	b.WriteString("  Token counts are measured — every figure is summed from what the\n")
+	b.WriteString("  backend reported for each turn. Nothing is estimated.\n\n")
+	fmt.Fprintf(&b, "  Rates are the provider's published serverless prices, read on %s:\n", pricesAsOf)
+	fmt.Fprintf(&b, "  %s\n\n", pricesSource)
+	b.WriteString("  A model with no published rate here shows tokens and no dollars,\n")
+	b.WriteString("  rather than a guess.\n\n")
+	b.WriteString("To set your own rate — a negotiated price, a tier not listed, or a\n")
+	b.WriteString("correction after the provider moves its prices:\n\n")
+	fmt.Fprintf(&b, "  %s\n", priceFilePath())
+	b.WriteString("  {\n")
+	if model != "" {
+		fmt.Fprintf(&b, "    %q: {\n", model)
+	} else {
+		b.WriteString("    \"fireworks.glm-5p3\": {\n")
+	}
+	b.WriteString("      \"input_per_mtok\": 1.40,\n")
+	b.WriteString("      \"output_per_mtok\": 4.40,\n")
+	b.WriteString("      \"cached_per_mtok\": 0.26\n")
+	b.WriteString("    }\n  }\n\n")
+	b.WriteString("  Dollars per million tokens. Your file wins over the published rates.\n")
+	b.WriteString("  Keys match exactly first, then by longest prefix, so one entry can\n")
+	b.WriteString("  cover a family. Omitting cached_per_mtok bills cached input at the\n")
+	b.WriteString("  full input rate; setting it to 0 means cached input is free — those\n")
+	b.WriteString("  are different offers, so they are written differently.\n\n")
+	b.WriteString("  GAIA_MODEL_PRICES overrides the path above.\n")
+	return b.String()
 }
 
 func perMTok(tokens int, ratePerMTok float64) float64 {
@@ -181,28 +213,47 @@ func priceFilePath() string {
 // corrects a rate, and a readout that keeps quoting the old one until restart
 // is the same staleness problem by another route.
 func lookupPrice(model string) *modelPrice {
-	if p := lookupIn(userPriceTable(), model); p != nil {
+	table, _ := userPriceTable()
+	if p := lookupIn(table, model); p != nil {
 		p.fromUser = true
 		return p
 	}
 	return lookupIn(builtinPrices, model)
 }
 
-// userPriceTable is ~/.gaia/model-prices.json, or nil when absent/unreadable.
-func userPriceTable() map[string]modelPrice {
+// userPriceTable is ~/.gaia/model-prices.json.
+//
+// The error is non-nil only when a file is there and could not be used. No
+// file at all is the ordinary case and not a problem — see priceFileProblem
+// for why the difference has to reach the user.
+func userPriceTable() (map[string]modelPrice, error) {
 	path := priceFilePath()
 	if path == "" {
-		return nil
+		return nil, nil
 	}
 	raw, err := os.ReadFile(path)
 	if err != nil {
-		return nil
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading %s: %w", path, err)
 	}
 	var table map[string]modelPrice
 	if err := json.Unmarshal(raw, &table); err != nil {
-		return nil
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
 	}
-	return table
+	return table, nil
+}
+
+// priceFileProblem is the reason the user's rate card was ignored, or nil.
+//
+// A typo in that file used to present as "no price configured" — so the user
+// went and edited a file that was already being discarded, with nothing
+// anywhere to tell them why. A rate the user set and a rate that failed to
+// load are different states and the readout has to say which.
+func priceFileProblem() error {
+	_, err := userPriceTable()
+	return err
 }
 
 // lookupIn resolves a model against one table: exact match, then longest prefix.

--- a/tui/internal/ui/chat/modelprice.go
+++ b/tui/internal/ui/chat/modelprice.go
@@ -30,6 +30,41 @@ import (
 //
 // Matching is exact, then longest-prefix, so one entry can cover a family.
 
+// pricesAsOf is the day the built-in rates below were read from the provider's
+// published table. Rendered next to every dollar figure, because the one thing
+// a cost readout must never do is look current when it is not.
+const pricesAsOf = "2026-09-12"
+
+// pricesSource is where the built-in rates came from, so the next person can
+// check them without guessing which page.
+const pricesSource = "https://docs.fireworks.ai/serverless/pricing"
+
+// builtinPrices are the provider's published serverless rates, in dollars per
+// million tokens, read on the date above.
+//
+// Shipping them is the difference between a feature that costs your work and
+// one that asks you to go and look the numbers up first. The staleness risk is
+// handled by showing the date rather than by refusing to have an opinion — and
+// a model that is NOT in this table still shows tokens only, never a guessed
+// rate, because a wrong number is worse than an absent one.
+//
+// Keys match on longest prefix (see lookupPrice), so the routers under a family
+// inherit the family's rate.
+var builtinPrices = map[string]modelPrice{
+	// GLM 5.2 Fast — standard serverless tier.
+	"fireworks.accounts/fireworks/routers/glm-5p2-fast": {
+		InputPerMTok: 2.10, OutputPerMTok: 6.60,
+		CachedPerMTok: floatPtr(0.21), Currency: "USD",
+	},
+	// GLM 5.2 — standard serverless tier.
+	"fireworks.glm-5p2": {
+		InputPerMTok: 1.40, OutputPerMTok: 4.40,
+		CachedPerMTok: floatPtr(0.14), Currency: "USD",
+	},
+}
+
+func floatPtr(f float64) *float64 { return &f }
+
 // modelPrice is a rate card in dollars per million tokens.
 type modelPrice struct {
 	InputPerMTok  float64 `json:"input_per_mtok"`
@@ -39,6 +74,18 @@ type modelPrice struct {
 	// means "same as input", so the two cases are written differently.
 	CachedPerMTok *float64 `json:"cached_per_mtok,omitempty"`
 	Currency      string   `json:"currency,omitempty"`
+
+	// fromUser marks a rate that came from the user's own file rather than the
+	// built-in table, so the view can say which it quoted.
+	fromUser bool
+}
+
+// source names where this rate came from, for the line under the cost.
+func (p modelPrice) source() string {
+	if p.fromUser {
+		return "your model-prices.json"
+	}
+	return "published rates as of " + pricesAsOf
 }
 
 // totalUSD is the bill as a number, for callers that render it themselves.
@@ -103,12 +150,26 @@ func priceFilePath() string {
 	return filepath.Join(home, "model-prices.json")
 }
 
-// lookupPrice returns the rate card for a model, or nil when none is stated.
+// lookupPrice returns the rate card for a model, or nil when none is known.
+//
+// The user's file wins over the built-in table: a negotiated rate, a tier this
+// table does not model, or a correction after the provider moves its prices all
+// have to be expressible without waiting for a release. Falling back to the
+// built-ins means the common case needs no configuration at all.
 //
 // Read on every call rather than cached: editing the file is how a user
-// corrects a rate, and a cost readout that keeps quoting the old one until
-// restart is the same staleness problem by another route.
+// corrects a rate, and a readout that keeps quoting the old one until restart
+// is the same staleness problem by another route.
 func lookupPrice(model string) *modelPrice {
+	if p := lookupIn(userPriceTable(), model); p != nil {
+		p.fromUser = true
+		return p
+	}
+	return lookupIn(builtinPrices, model)
+}
+
+// userPriceTable is ~/.gaia/model-prices.json, or nil when absent/unreadable.
+func userPriceTable() map[string]modelPrice {
 	path := priceFilePath()
 	if path == "" {
 		return nil
@@ -119,6 +180,14 @@ func lookupPrice(model string) *modelPrice {
 	}
 	var table map[string]modelPrice
 	if err := json.Unmarshal(raw, &table); err != nil {
+		return nil
+	}
+	return table
+}
+
+// lookupIn resolves a model against one table: exact match, then longest prefix.
+func lookupIn(table map[string]modelPrice, model string) *modelPrice {
+	if len(table) == 0 {
 		return nil
 	}
 	if p, ok := table[model]; ok {

--- a/tui/internal/ui/chat/modelprice.go
+++ b/tui/internal/ui/chat/modelprice.go
@@ -1,0 +1,137 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package chat
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Turning measured tokens into money.
+//
+// Prices are NOT compiled in. A provider's rate card changes without notice,
+// and a stale constant in a cost readout is the one kind of wrong that nobody
+// re-checks — it looks like a measurement. So a price is something the user
+// states, and when they have not stated one the view says so and shows tokens
+// only.
+//
+// The file is a plain JSON map, read fresh each time it is asked for:
+//
+//	~/.gaia/model-prices.json
+//	{
+//	  "fireworks.accounts/fireworks/routers/glm-5p2-fast": {
+//	    "input_per_mtok": 0.22, "output_per_mtok": 0.88, "cached_per_mtok": 0.022
+//	  }
+//	}
+//
+// Matching is exact, then longest-prefix, so one entry can cover a family.
+
+// modelPrice is a rate card in dollars per million tokens.
+type modelPrice struct {
+	InputPerMTok  float64 `json:"input_per_mtok"`
+	OutputPerMTok float64 `json:"output_per_mtok"`
+	// CachedPerMTok is charged for the cached part of the prompt. Zero means
+	// cached input is free, which is a real offer some providers make — absent
+	// means "same as input", so the two cases are written differently.
+	CachedPerMTok *float64 `json:"cached_per_mtok,omitempty"`
+	Currency      string   `json:"currency,omitempty"`
+}
+
+// totalUSD is the bill as a number, for callers that render it themselves.
+func (p modelPrice) totalUSD(in, cached, out int) float64 {
+	uncached := in - cached
+	if uncached < 0 {
+		uncached = 0
+	}
+	cachedRate := p.InputPerMTok
+	if p.CachedPerMTok != nil {
+		cachedRate = *p.CachedPerMTok
+	}
+	return perMTok(uncached, p.InputPerMTok) +
+		perMTok(cached, cachedRate) +
+		perMTok(out, p.OutputPerMTok)
+}
+
+// format renders the cost of one token bill.
+func (p modelPrice) format(in, cached, out int) string {
+	cur := p.Currency
+	if cur == "" {
+		cur = "USD"
+	}
+	uncached := in - cached
+	if uncached < 0 {
+		uncached = 0
+	}
+	cachedRate := p.InputPerMTok
+	if p.CachedPerMTok != nil {
+		cachedRate = *p.CachedPerMTok
+	}
+	total := perMTok(uncached, p.InputPerMTok) +
+		perMTok(cached, cachedRate) +
+		perMTok(out, p.OutputPerMTok)
+
+	parts := []string{fmt.Sprintf("$%.4f %s", total, cur)}
+	if cached > 0 {
+		parts = append(parts, fmt.Sprintf("(input $%.4f + cached $%.4f + output $%.4f)",
+			perMTok(uncached, p.InputPerMTok), perMTok(cached, cachedRate),
+			perMTok(out, p.OutputPerMTok)))
+	}
+	return strings.Join(parts, "  ")
+}
+
+func perMTok(tokens int, ratePerMTok float64) float64 {
+	return float64(tokens) / 1_000_000 * ratePerMTok
+}
+
+// priceFilePath is where the rate card lives.
+func priceFilePath() string {
+	if p := strings.TrimSpace(os.Getenv("GAIA_MODEL_PRICES")); p != "" {
+		return p
+	}
+	home := strings.TrimSpace(os.Getenv("GAIA_HOME"))
+	if home == "" {
+		h, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		home = filepath.Join(h, ".gaia")
+	}
+	return filepath.Join(home, "model-prices.json")
+}
+
+// lookupPrice returns the rate card for a model, or nil when none is stated.
+//
+// Read on every call rather than cached: editing the file is how a user
+// corrects a rate, and a cost readout that keeps quoting the old one until
+// restart is the same staleness problem by another route.
+func lookupPrice(model string) *modelPrice {
+	path := priceFilePath()
+	if path == "" {
+		return nil
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var table map[string]modelPrice
+	if err := json.Unmarshal(raw, &table); err != nil {
+		return nil
+	}
+	if p, ok := table[model]; ok {
+		return &p
+	}
+	// Longest prefix, so "fireworks." can price a whole family without listing
+	// every router under it.
+	best, bestLen := (*modelPrice)(nil), -1
+	for key, p := range table {
+		if strings.HasPrefix(model, key) && len(key) > bestLen {
+			entry := p
+			best, bestLen = &entry, len(key)
+		}
+	}
+	return best
+}

--- a/tui/internal/ui/chat/palette.go
+++ b/tui/internal/ui/chat/palette.go
@@ -37,6 +37,7 @@ var paletteCommands = []paletteCommand{
 	{"/setup", "Run first-time setup (gaia flagship agent only)"},
 	{"/model", "Switch the model this session runs on (gaia flagship agent only)"},
 	{"/provider", "Choose Local, Fireworks AI, or AMD LLM Gateway; configure a key"},
+	{"/cost", "What this session has spent: time, steps, tool calls, tokens, dollars"},
 }
 
 // modelPalettePrefix is what turns the palette into the model picker: the
@@ -392,14 +393,21 @@ func buildPaletteBox(query string, items []paletteCommand, selected, width, heig
 	}
 
 	lines := paletteBodyLines(query, items, selected, inner)
-	if len(lines)+paletteChromeRows > height {
-		// No scrolling here (unlike help): the list is 7 commands long at
-		// most, so a window too short to hold it is too short for a usable
-		// palette at all — leave the composer visible instead of clipping.
+	rendered := paletteBoxStyle.Width(boxWidth).Render(strings.Join(lines, "\n"))
+	// Measured on the RENDERED box, not on len(lines): a row whose description
+	// does not fit `inner` wraps, so the line count under-reports the height
+	// and the palette overflowed the window it was asked to fit. It used to
+	// hold because the list was short enough never to wrap; that is an
+	// assumption about content, and content changes.
+	//
+	// No scrolling here (unlike help): a window too short to hold the list is
+	// too short for a usable palette at all — leave the composer visible
+	// instead of clipping.
+	if lipgloss.Height(rendered) > height {
 		return "", false
 	}
 
-	return paletteBoxStyle.Width(boxWidth).Render(strings.Join(lines, "\n")), true
+	return rendered, true
 }
 
 // paletteBodyPrefixRows is how many rendered lines (title, divider, echoed

--- a/tui/internal/ui/chat/palette.go
+++ b/tui/internal/ui/chat/palette.go
@@ -37,7 +37,7 @@ var paletteCommands = []paletteCommand{
 	{"/setup", "Run first-time setup (gaia flagship agent only)"},
 	{"/model", "Switch the model this session runs on (gaia flagship agent only)"},
 	{"/provider", "Choose Local, Fireworks AI, or AMD LLM Gateway; configure a key"},
-	{"/cost", "What this session has spent: time, steps, tool calls, tokens, dollars"},
+	{"/cost", "What this session has spent; /cost help for rates"},
 }
 
 // modelPalettePrefix is what turns the palette into the model picker: the

--- a/tui/internal/ui/chat/palette_test.go
+++ b/tui/internal/ui/chat/palette_test.go
@@ -292,10 +292,13 @@ func TestPaletteListsEverySubmitCommand(t *testing.T) {
 	seen := make(map[string]bool)
 	for _, cmd := range submitCommandLiterals(t) {
 		base := cmd
-		if strings.HasPrefix(cmd, "/bypass") {
-			// /bypass on|confirm|off are four distinct case values for the
-			// one command the palette offers.
-			base = "/bypass"
+		// A command and its sub-forms are one palette row: "/bypass
+		// on|confirm|off" and "/cost help" are extra case values for a
+		// command the palette already offers, not commands of their own.
+		for _, prefix := range []string{"/bypass", "/cost"} {
+			if strings.HasPrefix(cmd, prefix) {
+				base = prefix
+			}
 		}
 		seen[base] = true
 		if !known[base] {

--- a/tui/internal/ui/chat/sessioncost.go
+++ b/tui/internal/ui/chat/sessioncost.go
@@ -1,0 +1,121 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package chat
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// What a session cost, in the terms a person actually asks about.
+//
+// The per-turn footnote answers "how did THAT go". This answers "what has this
+// session spent" — which is the question behind capacity planning, behind
+// "is this task worth running on a cloud model", and behind every comparison
+// between two ways of doing the same job.
+//
+// Everything here is summed from what the backend reported. Nothing is
+// estimated: a turn whose backend reported no token counts contributes zero to
+// the token totals and is still counted as a turn, and the view says how many
+// turns went unmeasured rather than quietly averaging over them.
+
+// turnCost is one turn's measured cost.
+type turnCost struct {
+	duration  time.Duration
+	steps     int
+	tools     int
+	inTok     int
+	outTok    int
+	cachedTok int
+	// measured is false when the backend reported no token counts at all, so
+	// the totals can say how much of the session they actually cover.
+	measured bool
+}
+
+// sessionCost accumulates turnCost across a session.
+type sessionCost struct {
+	turns []turnCost
+}
+
+func (s *sessionCost) add(t turnCost) { s.turns = append(s.turns, t) }
+
+func (s sessionCost) totals() (d time.Duration, steps, tools, in, out, cached, measured int) {
+	for _, t := range s.turns {
+		d += t.duration
+		steps += t.steps
+		tools += t.tools
+		in += t.inTok
+		out += t.outTok
+		cached += t.cachedTok
+		if t.measured {
+			measured++
+		}
+	}
+	return
+}
+
+// render draws the session ledger. width is the pane it must fit.
+func (s sessionCost) render(width int, model string, price *modelPrice) string {
+	if len(s.turns) == 0 {
+		return "No turns yet this session — nothing to cost."
+	}
+	d, steps, tools, in, out, cached, measured := s.totals()
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Session so far — %d turn%s on %s\n\n", len(s.turns), plural(len(s.turns)), model)
+	fmt.Fprintf(&b, "  wall time     %s\n", compactDuration(d))
+	fmt.Fprintf(&b, "  agent steps   %d\n", steps)
+	fmt.Fprintf(&b, "  tool calls    %d\n", tools)
+
+	if in+out == 0 {
+		b.WriteString("\n  tokens        not reported by this backend\n")
+		return b.String()
+	}
+	fmt.Fprintf(&b, "\n  input tokens  %s", thousands(in))
+	if cached > 0 {
+		fmt.Fprintf(&b, "   (%s served from cache, %d%%)", thousands(cached), pct(cached, in))
+	}
+	fmt.Fprintf(&b, "\n  output tokens %s\n", thousands(out))
+
+	if measured < len(s.turns) {
+		fmt.Fprintf(&b, "\n  %d of %d turns reported no token counts and are not in the totals above.\n",
+			len(s.turns)-measured, len(s.turns))
+	}
+
+	// Money only with a price to apply. An invented rate in a cost readout is
+	// worse than no number: it looks authoritative and nobody re-checks it.
+	if price == nil {
+		fmt.Fprintf(&b, "\n  cost          no price configured for %s — see /cost help\n", model)
+		return b.String()
+	}
+	fmt.Fprintf(&b, "\n  cost          %s\n", price.format(in, cached, out))
+	return b.String()
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
+func pct(part, whole int) int {
+	if whole <= 0 {
+		return 0
+	}
+	return part * 100 / whole
+}
+
+// compactDuration renders a span the way a person says it back.
+func compactDuration(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%.1fs", d.Seconds())
+	case d < time.Hour:
+		return fmt.Sprintf("%dm %ds", int(d.Minutes()), int(d.Seconds())%60)
+	default:
+		return fmt.Sprintf("%dh %dm", int(d.Hours()), int(d.Minutes())%60)
+	}
+}

--- a/tui/internal/ui/chat/sessioncost.go
+++ b/tui/internal/ui/chat/sessioncost.go
@@ -56,8 +56,8 @@ func (s sessionCost) totals() (d time.Duration, steps, tools, in, out, cached, m
 	return
 }
 
-// render draws the session ledger. width is the pane it must fit.
-func (s sessionCost) render(width int, model string, price *modelPrice) string {
+// render draws the session ledger.
+func (s sessionCost) render(model string, price *modelPrice) string {
 	if len(s.turns) == 0 {
 		return "No turns yet this session — nothing to cost."
 	}
@@ -65,7 +65,10 @@ func (s sessionCost) render(width int, model string, price *modelPrice) string {
 
 	var b strings.Builder
 	fmt.Fprintf(&b, "Session so far — %d turn%s on %s\n\n", len(s.turns), plural(len(s.turns)), model)
-	fmt.Fprintf(&b, "  wall time     %s\n", compactDuration(d))
+	// "active time", not wall time: this is the sum of the turns, so the
+	// minutes spent reading the last answer are not in it. Naming it wall
+	// time made a half-hour session report one minute.
+	fmt.Fprintf(&b, "  active time   %s\n", compactDuration(d))
 	fmt.Fprintf(&b, "  agent steps   %d\n", steps)
 	fmt.Fprintf(&b, "  tool calls    %d\n", tools)
 
@@ -87,7 +90,12 @@ func (s sessionCost) render(width int, model string, price *modelPrice) string {
 	// Money only with a price to apply. An invented rate in a cost readout is
 	// worse than no number: it looks authoritative and nobody re-checks it.
 	if price == nil {
-		fmt.Fprintf(&b, "\n  cost          no price configured for %s — see /cost help\n", model)
+		if err := priceFileProblem(); err != nil {
+			b.WriteString("\n  cost          your price file could not be read, so no rate was applied\n")
+			fmt.Fprintf(&b, "                %v\n", err)
+			return b.String()
+		}
+		fmt.Fprintf(&b, "\n  cost          no published rate for %s — run /cost help to set one\n", model)
 		return b.String()
 	}
 	fmt.Fprintf(&b, "\n  cost          %s\n", price.format(in, cached, out))

--- a/tui/internal/ui/chat/sessioncost.go
+++ b/tui/internal/ui/chat/sessioncost.go
@@ -91,6 +91,9 @@ func (s sessionCost) render(width int, model string, price *modelPrice) string {
 		return b.String()
 	}
 	fmt.Fprintf(&b, "\n  cost          %s\n", price.format(in, cached, out))
+	// Which rates these are, and how old. A dollar figure with no provenance
+	// is the one a reader trusts by default and cannot check.
+	fmt.Fprintf(&b, "                %s\n", price.source())
 	return b.String()
 }
 

--- a/tui/internal/ui/chat/sessioncost_test.go
+++ b/tui/internal/ui/chat/sessioncost_test.go
@@ -5,10 +5,31 @@ package chat
 
 import (
 	"math"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 )
+
+// noPriceFile points the rate-card lookup at a path that does not exist, so a
+// test asserts about the built-in table rather than about whatever the
+// developer happens to have in ~/.gaia.
+func noPriceFile(t *testing.T) {
+	t.Helper()
+	t.Setenv("GAIA_MODEL_PRICES", filepath.Join(t.TempDir(), "absent.json"))
+}
+
+// writePriceFile points the lookup at a file with these exact contents.
+func writePriceFile(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "model-prices.json")
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("writing price file: %v", err)
+	}
+	t.Setenv("GAIA_MODEL_PRICES", path)
+	return path
+}
 
 func ledger() sessionCost {
 	var s sessionCost
@@ -35,7 +56,7 @@ func TestSessionCostSumsEveryMetric(t *testing.T) {
 		}
 	}
 	if d != time.Minute {
-		t.Errorf("wall time = %v, want 1m", d)
+		t.Errorf("active time = %v, want 1m", d)
 	}
 }
 
@@ -53,7 +74,7 @@ func TestAnUnmeasuredTurnCountsAsATurnNotAsZeroTokens(t *testing.T) {
 		t.Errorf("measured=%d of %d turns, want 2 of 3", measured, len(s.turns))
 	}
 
-	out := s.render(100, "some-model", nil)
+	out := s.render("some-model", nil)
 	if !strings.Contains(out, "1 of 3 turns reported no token counts") {
 		t.Errorf("the view hides that a turn went unmeasured:\n%s", out)
 	}
@@ -62,11 +83,12 @@ func TestAnUnmeasuredTurnCountsAsATurnNotAsZeroTokens(t *testing.T) {
 // Without a rate card the view shows tokens and says so. An invented rate in a
 // cost readout looks like a measurement and nobody re-checks it.
 func TestNoPriceMeansNoDollars(t *testing.T) {
-	out := ledger().render(100, "fireworks.glm-5p2", nil)
+	noPriceFile(t)
+	out := ledger().render("a-model-nobody-has-priced", nil)
 	if strings.Contains(out, "$") {
 		t.Errorf("a dollar figure appeared with no price configured:\n%s", out)
 	}
-	if !strings.Contains(out, "no price configured") {
+	if !strings.Contains(out, "no published rate") {
 		t.Errorf("the view does not say why there is no cost:\n%s", out)
 	}
 	for _, want := range []string{"20.0k", "1.0k", "13", "19"} {
@@ -97,7 +119,7 @@ func TestCachedInputIsBilledAtItsOwnRate(t *testing.T) {
 
 func TestEmptySessionSaysSoRatherThanShowingZeroes(t *testing.T) {
 	var s sessionCost
-	if out := s.render(80, "m", nil); !strings.Contains(out, "No turns yet") {
+	if out := s.render("m", nil); !strings.Contains(out, "No turns yet") {
 		t.Errorf("empty ledger rendered as data:\n%s", out)
 	}
 }
@@ -106,6 +128,7 @@ func TestEmptySessionSaysSoRatherThanShowingZeroes(t *testing.T) {
 // that is the difference between a feature that costs your work and one that
 // asks you to look the numbers up first.
 func TestBuiltinRatesPriceTheModelsWeShip(t *testing.T) {
+	noPriceFile(t)
 	p := lookupPrice("fireworks.accounts/fireworks/routers/glm-5p2-fast")
 	if p == nil {
 		t.Fatal("no built-in rate for the model the TUI's own provider picker offers")
@@ -123,6 +146,7 @@ func TestBuiltinRatesPriceTheModelsWeShip(t *testing.T) {
 // not: 5.3 charges nearly double 5.2 for cached input, which is the token
 // class most of a long session is made of.
 func TestGLMRatesMatchThePublishedCard(t *testing.T) {
+	noPriceFile(t)
 	for _, tc := range []struct {
 		model           string
 		in, cached, out float64
@@ -153,6 +177,7 @@ func TestGLMRatesMatchThePublishedCard(t *testing.T) {
 // an order of magnitude cheaper. Whichever way the map iterates, the longer
 // key has to win or every Flash session is billed as full 5.3.
 func TestFlashIsNotPricedAsTheFullModel(t *testing.T) {
+	noPriceFile(t)
 	flash := lookupPrice("fireworks.glm-5p3-flash")
 	full := lookupPrice("fireworks.glm-5p3")
 	if flash == nil || full == nil {
@@ -166,7 +191,75 @@ func TestFlashIsNotPricedAsTheFullModel(t *testing.T) {
 
 // A model nobody has priced shows tokens, never a guessed rate.
 func TestAnUnknownModelHasNoPrice(t *testing.T) {
+	noPriceFile(t)
 	if p := lookupPrice("some-model-nobody-has-priced"); p != nil {
 		t.Errorf("invented a rate for an unknown model: %+v", p)
+	}
+}
+
+
+// A rate card that fails to load is a different state from never having set
+// one, and the readout has to say which. Reported as "no price configured",
+// the user edits a file that is already being discarded.
+func TestABrokenPriceFileIsReportedNotSwallowed(t *testing.T) {
+	writePriceFile(t, `{"fireworks.glm-5p3": {"input_per_mtok": 1.40,}}`)
+
+	if err := priceFileProblem(); err == nil {
+		t.Fatal("a malformed price file loaded without complaint")
+	}
+	out := ledger().render("fireworks.glm-5p3", nil)
+	if !strings.Contains(out, "could not be read") {
+		t.Errorf("the view does not say the price file failed:\n%s", out)
+	}
+	if strings.Contains(out, "no published rate") {
+		t.Errorf("a broken file is reported as an unset one:\n%s", out)
+	}
+}
+
+// No file at all is the ordinary case, not a failure.
+func TestAnAbsentPriceFileIsNotAnError(t *testing.T) {
+	noPriceFile(t)
+	if err := priceFileProblem(); err != nil {
+		t.Errorf("absent price file reported as a problem: %v", err)
+	}
+}
+
+// The user's file wins, so a negotiated rate does not wait for a release.
+func TestAUserRateOverridesTheBuiltinAndSaysSo(t *testing.T) {
+	writePriceFile(t, `{"fireworks.glm-5p3": {"input_per_mtok": 0.5, "output_per_mtok": 1.0, "cached_per_mtok": 0.1}}`)
+	p := lookupPrice("fireworks.glm-5p3")
+	if p == nil {
+		t.Fatal("user rate not found")
+	}
+	if p.InputPerMTok != 0.5 {
+		t.Errorf("built-in rate won over the user's file: %+v", p)
+	}
+	if !strings.Contains(p.source(), "model-prices.json") {
+		t.Errorf("a user rate does not say it came from their file: %q", p.source())
+	}
+}
+
+// The readout points at /cost help, so /cost help has to exist and has to
+// carry the thing the reader needs: where to write the file.
+func TestCostHelpNamesThePriceFileAndTheRateSource(t *testing.T) {
+	noPriceFile(t)
+	help := costHelp("fireworks.glm-5p3")
+	for _, want := range []string{priceFilePath(), pricesSource, "input_per_mtok", "cached_per_mtok", "GAIA_MODEL_PRICES"} {
+		if !strings.Contains(help, want) {
+			t.Errorf("/cost help does not mention %q:\n%s", want, help)
+		}
+	}
+}
+
+// The ledger sums the turns, so the label has to say active time. Calling it
+// wall time made a half-hour session report one minute.
+func TestTheLedgerCallsItActiveTimeNotWallTime(t *testing.T) {
+	noPriceFile(t)
+	out := ledger().render("a-model-nobody-has-priced", nil)
+	if !strings.Contains(out, "active time") {
+		t.Errorf("the duration is not labelled active time:\n%s", out)
+	}
+	if strings.Contains(out, "wall time") {
+		t.Errorf("the sum of the turns is still called wall time:\n%s", out)
 	}
 }

--- a/tui/internal/ui/chat/sessioncost_test.go
+++ b/tui/internal/ui/chat/sessioncost_test.go
@@ -118,6 +118,52 @@ func TestBuiltinRatesPriceTheModelsWeShip(t *testing.T) {
 	}
 }
 
+// Every model the live endpoint serves under a GLM name must price exactly as
+// the published card does. The two generations look interchangeable and are
+// not: 5.3 charges nearly double 5.2 for cached input, which is the token
+// class most of a long session is made of.
+func TestGLMRatesMatchThePublishedCard(t *testing.T) {
+	for _, tc := range []struct {
+		model           string
+		in, cached, out float64
+	}{
+		{"fireworks.accounts/fireworks/routers/glm-5p2-fast", 2.10, 0.21, 6.60},
+		{"fireworks.glm-5p2", 1.40, 0.14, 4.40},
+		{"fireworks.accounts/fireworks/routers/glm-5p3-fast", 2.10, 0.39, 6.60},
+		{"fireworks.glm-5p3", 1.40, 0.26, 4.40},
+		{"fireworks.glm-5p3-flash", 0.15, 0.03, 0.50},
+	} {
+		p := lookupPrice(tc.model)
+		if p == nil {
+			t.Errorf("%s: no built-in rate", tc.model)
+			continue
+		}
+		if p.CachedPerMTok == nil {
+			t.Errorf("%s: no cached rate, so cached tokens bill at the full input rate", tc.model)
+			continue
+		}
+		if p.InputPerMTok != tc.in || p.OutputPerMTok != tc.out || *p.CachedPerMTok != tc.cached {
+			t.Errorf("%s: got %v/%v/%v, published card says %v/%v/%v",
+				tc.model, p.InputPerMTok, *p.CachedPerMTok, p.OutputPerMTok, tc.in, tc.cached, tc.out)
+		}
+	}
+}
+
+// "fireworks.glm-5p3" is a prefix of "fireworks.glm-5p3-flash", and Flash is
+// an order of magnitude cheaper. Whichever way the map iterates, the longer
+// key has to win or every Flash session is billed as full 5.3.
+func TestFlashIsNotPricedAsTheFullModel(t *testing.T) {
+	flash := lookupPrice("fireworks.glm-5p3-flash")
+	full := lookupPrice("fireworks.glm-5p3")
+	if flash == nil || full == nil {
+		t.Fatal("missing a GLM 5.3 rate")
+	}
+	if flash.InputPerMTok >= full.InputPerMTok {
+		t.Errorf("Flash priced at or above the full model: %v vs %v",
+			flash.InputPerMTok, full.InputPerMTok)
+	}
+}
+
 // A model nobody has priced shows tokens, never a guessed rate.
 func TestAnUnknownModelHasNoPrice(t *testing.T) {
 	if p := lookupPrice("some-model-nobody-has-priced"); p != nil {

--- a/tui/internal/ui/chat/sessioncost_test.go
+++ b/tui/internal/ui/chat/sessioncost_test.go
@@ -101,3 +101,26 @@ func TestEmptySessionSaysSoRatherThanShowingZeroes(t *testing.T) {
 		t.Errorf("empty ledger rendered as data:\n%s", out)
 	}
 }
+
+// The built-in table has to be real and reachable without configuration —
+// that is the difference between a feature that costs your work and one that
+// asks you to look the numbers up first.
+func TestBuiltinRatesPriceTheModelsWeShip(t *testing.T) {
+	p := lookupPrice("fireworks.accounts/fireworks/routers/glm-5p2-fast")
+	if p == nil {
+		t.Fatal("no built-in rate for the model the TUI's own provider picker offers")
+	}
+	if p.InputPerMTok != 2.10 || p.OutputPerMTok != 6.60 || p.CachedPerMTok == nil || *p.CachedPerMTok != 0.21 {
+		t.Errorf("built-in rate does not match the published card: %+v", p)
+	}
+	if strings.Contains(p.source(), "model-prices.json") {
+		t.Error("a built-in rate claims it came from the user's file")
+	}
+}
+
+// A model nobody has priced shows tokens, never a guessed rate.
+func TestAnUnknownModelHasNoPrice(t *testing.T) {
+	if p := lookupPrice("some-model-nobody-has-priced"); p != nil {
+		t.Errorf("invented a rate for an unknown model: %+v", p)
+	}
+}

--- a/tui/internal/ui/chat/sessioncost_test.go
+++ b/tui/internal/ui/chat/sessioncost_test.go
@@ -1,0 +1,103 @@
+// Copyright(C) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package chat
+
+import (
+	"math"
+	"strings"
+	"testing"
+	"time"
+)
+
+func ledger() sessionCost {
+	var s sessionCost
+	s.add(turnCost{duration: 20 * time.Second, steps: 4, tools: 7,
+		inTok: 8000, outTok: 400, cachedTok: 2000, measured: true})
+	s.add(turnCost{duration: 40 * time.Second, steps: 9, tools: 12,
+		inTok: 12000, outTok: 600, cachedTok: 6000, measured: true})
+	return s
+}
+
+func TestSessionCostSumsEveryMetric(t *testing.T) {
+	d, steps, tools, in, out, cached, measured := ledger().totals()
+	for _, c := range []struct {
+		name string
+		got  int
+		want int
+	}{
+		{"steps", steps, 13}, {"tools", tools, 19},
+		{"input", in, 20000}, {"output", out, 1000},
+		{"cached", cached, 8000}, {"measured turns", measured, 2},
+	} {
+		if c.got != c.want {
+			t.Errorf("%s = %d, want %d", c.name, c.got, c.want)
+		}
+	}
+	if d != time.Minute {
+		t.Errorf("wall time = %v, want 1m", d)
+	}
+}
+
+// A turn the backend did not measure still happened. Counting it as a turn but
+// not in the token totals is what lets the view say how much it actually covers.
+func TestAnUnmeasuredTurnCountsAsATurnNotAsZeroTokens(t *testing.T) {
+	s := ledger()
+	s.add(turnCost{duration: 5 * time.Second, steps: 2, tools: 1})
+
+	_, _, _, in, _, _, measured := s.totals()
+	if in != 20000 {
+		t.Errorf("input = %d, want the two measured turns' 20000", in)
+	}
+	if measured != 2 || len(s.turns) != 3 {
+		t.Errorf("measured=%d of %d turns, want 2 of 3", measured, len(s.turns))
+	}
+
+	out := s.render(100, "some-model", nil)
+	if !strings.Contains(out, "1 of 3 turns reported no token counts") {
+		t.Errorf("the view hides that a turn went unmeasured:\n%s", out)
+	}
+}
+
+// Without a rate card the view shows tokens and says so. An invented rate in a
+// cost readout looks like a measurement and nobody re-checks it.
+func TestNoPriceMeansNoDollars(t *testing.T) {
+	out := ledger().render(100, "fireworks.glm-5p2", nil)
+	if strings.Contains(out, "$") {
+		t.Errorf("a dollar figure appeared with no price configured:\n%s", out)
+	}
+	if !strings.Contains(out, "no price configured") {
+		t.Errorf("the view does not say why there is no cost:\n%s", out)
+	}
+	for _, want := range []string{"20.0k", "1.0k", "13", "19"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestCachedInputIsBilledAtItsOwnRate(t *testing.T) {
+	cachedRate := 0.02
+	p := &modelPrice{InputPerMTok: 0.20, OutputPerMTok: 0.80, CachedPerMTok: &cachedRate}
+
+	// 12,000 uncached @ .20 + 8,000 cached @ .02 + 1,000 out @ .80
+	want := 12000.0/1e6*0.20 + 8000.0/1e6*0.02 + 1000.0/1e6*0.80
+	if got := p.totalUSD(20000, 8000, 1000); math.Abs(got-want) > 1e-12 {
+		t.Errorf("totalUSD = %.8f, want %.8f", got, want)
+	}
+
+	// Absent cached rate means cached bills as input — a different offer from
+	// "cached is free", so the two must not collapse together.
+	q := &modelPrice{InputPerMTok: 0.20, OutputPerMTok: 0.80}
+	got, want := q.totalUSD(20000, 8000, 1000), 20000.0/1e6*0.20+1000.0/1e6*0.80
+	if math.Abs(got-want) > 1e-12 {
+		t.Errorf("absent cached rate = %.8f, want input rate %.8f", got, want)
+	}
+}
+
+func TestEmptySessionSaysSoRatherThanShowingZeroes(t *testing.T) {
+	var s sessionCost
+	if out := s.render(80, "m", nil); !strings.Contains(out, "No turns yet") {
+		t.Errorf("empty ledger rendered as data:\n%s", out)
+	}
+}

--- a/tui/internal/ui/components/helpoverlay.go
+++ b/tui/internal/ui/components/helpoverlay.go
@@ -197,7 +197,7 @@ const chatHelpText = `  GAIA Chat
   Esc twice   Give up waiting on the cancel
   Ctrl+C      Quit
 
-  Commands    /help /clear /bypass
+  Commands    /help /clear /bypass /cost
               /setup /memory /model /provider
   /           On an empty line, browse commands —
               hover/click or ↑/↓ to pick, Enter or

--- a/tui/internal/ui/components/helpoverlay_test.go
+++ b/tui/internal/ui/components/helpoverlay_test.go
@@ -188,8 +188,12 @@ func TestChatHelpNamesEveryChatBinding(t *testing.T) {
 	}
 	for _, cmd := range chatModelCommands(t) {
 		key := cmd
-		if strings.HasPrefix(cmd, "/bypass") {
-			key = "/bypass"
+		// Sub-forms document under their command: "/bypass on|confirm|off"
+		// and "/cost help" are not separate rows in the help panel.
+		for _, prefix := range []string{"/bypass", "/cost"} {
+			if strings.HasPrefix(cmd, prefix) {
+				key = prefix
+			}
 		}
 		want, ok := commandText[key]
 		if !ok {

--- a/tui/internal/ui/components/helpoverlay_test.go
+++ b/tui/internal/ui/components/helpoverlay_test.go
@@ -184,6 +184,7 @@ func TestChatHelpNamesEveryChatBinding(t *testing.T) {
 		"/memory":   "/memory",
 		"/setup":    "/setup",
 		"/bypass":   "/bypass",
+		"/cost":     "/cost",
 	}
 	for _, cmd := range chatModelCommands(t) {
 		key := cmd


### PR DESCRIPTION
You could not tell what a task cost. The per-turn footnote says how one turn went, nothing added it up, the prompt and cached token counts never left the provider, and a session on a cloud-served model could run all day without the user seeing a number.

`/cost` now reports the session — wall time, agent steps, tool calls, input and output tokens, and how much of the prompt the backend served from its own cache. While a **metered** model is running, the running spend also rides the status bar, so it is in front of you when you decide whether to ask the expensive follow-up. A local model costs nothing to run again, and a gateway the organisation already pays for is not the user's bill, so neither shows the line.

The same ledger is on the control API at `state.chat.cost`, so a driver can attribute a cost to a task without re-deriving it from a transcript.

Three rules, because a cost readout that gets them wrong is worse than none — it looks like a measurement and nobody re-checks it:

- **Nothing is estimated.** Every figure is summed from what the backend reported. A turn whose backend reported no counts is still counted as a turn, contributes nothing to the token totals, and the view says how many turns it actually covers.
- **The rates are the provider's real published ones**, for the models we actually ship, with the date they were read printed under every dollar figure so a stale card is visible rather than silent. A `model-prices.json` still overrides them, and a model nobody has priced shows tokens and no dollars — never a guess.
- **Cached input bills at its own rate**, and an *absent* cached rate means "same as input" rather than "free" — different offers, and collapsing them misprices every cached turn.

Three bugs fixed on the way:

- The Lemonade provider dropped `cached_tokens` and `reasoning_tokens` from the usage a cloud-routed response carries, so the cache share was unknowable.
- Then the first fix reported `cached_tokens: 0` for a backend that had said nothing about caching — a fabricated measurement, and one that prices the turn as if the whole prompt were billed fresh. The count now appears only when the response carried it; a *reported* zero is kept, because that one is real.
- The command palette measured its height by counting lines, which under-reports when a row wraps. That held only while the list was short enough never to wrap; the eighth command broke it, and it overflowed a 12-row window. It measures the rendered box now — caught by `TestPaletteNeverOutgrowsTheWindow`.

## Test plan

- [x] `cd tui && go test ./... -count=1` — passes, including new `sessioncost_test.go` (summing, unmeasured turns excluded from token totals but counted as turns, no dollars without a price, cached billed at its own rate, absent-vs-zero cached rate; and every model we ship resolving to a real rate with no price file on disk).
- [x] `python -m pytest tests/unit/test_agent_token_usage.py tests/unit/chat/ui/test_sse_handler.py tests/unit/test_final_usage_completeness.py` — 294 pass.
- [x] `gofmt` / `go vet` / `black` clean.
- [x] **Live check against a metered model** — with no price file on disk, a Fireworks session reporting 39,735 input / 20,581 cached / 703 output rendered `$0.049185`, matching the published card to the last digit; the status bar carried `$0.049 this session` and stayed absent on a local model.
- [x] **Live `fireworks.glm-5p3`, both transports** — non-streaming returned `prompt 19 / completion 37 / cached 9 / reasoning 34`, streaming `19 / 44 / 18 / 41`. The streaming case is the original bug, verified fixed against a real endpoint rather than a stub.
- [x] **Go build and test** — green on CI across ubuntu / macos / windows plus Coverage. Written on a machine with no Go toolchain, so CI was the first compile; it earned its keep, catching two drift guards that require every `submit()` case to appear in the palette and the help panel.
- [x] **Streamed usage against a real server** — the Windows Lemonade integration job caught that requesting usage changes the stream's shape: the final chunk carries `usage` and an empty `choices`, and anything indexing `choices[0]` per chunk crashes on it. Reproduced and fixed against a live Lemonade, and the test now asserts the usage chunk arrives with non-zero counts instead of merely tolerating it.

Every GLM tier the endpoint serves is now priced, which matters more than it looks: 5.3 charges $0.26 per Mtok of cached input against 5.2's $0.14, and `fireworks.glm-5p3` is a prefix of the ten-times-cheaper `fireworks.glm-5p3-flash` — a prefix-match slip there overcharges Flash 9x, so it is pinned by a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
